### PR TITLE
Diagnosis/recovery for infinite loop in AbstractTestResultAction.buildDataSet

### DIFF
--- a/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
+++ b/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
@@ -221,8 +221,15 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
             if(b==null)
                 return null;
             U r = b.getAction(type);
-            if(r!=null)
+            if (r != null) {
+                if (r == this) {
+                    throw new IllegalStateException(this + " was attached to both " + b + " and " + run);
+                }
+                if (r.run.number != b.number) {
+                    throw new IllegalStateException(r + " was attached to both " + b + " and " + r.run);
+                }
                 return r;
+            }
         }
     }
     


### PR DESCRIPTION
A Jenkins instance running 1.554.3 was observed to crash in a thread running

```
Handling GET /job/…/test/trend : …
  at java.lang.OutOfMemoryError.<init>()V (Unknown Source)
  at java.util.Arrays.copyOf([Ljava/lang/Object;I)[Ljava/lang/Object; (Unknown Source)
  at java.util.ArrayList.grow(I)V (Unknown Source)
  at java.util.ArrayList.ensureCapacityInternal(I)V (Unknown Source)
  at java.util.ArrayList.add(Ljava/lang/Object;)Z (Unknown Source)
  at hudson.util.DataSetBuilder.add(Ljava/lang/Number;Ljava/lang/Comparable;Ljava/lang/Comparable;)V (DataSetBuilder.java:52)
  at hudson.tasks.test.AbstractTestResultAction.buildDataSet(Lorg/kohsuke/stapler/StaplerRequest;)Lorg/jfree/data/category/CategoryDataset; (AbstractTestResultAction.java:260)
  at hudson.tasks.test.AbstractTestResultAction.doGraph(Lorg/kohsuke/stapler/StaplerRequest;Lorg/kohsuke/stapler/StaplerResponse;)V (AbstractTestResultAction.java:221)
  at hudson.tasks.test.TestResultProjectAction.doTrend(Lorg/kohsuke/stapler/StaplerRequest;Lorg/kohsuke/stapler/StaplerResponse;)V (TestResultProjectAction.java:97)
  at …
```

where (according to Eclipse Memory Analyzer) the `DataSetBuilder` had accumulated hundreds of megabytes of objects. I hypothesize that [this loop](https://github.com/jenkinsci/jenkins/blob/jenkins-1.554.3/core/src/main/java/hudson/tasks/test/AbstractTestResultAction.java#L259) fails to terminate. This patch tries to detect (and recover from) the most plausible proximate cause, that an action is attached simultaneously to two builds.

@reviewbybees (ref. ZD-24012)