### PR TITLE
Fix typo.

### DIFF
--- a/src/main/java/hudson/tasks/junit/ClassResult.java
+++ b/src/main/java/hudson/tasks/junit/ClassResult.java
@@ -101,7 +101,7 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
 
     @Override
     public String getChildTitle() {
-        return "Class Reults"; 
+        return "Class Results";
     }
 
     @Exported(visibility=999)


### PR DESCRIPTION
I want use getName() for email-ext plugin for groovy-html.template as title of tests table section. Some classes provide pretty name like "Class results" and other just "junit" or "cucumber" can name be enhanced to "Junit test results" or something like this?
