### PR TITLE
[JENKINS-27974]: Safe URL for empty className

### DIFF
--- a/src/main/java/hudson/tasks/test/TestObject.java
+++ b/src/main/java/hudson/tasks/test/TestObject.java
@@ -373,8 +373,12 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
      * Replaces URL-unsafe characters.
      */
     public static String safe(String s) {
-        // this still seems to be a bit faster than a single replace with regexp
-        return s.replace('/', '_').replace('\\', '_').replace(':', '_').replace('?', '_').replace('#', '_').replace('%', '_');
+        if (s.isEmpty()) {
+            return "(empty)";
+        } else {
+            // this still seems to be a bit faster than a single replace with regexp
+            return s.replace('/', '_').replace('\\', '_').replace(':', '_').replace('?', '_').replace('#', '_').replace('%', '_');
+        }
         
         // Note: we probably should some helpers like Commons URIEscapeUtils here to escape all invalid URL chars, but then we
         // still would have to escape /, ? and so on

--- a/src/main/java/hudson/tasks/test/TestObject.java
+++ b/src/main/java/hudson/tasks/test/TestObject.java
@@ -32,6 +32,7 @@ import hudson.tasks.junit.TestAction;
 import hudson.tasks.junit.TestResultAction;
 import jenkins.model.Jenkins;
 
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.*;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -371,17 +372,19 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
 
     /**
      * Replaces URL-unsafe characters.
+     *
+     * If s is an empty string, returns "(empty)" otherwise the generated URL would contain
+     * two slashes one after the other and getDynamic() would fail
      */
     public static String safe(String s) {
-        if (s.isEmpty()) {
+        if (StringUtils.isEmpty(s)) {
             return "(empty)";
         } else {
             // this still seems to be a bit faster than a single replace with regexp
             return s.replace('/', '_').replace('\\', '_').replace(':', '_').replace('?', '_').replace('#', '_').replace('%', '_');
+            // Note: we probably should some helpers like Commons URIEscapeUtils here to escape all invalid URL chars, but then we
+            // still would have to escape /, ? and so on
         }
-        
-        // Note: we probably should some helpers like Commons URIEscapeUtils here to escape all invalid URL chars, but then we
-        // still would have to escape /, ? and so on
     }
 
     /**


### PR DESCRIPTION
Opening a test result with a empty className tag in junitReport.xml file results in a 404 page because the URL contains a empty path for the class.

This patch prevents this.

