### PR TITLE
[ISSUE JENKINS-25280] TestObject has no getFullDisplayName

### DIFF
--- a/src/main/resources/hudson/tasks/test/AbstractTestResultAction/summary.jelly
+++ b/src/main/resources/hudson/tasks/test/AbstractTestResultAction/summary.jelly
@@ -66,7 +66,7 @@ THE SOFTWARE.
             <!-- child test results are referenced from their parent builds -->
             <j:set var="build" value="${testObject.run}" />
             <a href="${it.getTestResultPath(testObject)}">
-              <st:out value="${testObject.fullDisplayName}" />
+              <st:out value="${testObject.displayName}" />
             </a>
           </li>
         </j:while>


### PR DESCRIPTION
use displayName not fullDisplayName which does not exist on generic TestObjects.
