### PR TITLE
Refactored code duplication in ClassResult.

### DIFF
--- a/src/main/java/hudson/tasks/junit/ClassResult.java
+++ b/src/main/java/hudson/tasks/junit/ClassResult.java
@@ -194,21 +194,7 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
 
 
     void freeze() {
-        passCount=failCount=skipCount=0;
-        duration=0;
-        for (CaseResult r : cases) {
-            r.setClass(this);
-            if (r.isSkipped()) {
-                skipCount++;
-            }
-            else if(r.isPassed()) {
-                passCount++;
-            }
-            else {
-                failCount++;
-            }
-            duration += r.getDuration();
-        }
+        this.tally();
         Collections.sort(cases);
     }
 


### PR DESCRIPTION
ClassResult#freeze() method now calls ClassResult#tally() instead of having it's whole body repeated.
Since ClassResult class is already final, there's no chance for the tally method to be overridden, so no problem.