### PR TITLE
[FIXED JENKINS-24006] Remember scaleHealthFactor

### DIFF
--- a/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
+++ b/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
@@ -237,20 +237,21 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep {
 			return Messages.JUnitResultArchiver_DisplayName();
 		}
 
-		@Override
-		public Publisher newInstance(StaplerRequest req, JSONObject formData)
-				throws hudson.model.Descriptor.FormException {
-			String testResults = formData.getString("testResults");
+        @Override
+        public Publisher newInstance(StaplerRequest req, JSONObject formData)
+                throws hudson.model.Descriptor.FormException {
+            String testResults = formData.getString("testResults");
             boolean keepLongStdio = formData.getBoolean("keepLongStdio");
-			DescribableList<TestDataPublisher, Descriptor<TestDataPublisher>> testDataPublishers = new DescribableList<TestDataPublisher, Descriptor<TestDataPublisher>>(Saveable.NOOP);
+            double healthScaleFactor = formData.getDouble("healthScaleFactor");
+            DescribableList<TestDataPublisher, Descriptor<TestDataPublisher>> testDataPublishers = new DescribableList<TestDataPublisher, Descriptor<TestDataPublisher>>(Saveable.NOOP);
             try {
                 testDataPublishers.rebuild(req, formData, TestDataPublisher.all());
             } catch (IOException e) {
                 throw new FormException(e,null);
             }
 
-            return new JUnitResultArchiver(testResults, keepLongStdio, testDataPublishers);
-		}
+            return new JUnitResultArchiver(testResults, keepLongStdio, testDataPublishers, healthScaleFactor);
+        }
 
 		/**
 		 * Performs on-the-fly validation on the file mask wildcard.


### PR DESCRIPTION
Fix for not remembering "health report amplification factor" when visiting the job configuration page after setting the value.

https://issues.jenkins-ci.org/browse/JENKINS-24006
