### PR TITLE
JENKINS-24352 - JUnit test result table wrapping duration text

### DIFF
--- a/src/main/resources/hudson/tasks/junit/CaseResult/list.jelly
+++ b/src/main/resources/hudson/tasks/junit/CaseResult/list.jelly
@@ -47,7 +47,7 @@ THE SOFTWARE.
               </j:forEach>
             </td>
             <td class="pane" style="text-align:left"><j:out value="${test.description}"/></td>
-            <td class="pane" style="text-align:left" data="${test.duration}">${test.durationString}</td>
+            <td class="pane no-wrap" style="text-align:left" data="${test.duration}">${test.durationString}</td>
             <td class="pane">
               <j:set var="pst" value="${test.status}" />
               <span class="${pst.cssClass}">

--- a/src/main/resources/hudson/tasks/junit/ClassResult/body.jelly
+++ b/src/main/resources/hudson/tasks/junit/ClassResult/body.jelly
@@ -41,7 +41,7 @@ THE SOFTWARE.
                 <st:include it="${badge}" page="badge.jelly" optional="true"/>
               </j:forEach>
             </td>
-            <td class="pane" style="width:6em" data="${p.duration}">${p.durationString}</td>
+            <td class="pane no-wrap" style="width:6em" data="${p.duration}">${p.durationString}</td>
             <td class="pane" style="width:6em">
               <j:set var="pst" value="${p.status}" />
               <span class="${pst.cssClass}">

--- a/src/main/resources/hudson/tasks/junit/ClassResult/list.jelly
+++ b/src/main/resources/hudson/tasks/junit/ClassResult/list.jelly
@@ -46,7 +46,7 @@ THE SOFTWARE.
               </j:forEach>
             </td>
             <td class="pane" style="text-align:right"><j:out value="${p.description}"/></td>
-            <td class="pane" style="text-align:right" data="${p.duration}">${p.durationString}</td>
+            <td class="pane no-wrap" style="text-align:right" data="${p.duration}">${p.durationString}</td>
             <td class="pane" style="text-align:right">${p.failCount}</td>
             <td class="pane" style="text-align:right">${p.skipCount}</td>
             <td class="pane" style="text-align:right">${p.totalCount}</td>

--- a/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
+++ b/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
@@ -36,7 +36,7 @@ THE SOFTWARE.
       <j:forEach var="f" items="${it.failedTests}" varStatus="i">
         <tr>
           <td class="pane"><t:failed-test result="${f}" url="${f.getRelativePathFrom(it)}"/></td>
-          <td class="pane" style="text-align:right;" data="${f.duration}">
+          <td class="pane no-wrap" style="text-align:right;" data="${f.duration}">
             ${f.durationString}
           </td>
           <td class="pane" style="text-align:right;">
@@ -73,7 +73,7 @@ THE SOFTWARE.
                 <st:include it="${badge}" page="badge.jelly" optional="true"/>
               </j:forEach>
             </td>
-            <td class="pane" style="text-align:right" data="${p.duration}">${p.durationString}</td>
+            <td class="pane no-wrap" style="text-align:right" data="${p.duration}">${p.durationString}</td>
             <td class="pane" style="text-align:right">${p.failCount}</td>
             <td class="pane" style="text-align:right" data="${p.failCount-prev.failCount}">
               ${h.getDiffString2(p.failCount-prev.failCount)}

--- a/src/main/resources/hudson/tasks/test/MetaTabulatedResult/list.jelly
+++ b/src/main/resources/hudson/tasks/test/MetaTabulatedResult/list.jelly
@@ -46,7 +46,7 @@ THE SOFTWARE.
               </j:forEach>
             </td>
             <td class="pane" style="text-align:right"><j:out value="${p.description}"/></td>
-            <td class="pane" style="text-align:right" data="${p.duration}">${p.durationString}</td>
+            <td class="pane no-wrap" style="text-align:right" data="${p.duration}">${p.durationString}</td>
             <td class="pane" style="text-align:right">${p.failCount}</td>
             <td class="pane" style="text-align:right">${p.skipCount}</td>
             <td class="pane" style="text-align:right">${p.totalCount}</td>

