### PR TITLE
Added option allowing empty test results.

### DIFF
--- a/src/main/java/hudson/tasks/junit/JUnitParser.java
+++ b/src/main/java/hudson/tasks/junit/JUnitParser.java
@@ -57,6 +57,17 @@ public class JUnitParser extends TestResultParser {
      * @param keepLongStdio if true, retain a suite's complete stdout/stderr even if this is huge and the suite passed
      * @since 1.358
      */
+    @Deprecated
+    public JUnitParser(boolean keepLongStdio) {
+        this.keepLongStdio = keepLongStdio;
+        this.allowEmptyResults = false;
+    }
+
+    /**
+     * @param keepLongStdio if true, retain a suite's complete stdout/stderr even if this is huge and the suite passed
+     * @param allowEmptyResults if true, empty results are allowed
+     * @since 1.10
+     */
     public JUnitParser(boolean keepLongStdio, boolean allowEmptyResults) {
         this.keepLongStdio = keepLongStdio;
         this.allowEmptyResults = allowEmptyResults;

--- a/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
+++ b/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
@@ -25,22 +25,28 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="${%Test report XMLs}" field="testResults"
-		description="${%description('http://ant.apache.org/manual/Types/fileset.html')}">
-		<f:textbox />
-	</f:entry>
-	<f:entry field="keepLongStdio" title="">
-		<f:checkbox name="keepLongStdio" title="${%Retain long standard output/error}"/>
-	</f:entry>
-  <f:entry field="healthScaleFactor" title="${%Health report amplification factor}">
-    <f:number default="1.0" min="0" step="0.1" size="10"/>
-  </f:entry>
-	<j:invokeStatic var="testDataPublisherDescriptors"
-		className="hudson.tasks.junit.TestDataPublisher" method="all" />
-	<j:if test="${testDataPublisherDescriptors.size() > 0}">
-	<f:entry title="Additional test report features" field="testDataPublishers">
+    xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="${%Test report XMLs}" field="testResults"
+        description="${%description('http://ant.apache.org/manual/Types/fileset.html')}">
+        <f:textbox />
+    </f:entry>
+    <f:entry field="keepLongStdio" title="">
+        <f:checkbox name="keepLongStdio" title="${%Retain long standard output/error}"/>
+    </f:entry>
+    <f:entry field="healthScaleFactor" title="${%Health report amplification factor}">
+        <f:number default="1.0" min="0" step="0.1" size="10"/>
+    </f:entry>
+    <j:invokeStatic var="testDataPublisherDescriptors"
+        className="hudson.tasks.junit.TestDataPublisher" method="all" />
+    <j:if test="${testDataPublisherDescriptors.size() > 0}">
+    <f:entry title="Additional test report features" field="testDataPublishers">
             <f:repeatableHeteroProperty field="testDataPublishers" hasHeader="true" oneEach="true"/>
-	</f:entry>
-	</j:if>
+    </f:entry>
+    </j:if>
+    <f:advanced>
+        <f:entry title="${%Allow empty results}" field="allowEmptyResults">
+            <f:checkbox default="false" title="${%Do not fail the build on empty test results}"/>
+        </f:entry>
+    </f:advanced>
+    -->
 </j:jelly>

--- a/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/help-allowEmptyResults.html
+++ b/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/help-allowEmptyResults.html
@@ -1,0 +1,7 @@
+<div>
+    If checked, the default behavior of failing a build on missing test result files
+    or empty test results is changed to not affect the status of the build.
+    Please note that this setting make it harder to spot misconfigured jobs or
+    build failures where the test tool does not exit with an error code when
+    not producing test report files.
+</div>

--- a/src/test/java/hudson/tasks/junit/JUnitResultArchiverTest.java
+++ b/src/test/java/hudson/tasks/junit/JUnitResultArchiverTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2009, Yahoo!, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -76,33 +76,33 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class JUnitResultArchiverTest {
 
     @Rule public JenkinsRule j = new JenkinsRule();
-	private FreeStyleProject project;
-	private JUnitResultArchiver archiver;
+    private FreeStyleProject project;
+    private JUnitResultArchiver archiver;
 
-	@Before public void setUp() throws Exception {
-		project = j.createFreeStyleProject("junit");
-		archiver = new JUnitResultArchiver("*.xml");
-		project.getPublishersList().add(archiver);
-		
-		project.getBuildersList().add(new TouchBuilder());
-	}
-	
-	@LocalData
-	@Test public void basic() throws Exception {
-		FreeStyleBuild build = project.scheduleBuild2(0).get(10, TimeUnit.SECONDS);
-		
-		assertTestResults(build);
-		
-		WebClient wc = j.new WebClient();
-		wc.getPage(project); // project page
-		wc.getPage(build); // build page
-		wc.getPage(build, "testReport");  // test report
-		wc.getPage(build, "testReport/hudson.security"); // package
-		wc.getPage(build, "testReport/hudson.security/HudsonPrivateSecurityRealmTest/"); // class
-		wc.getPage(build, "testReport/hudson.security/HudsonPrivateSecurityRealmTest/testDataCompatibilityWith1_282/"); // method
-		
+    @Before public void setUp() throws Exception {
+        project = j.createFreeStyleProject("junit");
+        archiver = new JUnitResultArchiver("*.xml");
+        project.getPublishersList().add(archiver);
 
-	}
+        project.getBuildersList().add(new TouchBuilder());
+    }
+
+    @LocalData
+    @Test public void basic() throws Exception {
+        FreeStyleBuild build = project.scheduleBuild2(0).get(10, TimeUnit.SECONDS);
+
+        assertTestResults(build);
+
+        WebClient wc = j.new WebClient();
+        wc.getPage(project); // project page
+        wc.getPage(build); // build page
+        wc.getPage(build, "testReport");  // test report
+        wc.getPage(build, "testReport/hudson.security"); // package
+        wc.getPage(build, "testReport/hudson.security/HudsonPrivateSecurityRealmTest/"); // class
+        wc.getPage(build, "testReport/hudson.security/HudsonPrivateSecurityRealmTest/testDataCompatibilityWith1_282/"); // method
+
+
+    }
 
     @RandomlyFails("TimeoutException from basic")
    @LocalData
@@ -115,80 +115,80 @@ public class JUnitResultArchiverTest {
         FilePath dest = s.getWorkspaceFor(project);
         assertNotNull(dest);
         src.copyRecursiveTo("*.xml", dest);
-        
+
         basic();
     }
 
-	private void assertTestResults(FreeStyleBuild build) {
-		TestResultAction testResultAction = build.getAction(TestResultAction.class);
-		assertNotNull("no TestResultAction", testResultAction);
-		
-		TestResult result = testResultAction.getResult();
-		assertNotNull("no TestResult", result);
-		
-		assertEquals("should have 1 failing test", 1, testResultAction.getFailCount());
-		assertEquals("should have 1 failing test", 1, result.getFailCount());
-		
-		assertEquals("should have 132 total tests", 132, testResultAction.getTotalCount());
-		assertEquals("should have 132 total tests", 132, result.getTotalCount());
-	}
-	
-	@LocalData
-	@Test public void persistence() throws Exception {
+    private void assertTestResults(FreeStyleBuild build) {
+        TestResultAction testResultAction = build.getAction(TestResultAction.class);
+        assertNotNull("no TestResultAction", testResultAction);
+
+        TestResult result = testResultAction.getResult();
+        assertNotNull("no TestResult", result);
+
+        assertEquals("should have 1 failing test", 1, testResultAction.getFailCount());
+        assertEquals("should have 1 failing test", 1, result.getFailCount());
+
+        assertEquals("should have 132 total tests", 132, testResultAction.getTotalCount());
+        assertEquals("should have 132 total tests", 132, result.getTotalCount());
+    }
+
+    @LocalData
+    @Test public void persistence() throws Exception {
         project.scheduleBuild2(0).get(60, TimeUnit.SECONDS);
-		
-		reloadJenkins();
-		
-		FreeStyleBuild build = project.getBuildByNumber(1);
-		
-		assertTestResults(build);
-	}
 
-	private void reloadJenkins() throws Exception {
+        reloadJenkins();
+
+        FreeStyleBuild build = project.getBuildByNumber(1);
+
+        assertTestResults(build);
+    }
+
+    private void reloadJenkins() throws Exception {
         j.jenkins.reload();
-		project = (FreeStyleProject) j.jenkins.getItem("junit");
-	}
-	
-	@LocalData
-	@Test public void setDescription() throws Exception {
-		FreeStyleBuild build = project.scheduleBuild2(0).get(10, TimeUnit.SECONDS);
-		
-		CaseResult caseResult = build.getAction(TestResultAction.class).getFailedTests().get(0);
-		String url = build.getUrl() + "/testReport/" + caseResult.getRelativePathFrom(caseResult.getTestResult());
-		
-		testSetDescription(url, caseResult);
-		
-		ClassResult classResult = caseResult.getParent();
-		url = build.getUrl() + "/testReport/" + classResult.getParent().getSafeName() + "/" + classResult.getSafeName();
-		testSetDescription(url, classResult);
-		
-		PackageResult packageResult = classResult.getParent();
-		url = build.getUrl() + "/testReport/" + classResult.getParent().getSafeName();
-		testSetDescription(url, packageResult);
-		
-	}
+        project = (FreeStyleProject) j.jenkins.getItem("junit");
+    }
 
-	private void testSetDescription(String url, TestObject object) throws Exception {
+    @LocalData
+    @Test public void setDescription() throws Exception {
+        FreeStyleBuild build = project.scheduleBuild2(0).get(10, TimeUnit.SECONDS);
+
+        CaseResult caseResult = build.getAction(TestResultAction.class).getFailedTests().get(0);
+        String url = build.getUrl() + "/testReport/" + caseResult.getRelativePathFrom(caseResult.getTestResult());
+
+        testSetDescription(url, caseResult);
+
+        ClassResult classResult = caseResult.getParent();
+        url = build.getUrl() + "/testReport/" + classResult.getParent().getSafeName() + "/" + classResult.getSafeName();
+        testSetDescription(url, classResult);
+
+        PackageResult packageResult = classResult.getParent();
+        url = build.getUrl() + "/testReport/" + classResult.getParent().getSafeName();
+        testSetDescription(url, packageResult);
+
+    }
+
+    private void testSetDescription(String url, TestObject object) throws Exception {
         object.doSubmitDescription("description");
 
         // test the roundtrip
         HtmlPage page = j.new WebClient().goTo(url);
-		page.getAnchorByHref("editDescription").click();
-		HtmlForm form = findForm(page, "submitDescription");
-		j.submit(form);
-		
-		assertEquals("description", object.getDescription());
-	}
-	
-	private HtmlForm findForm(HtmlPage page, String action) {
-		for (HtmlForm form: page.getForms()) {
-			if (action.equals(form.getActionAttribute())) {
-				return form;
-			}
-		}
-		fail("no form found");
-		return null;
-	}
+        page.getAnchorByHref("editDescription").click();
+        HtmlForm form = findForm(page, "submitDescription");
+        j.submit(form);
+
+        assertEquals("description", object.getDescription());
+    }
+
+    private HtmlForm findForm(HtmlPage page, String action) {
+        for (HtmlForm form: page.getForms()) {
+            if (action.equals(form.getActionAttribute())) {
+                return form;
+            }
+        }
+        fail("no form found");
+        return null;
+    }
 
     @Test public void repeatedArchiving() throws Exception {
         doRepeatedArchiving(false);
@@ -208,12 +208,12 @@ public class JUnitResultArchiverTest {
         List<TestResultAction> actions = build.getActions(TestResultAction.class);
         assertEquals(1, actions.size());
         TestResultAction testResultAction = actions.get(0);
-		TestResult result = testResultAction.getResult();
-		assertNotNull("no TestResult", result);
-		assertEquals("should have 1 failing test", 1, testResultAction.getFailCount());
-		assertEquals("should have 1 failing test", 1, result.getFailCount());
-		assertEquals("should have 8 total tests", 8, testResultAction.getTotalCount());
-		assertEquals("should have 8 total tests", 8, result.getTotalCount());
+        TestResult result = testResultAction.getResult();
+        assertNotNull("no TestResult", result);
+        assertEquals("should have 1 failing test", 1, testResultAction.getFailCount());
+        assertEquals("should have 1 failing test", 1, result.getFailCount());
+        assertEquals("should have 8 total tests", 8, testResultAction.getTotalCount());
+        assertEquals("should have 8 total tests", 8, result.getTotalCount());
         assertEquals(/* ⅞ = 87.5% */87, testResultAction.getBuildHealth().getScore());
     }
     public static final class SimpleArchive extends Builder {
@@ -285,6 +285,22 @@ public class JUnitResultArchiverTest {
                 return "MockTestDataPublisher";
             }
         }
+    }
+
+    @Test public void emptyDirectoryAllowEmptyResult() throws Exception {
+        JUnitResultArchiver a = new JUnitResultArchiver("TEST-*.xml");
+        a.setAllowEmptyResults(true);
+        FreeStyleProject freeStyleProject = j.createFreeStyleProject();
+        freeStyleProject.getPublishersList().add(a);
+        j.assertBuildStatus(Result.SUCCESS, freeStyleProject.scheduleBuild2(0).get());
+    }
+
+    @Test public void emptyDirectory() throws Exception {
+        JUnitResultArchiver a = new JUnitResultArchiver("TEST-*.xml");
+        a.setAllowEmptyResults(false);
+        FreeStyleProject freeStyleProject = j.createFreeStyleProject();
+        freeStyleProject.getPublishersList().add(a);
+        j.assertBuildStatus(Result.FAILURE, freeStyleProject.scheduleBuild2(0).get());
     }
 
     @Test public void specialCharsInRelativePath() throws Exception {


### PR DESCRIPTION
This is an attempt at solving one aspect of JENKINS-12815 (https://issues.jenkins-ci.org/browse/JENKINS-12815). This implementation does not allow for setting the build status on missing files, but a simple check-box to allow empty results at all. I hope it is a reasonable compromise between the functionality needed by many (myself included) to allow for missing test files and not to clutter the GUI with too many options.