### PR TITLE
[WiP] Remove exception from being thrown on empty/non-existent test result

### DIFF
--- a/src/main/java/hudson/tasks/junit/JUnitParser.java
+++ b/src/main/java/hudson/tasks/junit/JUnitParser.java
@@ -113,7 +113,7 @@ public class JUnitParser extends TestResultParser {
             if (files.length == 0) {
                 // no test result. Most likely a configuration
                 // error or fatal problem
-                throw new AbortException(Messages.JUnitResultArchiver_NoTestReportFound());
+                return new TestResult();
             }
 
             TestResult result = new TestResult(buildTime + (nowSlave - nowMaster), ds, keepLongStdio);

--- a/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
+++ b/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
@@ -150,13 +150,9 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep {
             }
             action.setHealthScaleFactor(getHealthScaleFactor()); // overwrites previous value if appending
 			if (result.isEmpty()) {
-                if (build.getResult() == Result.FAILURE) {
-                    // most likely a build failed before it gets to the test phase.
-                    // don't report confusing error message.
-                    return;
-                }
 			    // most likely a configuration error in the job - e.g. false pattern to match the JUnit result files
-				throw new AbortException(Messages.JUnitResultArchiver_ResultIsEmpty());
+                listener.getLogger().println(Messages.JUnitResultArchiver_ResultIsEmpty());
+                return;
 			}
 
             // TODO: Move into JUnitParser [BUG 3123310]

--- a/src/test/java/hudson/tasks/junit/JUnitResultArchiverTest.java
+++ b/src/test/java/hudson/tasks/junit/JUnitResultArchiverTest.java
@@ -274,5 +274,11 @@ public class JUnitResultArchiverTest {
             }
         }
     }
+    @Test public void emptyDirectory() throws Exception{
+        JUnitResultArchiver a = new JUnitResultArchiver("TEST-*.xml");
+        FreeStyleProject freeStyleProject = j.createFreeStyleProject();
+        freeStyleProject.getPublishersList().add(a);
+        j.assertBuildStatusSuccess(freeStyleProject.scheduleBuild2(0));
+    }
 
 }


### PR DESCRIPTION
In certain scenarios, such as customized Maven builds where specific modules are skipped, an exception would be thrown due to an empty test result file.  Now, no exception is thrown and the build will be able to continue.  See https://issues.jenkins-ci.org/browse/JENKINS-25657

@reviewbybees