--- a/src/main/resources/lib/hudson/test/aggregated-failed-tests.jelly
+++ b/src/main/resources/lib/hudson/test/aggregated-failed-tests.jelly
@@ -53,7 +53,7 @@ THE SOFTWARE.
           <j:forEach var="f" items="${report.result.failedTests}" varStatus="i">
             <tr>
               <td class="pane"><t:failed-test result="${f}" url="../${report.child.project.shortUrl}testReport/${f.getRelativePathFrom(report.result)}"/></td>
-              <td class="pane" style="text-align:right;">${f.duration}</td>
+              <td class="pane no-wrap" style="text-align:right;" data="${f.duration}">${f.durationString}</td>
               <td class="pane" style="text-align:right;">${f.age}</td>
             </tr>
           </j:forEach>

--- a/src/test/java/hudson/tasks/test/TestReportUiTest.java
+++ b/src/test/java/hudson/tasks/test/TestReportUiTest.java
@@ -1,0 +1,109 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.tasks.test;
+
+import com.gargoylesoftware.htmlunit.AlertHandler;
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.tasks.junit.JUnitResultArchiver;
+import java.io.IOException;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestBuilder;
+
+/**
+ * Simple test for UI changes to the test reports
+ *
+ * @author kzantow
+ */
+public class TestReportUiTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    /**
+     * Validate CSS styles present to prevent duration text from wrapping
+     */
+    @Issue("JENKINS-24352")
+    @Test
+    public void testDurationStyle() throws Exception {
+        AbstractBuild b = configureTestBuild("render-test");
+
+        JenkinsRule.WebClient wc = j.createWebClient();
+
+        wc.setAlertHandler(new AlertHandler() {
+            @Override
+            public void handleAlert(Page page, String message) {
+                throw new AssertionError();
+            }
+        });
+
+        HtmlPage pg = wc.getPage(b, "testReport");
+
+        // these are from the test result file:
+        String duration14sec = Util.getTimeSpanString((long) (14.398 * 1000));
+        String duration3_3sec = Util.getTimeSpanString((long) (3.377 * 1000));
+        String duration2_5sec = Util.getTimeSpanString((long) (2.502 * 1000));
+
+        Assert.assertNotNull(pg.getFirstByXPath("//td[contains(text(),'" + duration3_3sec + "')][contains(@class,'no-wrap')]"));
+
+        pg = wc.getPage(b, "testReport/org.twia.vendor");
+
+        Assert.assertNotNull(pg.getFirstByXPath("//td[contains(text(),'" + duration3_3sec + "')][contains(@class,'no-wrap')]"));
+        Assert.assertNotNull(pg.getFirstByXPath("//td[contains(text(),'" + duration14sec + "')][contains(@class,'no-wrap')]"));
+
+        pg = wc.getPage(b, "testReport/org.twia.vendor/VendorManagerTest");
+
+        Assert.assertNotNull(pg.getFirstByXPath("//td[contains(text(),'" + duration2_5sec + "')][contains(@class,'no-wrap')]"));
+    }
+
+    /**
+     * Creates a freestyle project & build with UNSTABLE status
+     * containing a test report from: /hudson/tasks/junit/junit-report-20090516.xml
+     */
+    private FreeStyleBuild configureTestBuild(String projectName) throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject(projectName);
+        p.getBuildersList().add(new TestBuilder() {
+            @Override
+            @SuppressWarnings("null")
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                build.getWorkspace().child("junit.xml").copyFrom(
+                        getClass().getResource("/hudson/tasks/junit/junit-report-20090516.xml"));
+                return true;
+            }
+        });
+        p.getPublishersList().add(new JUnitResultArchiver("*.xml"));
+        return j.assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
+    }
+}


### PR DESCRIPTION
Prevents wrapping duration text in JUnit test results.

https://issues.jenkins-ci.org/browse/JENKINS-24352

@reviewbybees 

Before:
![Wrapping Issue](https://issues.jenkins-ci.org/secure/attachment/26620/table.PNG)

After:
![junit-result-no-wrap](https://cloud.githubusercontent.com/assets/3009477/9550434/46602900-4d79-11e5-8792-15af2acdc0b4.png)