### PR TITLE
Correct the help for the health scale factor

### DIFF
--- a/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/help-healthScaleFactor.html
+++ b/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/help-healthScaleFactor.html
@@ -7,9 +7,9 @@
         <li>A factor of <code>0.0</code> will disable the test result contribution to build health score.</li>
         <li>A factor of <code>0.1</code> means that 10% of tests failing will score 99% health</li>
         <li>A factor of <code>0.5</code> means that 10% of tests failing will score 95% health</li>
-        <li>A factor of <code>1.0</code> means that 10% of tests failing will score 10% health</li>
-        <li>A factor of <code>2.0</code> means that 10% of tests failing will score 20% health</li>
-        <li>A factor of <code>2.5</code> means that 10% of tests failing will score 25% health</li>
+        <li>A factor of <code>1.0</code> means that 10% of tests failing will score 90% health</li>
+        <li>A factor of <code>2.0</code> means that 10% of tests failing will score 80% health</li>
+        <li>A factor of <code>2.5</code> means that 10% of tests failing will score 75% health</li>
         <li>A factor of <code>5.0</code> means that 10% of tests failing will score 50% health</li>
         <li>A factor of <code>10.0</code> means that 10% of tests failing will score 0% health</li>
     </ul>


### PR DESCRIPTION
This is a minor change one of our users noticed that the help for the health scale factor had some minor bugs.  I would believe this is correct due to the other values and multiplying them out but I have not tested with the plug-in itself to see if this is true.  If need be I can setup a testcase locally and take some screenshots.