### PR TITLE
Make it easier for scripts to retrieve passed and skipped test results

### DIFF
--- a/src/main/java/hudson/tasks/junit/PackageResult.java
+++ b/src/main/java/hudson/tasks/junit/PackageResult.java
@@ -201,7 +201,7 @@ public final class PackageResult extends MetaTabulatedResult implements Comparab
      * @return the children of this test result, if any, or an empty collection
      */
     @Override
-    public Collection<? extends hudson.tasks.test.TestResult> getPassedTests() {
+    public List<CaseResult> getPassedTests() {
         List<CaseResult> r = new ArrayList<CaseResult>();
         for (ClassResult clr : classes.values()) {
             for (CaseResult cr : clr.getChildren()) {
@@ -220,7 +220,7 @@ public final class PackageResult extends MetaTabulatedResult implements Comparab
      * @return the children of this test result, if any, or an empty list
      */
     @Override
-    public Collection<? extends TestResult> getSkippedTests() {
+    public List<CaseResult> getSkippedTests() {
         List<CaseResult> r = new ArrayList<CaseResult>();
         for (ClassResult clr : classes.values()) {
             for (CaseResult cr : clr.getChildren()) {

--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -625,6 +625,8 @@ public final class TestResult extends MetaTabulatedResult {
             suitesByName = new HashMap<String,SuiteResult>();
             totalTests = 0;
             failedTests = new ArrayList<CaseResult>();
+            skippedTests = new ArrayList<CaseResult>();
+            passedTests = new ArrayList<CaseResult>();
             byPackages = new TreeMap<String,PackageResult>();
         }
 

--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -584,7 +584,6 @@ public final class TestResult extends MetaTabulatedResult {
         byPackages = new TreeMap<String,PackageResult>();
 
         totalTests = 0;
-        //skippedTests = 0;
 
         // Ask all of our children to tally themselves
         for (SuiteResult s : suites) {

--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -416,7 +416,7 @@ public final class TestResult extends MetaTabulatedResult {
      * @return the children of this test result, if any, or an empty collection
      */
     @Override
-    public List<CaseResult> getPassedTests() {
+    public synchronized List<CaseResult> getPassedTests() {
         if(passedTests == null){
             passedTests = new ArrayList<CaseResult>();
             for(SuiteResult s : suites) {
@@ -437,7 +437,7 @@ public final class TestResult extends MetaTabulatedResult {
      * @return the children of this test result, if any, or an empty list
      */
     @Override
-    public List<CaseResult> getSkippedTests() {
+    public synchronized List<CaseResult> getSkippedTests() {
         if(skippedTests == null){
             skippedTests = new ArrayList<CaseResult>();
             for(SuiteResult s : suites) {

--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -664,13 +664,13 @@ public final class TestResult extends MetaTabulatedResult {
                 if(cr.isSkipped()) {
                     skippedTestsCounter++;
                     if (skippedTests != null) {
-                        skippedTests.add(cr)
+                        skippedTests.add(cr);
                     }
                 } else if(!cr.isPassed()) {
                     failedTests.add(cr);
                 } else {
                     if(passedTests != null) {
-                        passedTests.add(cr)
+                        passedTests.add(cr);
                     }
                 }
 

--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -417,7 +417,7 @@ public final class TestResult extends MetaTabulatedResult {
      * @return the children of this test result, if any, or an empty collection
      */
     @Override
-    public Collection<? extends hudson.tasks.test.TestResult> getPassedTests() {
+    public List<CaseResult> getPassedTests() {
         return passedTests;
     }
 
@@ -427,7 +427,7 @@ public final class TestResult extends MetaTabulatedResult {
      * @return the children of this test result, if any, or an empty list
      */
     @Override
-    public Collection<? extends hudson.tasks.test.TestResult> getSkippedTests() {
+    public List<CaseResult> getSkippedTests() {
         return skippedTests;
     }
 

--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -391,6 +391,9 @@ public final class TestResult extends MetaTabulatedResult {
     @Exported(visibility=999)
     @Override
     public int getSkipCount() {
+        if(skippedTests==null)
+            return 0;
+        else
         return skippedTests.size();
     }
     

--- a/src/main/java/hudson/tasks/junit/TestResultAction.java
+++ b/src/main/java/hudson/tasks/junit/TestResultAction.java
@@ -186,6 +186,17 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
           return getResult().getFailedTests();
      }
 
+    @Override
+    public List<CaseResult> getPassedTests() {
+        return getResult().getPassedTests();
+    }
+
+    @Override
+    public List<CaseResult> getSkippedTests() {
+        return getResult().getSkippedTests();
+    }
+
+
     /**
      * Loads a {@link TestResult} from disk.
      */

--- a/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
+++ b/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
@@ -260,7 +260,9 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
      * A shortcut for scripting
      * 
      * @return List of passed tests from associated test result.
+     * @since TODO
      */
+    @NonNull
     public List<? extends TestResult> getPassedTests() {
         return Collections.emptyList();
     }
@@ -269,7 +271,9 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
      * A shortcut for scripting
      * 
      * @return List of skipped tests from associated test result.
+     * @since TODO
      */
+    @NonNull
     public List<? extends TestResult> getSkippedTests() {
         return Collections.emptyList();
     }

--- a/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
+++ b/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.validation.constraints.NotNull;
 import jenkins.model.RunAction2;
 import jenkins.model.lazy.LazyBuildMixIn;
 import org.jfree.chart.ChartFactory;
@@ -262,7 +263,7 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
      * @return List of passed tests from associated test result.
      * @since TODO
      */
-    @NonNull
+    @NotNull
     public List<? extends TestResult> getPassedTests() {
         return Collections.emptyList();
     }
@@ -273,7 +274,7 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
      * @return List of skipped tests from associated test result.
      * @since TODO
      */
-    @NonNull
+    @NotNull
     public List<? extends TestResult> getSkippedTests() {
         return Collections.emptyList();
     }

--- a/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
+++ b/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.validation.constraints.NotNull;
+import javax.annotation.Nonnull;
 import jenkins.model.RunAction2;
 import jenkins.model.lazy.LazyBuildMixIn;
 import org.jfree.chart.ChartFactory;
@@ -263,7 +263,7 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
      * @return List of passed tests from associated test result.
      * @since TODO
      */
-    @NotNull
+    @Nonnull
     public List<? extends TestResult> getPassedTests() {
         return Collections.emptyList();
     }
@@ -274,7 +274,7 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
      * @return List of skipped tests from associated test result.
      * @since TODO
      */
-    @NotNull
+    @Nonnull
     public List<? extends TestResult> getSkippedTests() {
         return Collections.emptyList();
     }

--- a/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
+++ b/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
@@ -257,6 +257,24 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
     }
 
     /**
+     * A shortcut for scripting
+     * 
+     * @return List of passed tests from associated test result.
+     */
+    public List<? extends TestResult> getPassedTests() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * A shortcut for scripting
+     * 
+     * @return List of skipped tests from associated test result.
+     */
+    public List<? extends TestResult> getSkippedTests() {
+        return Collections.emptyList();
+    }
+
+    /**
      * Generates a PNG image for the test result trend.
      */
     public void doGraph( StaplerRequest req, StaplerResponse rsp) throws IOException {


### PR DESCRIPTION
Currently, it is very simple to get a list of failed tests with a single line of code by calling `getFailedTests()` on the `TestResultAction`.  However, getting a list of passed or skipped tests is significantly more difficult.  To do that, you have to dig down to the `PackageResult` level, which not involves traversing further down into the data structures, but also means that you have to collect the results from each package individually.

The changes in this pull request aim to allow passed and skipped test results to be retrieved just as easily as failed ones by changing the way passed and skipped results are handled internally to be more similar to how failed results are handled.