### PR TITLE
[FIXED JENKINS-29383] Fix handling of special chars in aggregated matrix reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,5 +48,15 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!--
+            Override beta version declared by jenkins-test-harness.
+            TODO: Reomve once depending on 1.600 or newer: f987f9ce89952c79e045f6125c08bfd7c6b9aa99
+        -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/resources/lib/hudson/test/failed-test.jelly
+++ b/src/main/resources/lib/hudson/test/failed-test.jelly
@@ -82,12 +82,12 @@ THE SOFTWARE.
     </style>
   </st:once>
   <j:set var="id" value="${h.jsStringEscape(url)}"/>
-  <j:set var="open" value="javascript:showFailureSummary('test-${id}','${url}/summary')"/>
-  <j:set var="close" value="javascript:hideFailureSummary('test-${id}')"/>
-  <a id="test-${id}-showlink" href="${open}" title="${%Show details}">
+  <j:set var="open" value="showFailureSummary('test-${id}','${url}/summary')"/>
+  <j:set var="close" value="hideFailureSummary('test-${id}')"/>
+  <a id="test-${id}-showlink" href="#" onclick="${open}" title="${%Show details}">
     <l:icon class="icon-document-add icon-sm"/>
   </a>
-  <a id="test-${id}-hidelink" href="${close}" title="${%Hide details}" style="display:none">
+  <a id="test-${id}-hidelink" href="#" onclick="${close}" title="${%Hide details}" style="display:none">
     <l:icon class="icon-document-delete icon-sm"/>
   </a>
   <st:nbsp/>


### PR DESCRIPTION
The path can contain url-encoded special characters. Passing it to the javascript
function over `href="javascript:..."` decodes at least some of the characters so
`showFailureSummary` function search decoded version of element IDs and fails when
the decoded string differs. This change uses onclick event instead, where arguments
are not url-decoded.