### PR TITLE
[JENKINS-31040] Group failed tests by error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,5 +58,12 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
+    <!-- This is used to calculate string similarity. -->
+	<dependency>
+	    <groupId>org.apache.commons</groupId>
+	    <artifactId>commons-lang3</artifactId>
+	    <version>3.4</version>
+	    <scope>compile</scope>
+	</dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -58,12 +58,5 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
-    <!-- This is used to calculate string similarity. -->
-	<dependency>
-	    <groupId>org.apache.commons</groupId>
-	    <artifactId>commons-lang3</artifactId>
-	    <version>3.4</version>
-	    <scope>compile</scope>
-	</dependency>
     </dependencies>
 </project>

--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -300,12 +300,13 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
      */
     @Exported(visibility=9) 
     public String getShortErrorMessage() {
-    	if(getErrorDetails() == null || getErrorDetails().isEmpty() == true) {
-    		return getErrorStackTrace().split("[\\r\\n]+")[0];			// Get the first line
+    	if(errorDetails != null && errorDetails.isEmpty() == false) {
+    		return errorDetails;
+    	}else if(errorStackTrace != null) {
+    		return errorStackTrace.split("[\\r\\n]+")[0];			// Get the first line
     	}else {
-    		return getErrorDetails();
+    		return "";
     	}
-    	
     }
 
     /**

--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -293,6 +293,20 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     public float getDuration() {
         return duration;
     }
+    
+   
+    /**
+     * Gets the short version of error message.
+     */
+    @Exported(visibility=9) 
+    public String getShortErrorMessage() {
+    	if(getErrorDetails() == null || getErrorDetails().isEmpty() == true) {
+    		return getErrorStackTrace().split("[\\r\\n]+")[0];			// Get the first line
+    	}else {
+    		return getErrorDetails();
+    	}
+    	
+    }
 
     /**
      * Gets the version of {@link #getName()} that's URL-safe.

--- a/src/main/java/hudson/tasks/junit/GroupByError.java
+++ b/src/main/java/hudson/tasks/junit/GroupByError.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, Hyunil Shin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.tasks.junit;
+
+import hudson.tasks.test.TestObject;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * 
+ * Group case results by error message.
+ */
+public class GroupByError {
+	private final TestObject testObject;
+
+	/**
+     * Minimum distance for testing whether they are similar.
+	 * 0.9f is just personal opinion.
+	 */
+	private double minDist = 0.9f;
+	
+	/**
+	 * All {@link GroupedCaseResults}
+	 */
+	private final HashMap<String, GroupedCaseResults> groups;
+
+	public GroupByError(TestObject testObject) {
+		this.testObject = testObject;
+
+		groups = new HashMap<String, GroupedCaseResults>();
+		
+		// generate groups
+		List<CaseResult> failedCases = (List<CaseResult>) testObject.getResultInRun(testObject.getRun()).getFailedTests();
+		for(CaseResult cr: failedCases) {
+			add(cr);
+		}
+	}
+	
+	private void add(CaseResult cr) {
+		for(GroupedCaseResults g: groups.values()) {
+			if(g.similar(cr, minDist)) {
+				// add case to the existing group
+				g.add(cr);
+				return;
+			}
+		}
+	
+		// add a new group
+		GroupedCaseResults g = new GroupedCaseResults(cr.getShortErrorMessage());
+		g.add(cr);
+		groups.put(cr.getShortErrorMessage(), g);
+	}
+
+	public TestObject getTestObject() {
+		return testObject;
+	}
+	
+
+	/**
+	 * 
+	 * @return The list of representative error messages.
+	 */
+	public Set<String> getRepresentativeErrorMessages() {
+		return groups.keySet();
+	}
+
+	/**
+	 * 
+	 * @return All {@link GroupedCaseResults}.
+	 */
+    public List<GroupedCaseResults> getGroups() {
+        return new ArrayList<GroupedCaseResults>(groups.values());
+    }
+    
+}

--- a/src/main/java/hudson/tasks/junit/GroupByError.java
+++ b/src/main/java/hudson/tasks/junit/GroupByError.java
@@ -30,8 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.lang3.StringUtils;
-
 /**
  * 
  * Group case results by error message.
@@ -40,10 +38,11 @@ public class GroupByError {
 	private final TestObject testObject;
 
 	/**
-     * Minimum distance for testing whether they are similar.
-	 * 0.9f is just personal opinion.
+     * Maximum percentage of difference for testing whether two strings are similar.
+     * If the percentage of difference of two strings is below 50%, they seem to be similar.
+	 * 0.5f (50%) is just personal opinion.
 	 */
-	private double minDist = 0.9f;
+	private static double MAX_DIFF_PERCENTAGE_FOR_SIMILARITY = 0.5f;
 	
 	/**
 	 * All {@link GroupedCaseResults}
@@ -64,7 +63,7 @@ public class GroupByError {
 	
 	private void add(CaseResult cr) {
 		for(GroupedCaseResults g: groups.values()) {
-			if(g.similar(cr, minDist)) {
+			if(g.similar(cr, MAX_DIFF_PERCENTAGE_FOR_SIMILARITY)) {
 				// add case to the existing group
 				g.add(cr);
 				return;

--- a/src/main/java/hudson/tasks/junit/GroupByError.java
+++ b/src/main/java/hudson/tasks/junit/GroupByError.java
@@ -38,12 +38,12 @@ public class GroupByError {
 	private final TestObject testObject;
 
 	/**
-     * Maximum percentage of difference for testing whether two strings are similar.
-     * If the percentage of difference of two strings is below 50%, they seem to be similar.
+	 * Maximum percentage of difference for testing whether two strings are similar.
+	 * If the percentage of difference of two strings is below 50%, they seem to be similar.
 	 * 0.5f (50%) is just personal opinion.
 	 */
 	private static double MAX_DIFF_PERCENTAGE_FOR_SIMILARITY = 0.5f;
-	
+
 	/**
 	 * All {@link GroupedCaseResults}
 	 */
@@ -53,14 +53,14 @@ public class GroupByError {
 		this.testObject = testObject;
 
 		groups = new HashMap<String, GroupedCaseResults>();
-		
+
 		// generate groups
 		List<CaseResult> failedCases = (List<CaseResult>) testObject.getResultInRun(testObject.getRun()).getFailedTests();
 		for(CaseResult cr: failedCases) {
 			add(cr);
 		}
 	}
-	
+
 	private void add(CaseResult cr) {
 		for(GroupedCaseResults g: groups.values()) {
 			if(g.similar(cr, MAX_DIFF_PERCENTAGE_FOR_SIMILARITY)) {
@@ -69,7 +69,7 @@ public class GroupByError {
 				return;
 			}
 		}
-	
+
 		// add a new group
 		GroupedCaseResults g = new GroupedCaseResults(cr.getShortErrorMessage());
 		g.add(cr);
@@ -79,7 +79,7 @@ public class GroupByError {
 	public TestObject getTestObject() {
 		return testObject;
 	}
-	
+
 
 	/**
 	 * 
@@ -93,8 +93,8 @@ public class GroupByError {
 	 * 
 	 * @return All {@link GroupedCaseResults}.
 	 */
-    public List<GroupedCaseResults> getGroups() {
-        return new ArrayList<GroupedCaseResults>(groups.values());
-    }
-    
+	public List<GroupedCaseResults> getGroups() {
+		return new ArrayList<GroupedCaseResults>(groups.values());
+	}
+
 }

--- a/src/main/java/hudson/tasks/junit/GroupedCaseResults.java
+++ b/src/main/java/hudson/tasks/junit/GroupedCaseResults.java
@@ -25,18 +25,14 @@ package hudson.tasks.junit;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
 
 import hudson.util.EditDistance;
 
-import org.kohsuke.stapler.export.Exported;
 
 /**
  * Case results with similar error message.
  */
 public class GroupedCaseResults {
-	private static final Logger LOGGER = Logger.getLogger(GroupedCaseResults.class.getName());
-
 	/**
 	 * Representative error message for this group, actually one of error messages.
 	 */

--- a/src/main/java/hudson/tasks/junit/GroupedCaseResults.java
+++ b/src/main/java/hudson/tasks/junit/GroupedCaseResults.java
@@ -35,63 +35,63 @@ import org.kohsuke.stapler.export.Exported;
  * Case results with similar error message.
  */
 public class GroupedCaseResults {
-    private static final Logger LOGGER = Logger.getLogger(GroupedCaseResults.class.getName());
-    
-    /**
-     * Representative error message for this group, actually one of error messages.
-     */
-    private final String repErrorMessage;
-    
-    /**
-     * Case results which have similar error message.
-     */
-    private final List<CaseResult> cases = new ArrayList<CaseResult>();
-    
-    
-    public GroupedCaseResults(String repErrorMessage) {
-    	this.repErrorMessage = repErrorMessage;
-    }
-    
-    public String getRepErrorMessage() {
-        return repErrorMessage;
-    }
-    
-    public String getId() {
-    	return cases.get(0).getId();
-    }
+	private static final Logger LOGGER = Logger.getLogger(GroupedCaseResults.class.getName());
 
-    public List<CaseResult> getChildren() {
-        return cases;
-    }
+	/**
+	 * Representative error message for this group, actually one of error messages.
+	 */
+	private final String repErrorMessage;
 
-    public boolean hasChildren() {
-        return ((cases != null) && (cases.size() > 0));
-    }
-    
-    public void add(CaseResult r) {
-        cases.add(r);
-    }
-    
-    public CaseResult getCaseResult(String name) {
-        for (CaseResult c : cases) {
-            if(c.getSafeName().equals(name))
-                return c;
-        }
-        return null;
-    }
-    
-    public int getCount() {
-    	return cases.size();
-    }
+	/**
+	 * Case results which have similar error message.
+	 */
+	private final List<CaseResult> cases = new ArrayList<CaseResult>();
 
-    public boolean similar(CaseResult cr, double maxDiff) {
-   
-    	// The more different two strings are, the longer their distance is.
-    	float diffPercent = EditDistance.editDistance(repErrorMessage, cr.getShortErrorMessage()) / (float)(repErrorMessage.length());
+
+	public GroupedCaseResults(String repErrorMessage) {
+		this.repErrorMessage = repErrorMessage;
+	}
+
+	public String getRepErrorMessage() {
+		return repErrorMessage;
+	}
+
+	public String getId() {
+		return cases.get(0).getId();
+	}
+
+	public List<CaseResult> getChildren() {
+		return cases;
+	}
+
+	public boolean hasChildren() {
+		return ((cases != null) && (cases.size() > 0));
+	}
+
+	public void add(CaseResult r) {
+		cases.add(r);
+	}
+
+	public CaseResult getCaseResult(String name) {
+		for (CaseResult c : cases) {
+			if(c.getSafeName().equals(name))
+				return c;
+		}
+		return null;
+	}
+
+	public int getCount() {
+		return cases.size();
+	}
+
+	public boolean similar(CaseResult cr, double maxDiff) {
+
+		// The more different two strings are, the longer their distance is.
+		float diffPercent = EditDistance.editDistance(repErrorMessage, cr.getShortErrorMessage()) / (float)(repErrorMessage.length());
 		if(diffPercent <= maxDiff) {
 			return true;
 		}else {
 			return false;
 		}
-    }
+	}
 }

--- a/src/main/java/hudson/tasks/junit/GroupedCaseResults.java
+++ b/src/main/java/hudson/tasks/junit/GroupedCaseResults.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, Hyunil Shin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.tasks.junit;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kohsuke.stapler.export.Exported;
+
+/**
+ * Case results with similar error message.
+ */
+public class GroupedCaseResults {
+    private static final Logger LOGGER = Logger.getLogger(GroupedCaseResults.class.getName());
+    
+    /**
+     * Representative error message for this group, actually one of error messages.
+     */
+    private final String repErrorMessage;
+    
+    /**
+     * Case results which have similar error message.
+     */
+    private final List<CaseResult> cases = new ArrayList<CaseResult>();
+    
+    
+    public GroupedCaseResults(String repErrorMessage) {
+    	this.repErrorMessage = repErrorMessage;
+    }
+    
+    public String getRepErrorMessage() {
+        return repErrorMessage;
+    }
+    
+    public String getId() {
+    	return cases.get(0).getId();
+    }
+
+    public List<CaseResult> getChildren() {
+        return cases;
+    }
+
+    public boolean hasChildren() {
+        return ((cases != null) && (cases.size() > 0));
+    }
+    
+    public void add(CaseResult r) {
+        cases.add(r);
+    }
+    
+    public CaseResult getCaseResult(String name) {
+        for (CaseResult c : cases) {
+            if(c.getSafeName().equals(name))
+                return c;
+        }
+        return null;
+    }
+    
+    public int getCount() {
+    	return cases.size();
+    }
+
+    public boolean similar(CaseResult cr, double minDist) {
+    	
+		if(StringUtils.getJaroWinklerDistance(repErrorMessage, cr.getShortErrorMessage()) >= minDist) {
+			return true;
+		}else {
+			return false;
+		}
+    }
+}

--- a/src/main/java/hudson/tasks/junit/GroupedCaseResults.java
+++ b/src/main/java/hudson/tasks/junit/GroupedCaseResults.java
@@ -80,11 +80,26 @@ public class GroupedCaseResults {
 		return cases.size();
 	}
 
-	public boolean similar(CaseResult cr, double maxDiff) {
+	// http://stackoverflow.com/questions/955110/similarity-string-comparison-in-java
+	public boolean similar(CaseResult cr, double minDiff) {
+		
+		String longer = repErrorMessage;
+		String shorter = cr.getShortErrorMessage();
+		if(longer.length() < shorter.length()) {		// longer should always have greater lengths.
+			longer = cr.getShortErrorMessage();
+			shorter = repErrorMessage;
+		}
 
-		// The more different two strings are, the longer their distance is.
-		float diffPercent = EditDistance.editDistance(repErrorMessage, cr.getShortErrorMessage()) / (float)(repErrorMessage.length());
-		if(diffPercent <= maxDiff) {
+		int longerLength = longer.length();
+		if(longerLength == 0) {
+			return true;		// both strings are zero length.
+		}
+
+		// editDistance(): The more different two strings are, the longer their distance is.
+		// 0 (toally different) <= diff <= 1 (same)
+		float diff = (longerLength - EditDistance.editDistance(longer, shorter)) / (float)(longerLength);
+
+		if(diff >= minDiff) {
 			return true;
 		}else {
 			return false;

--- a/src/main/java/hudson/tasks/junit/GroupedCaseResults.java
+++ b/src/main/java/hudson/tasks/junit/GroupedCaseResults.java
@@ -27,7 +27,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
-import org.apache.commons.lang3.StringUtils;
+import hudson.util.EditDistance;
+
 import org.kohsuke.stapler.export.Exported;
 
 /**
@@ -83,9 +84,11 @@ public class GroupedCaseResults {
     	return cases.size();
     }
 
-    public boolean similar(CaseResult cr, double minDist) {
-    	
-		if(StringUtils.getJaroWinklerDistance(repErrorMessage, cr.getShortErrorMessage()) >= minDist) {
+    public boolean similar(CaseResult cr, double maxDiff) {
+   
+    	// The more different two strings are, the longer their distance is.
+    	float diffPercent = EditDistance.editDistance(repErrorMessage, cr.getShortErrorMessage()) / (float)(repErrorMessage.length());
+		if(diffPercent <= maxDiff) {
 			return true;
 		}else {
 			return false;

--- a/src/main/java/hudson/tasks/test/TestObject.java
+++ b/src/main/java/hudson/tasks/test/TestObject.java
@@ -28,6 +28,7 @@ import hudson.Util;
 import hudson.Functions;
 import hudson.model.*;
 import hudson.tasks.junit.History;
+import hudson.tasks.junit.GroupByError;
 import hudson.tasks.junit.TestAction;
 import hudson.tasks.junit.TestResultAction;
 import jenkins.model.Jenkins;
@@ -40,6 +41,7 @@ import org.kohsuke.stapler.export.ExportedBean;
 import com.google.common.collect.MapMaker;
 
 import javax.servlet.ServletException;
+
 import java.io.IOException;
 import java.util.*;
 import java.util.logging.Logger;
@@ -415,6 +417,10 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
     @Override
     public History getHistory() {
         return new History(this);
+    }
+    
+    public GroupByError getGroupByError() {
+    	return new GroupByError(this);
     }
 
     public Object getDynamic(String token, StaplerRequest req,

--- a/src/main/resources/hudson/tasks/junit/GroupByError/index.jelly
+++ b/src/main/resources/hudson/tasks/junit/GroupByError/index.jelly
@@ -1,0 +1,50 @@
+<!--
+The MIT License
+
+Copyright (c) 2015, Hyunil Shin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<!-- Groups failed tests by error message -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson/test" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+  <l:layout title="${%title(it.testObject.displayName)}">
+		<st:include from="${it.testObject}" it="${it.testObject}" page="sidepanel.jelly" />
+		<l:main-panel>
+			<H2>${%title(it.testObject.displayName)}</H2>
+	
+	<j:if test="${it.failCount!=0}">
+    <table class="pane sortable bigtable">
+      <tr>
+        <td class="pane-header">${%Error Message}</td>
+        <td class="pane-header">${%Count}</td>
+      </tr>
+    
+      <j:forEach var="f" items="${it.groups}" varStatus="i">
+     	<tr>
+            <td class="pane"><t:failed-tests-group group="${f}" testObject="${it.testObject}"/></td>
+     		<td>${f.count}</td>
+     	</tr> 
+      </j:forEach>
+    </table>
+  </j:if>	
+    	</l:main-panel>
+	</l:layout>
+</j:jelly>

--- a/src/main/resources/hudson/tasks/junit/GroupByError/index.jelly
+++ b/src/main/resources/hudson/tasks/junit/GroupByError/index.jelly
@@ -26,25 +26,25 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson/test" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${%title(it.testObject.displayName)}">
-		<st:include from="${it.testObject}" it="${it.testObject}" page="sidepanel.jelly" />
-		<l:main-panel>
-			<H2>${%title(it.testObject.displayName)}</H2>
+	<st:include from="${it.testObject}" it="${it.testObject}" page="sidepanel.jelly" />
+	<l:main-panel>
+		<H2>${%title(it.testObject.displayName)}</H2>
 	
-	<j:if test="${it.failCount!=0}">
-    <table class="pane sortable bigtable">
-      <tr>
-        <td class="pane-header">${%Error Message}</td>
-        <td class="pane-header">${%Count}</td>
-      </tr>
+		<j:if test="${it.failCount!=0}">
+    		<table class="pane sortable bigtable">
+      			<tr>
+        			<td class="pane-header">${%Error Message}</td>
+        			<td class="pane-header">${%Count}</td>
+      			</tr>
     
-      <j:forEach var="f" items="${it.groups}" varStatus="i">
-     	<tr>
-            <td class="pane"><t:failed-tests-group group="${f}" testObject="${it.testObject}"/></td>
-     		<td>${f.count}</td>
-     	</tr> 
-      </j:forEach>
-    </table>
-  </j:if>	
-    	</l:main-panel>
-	</l:layout>
+      			<j:forEach var="f" items="${it.groups}" varStatus="i">
+     				<tr>
+        				<td class="pane"><t:failed-tests-group group="${f}" testObject="${it.testObject}"/></td>
+     					<td>${f.count}</td>
+     				</tr> 
+      			</j:forEach>
+    		</table>
+  		</j:if>	
+    </l:main-panel>
+  </l:layout>
 </j:jelly>

--- a/src/main/resources/hudson/tasks/junit/GroupByError/index.jelly
+++ b/src/main/resources/hudson/tasks/junit/GroupByError/index.jelly
@@ -24,19 +24,44 @@ THE SOFTWARE.
 
 <!-- Groups failed tests by error message -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson/test" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson/test">
+
+<j:set var="minSimilarity" value="${request.getParameter('minSimilarity')}"/>
+<j:if test="${minSimilarity == null}">
+	<j:set var="minSimilarity" value="0.5"/>
+</j:if>
+${it.group(minSimilarity)}		<!-- if the minSimilarity is null, this line is not invoked. -->
+
+<script type="text/javascript">
+	function regroup() {
+        window.location = window.location.pathname + "?minSimilarity=" + 
+							document.getElementById('minSimilarity').value;
+
+    }
+</script>
+
   <l:layout title="${%title(it.testObject.displayName)}">
 	<st:include from="${it.testObject}" it="${it.testObject}" page="sidepanel.jelly" />
 	<l:main-panel>
 		<H2>${%title(it.testObject.displayName)}</H2>
 	
 		<j:if test="${it.failCount!=0}">
+            <table>
+                <tr>
+                  <td>Min. Similarity (between 0 and 1):</td>
+			      <td> <input id="minSimilarity" type="number" value="${minSimilarity}" step="0.01" 
+					    	  min = "0.0" max = "1.0"/> </td>
+                  <td> <button id="regroup" onclick="regroup()">Regroup</button> </td>
+                  <td>(0: All failed tests are grouped into one. 1: The exactly same errors are grouped together.) </td>
+                </tr>
+            </table>
+
     		<table class="pane sortable bigtable">
       			<tr>
         			<td class="pane-header">${%Error Message}</td>
         			<td class="pane-header">${%Count}</td>
       			</tr>
-    
+                 
       			<j:forEach var="f" items="${it.groups}" varStatus="i">
      				<tr>
         				<td class="pane"><t:failed-tests-group group="${f}" testObject="${it.testObject}"/></td>
@@ -44,7 +69,7 @@ THE SOFTWARE.
      				</tr> 
       			</j:forEach>
     		</table>
-  		</j:if>	
+		</j:if>	
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/src/main/resources/hudson/tasks/junit/GroupByError/index.properties
+++ b/src/main/resources/hudson/tasks/junit/GroupByError/index.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2015, Hyunil Shin
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+title=Group Failed Tests By Error Message for {0}

--- a/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
+++ b/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
@@ -27,15 +27,18 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson/test" xmlns:f="/lib/form">
   <j:if test="${it.failCount!=0}">
     <h2>${%All Failed Tests}</h2>
+    <a href="groupByError">${%Group Failed Tests}</a>
     <table class="pane sortable bigtable">
       <tr>
         <td class="pane-header">${%Test Name}</td>
+        <td class="pane-header">${%Error Message}</td>
         <td class="pane-header" style="width:4em">${%Duration}</td>
         <td class="pane-header" style="width:3em">${%Age}</td>
       </tr>
       <j:forEach var="f" items="${it.failedTests}" varStatus="i">
         <tr>
           <td class="pane"><t:failed-test result="${f}" url="${f.getRelativePathFrom(it)}"/></td>
+          <td class="pane no-wrap"><div style="width:600px;overflow:hidden;text-overflow:ellipsis">${f.shortErrorMessage}</div></td>
           <td class="pane no-wrap" style="text-align:right;" data="${f.duration}">
             ${f.durationString}
           </td>

--- a/src/main/resources/lib/hudson/test/failed-tests-group.jelly
+++ b/src/main/resources/lib/hudson/test/failed-tests-group.jelly
@@ -1,0 +1,96 @@
+<!--
+The MIT License
+
+Copyright (c) 2015, Hyunil Shin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <st:documentation>
+    Display link to the grouped failed tests.
+    <st:attribute name="group" type="GroupedCaseResults">
+      Group object 
+    </st:attribute>
+    <st:attribute name="testObject" type="TestObject">
+      Failed test object
+    </st:attribute>
+  </st:documentation>
+    <st:once>
+      <script type="text/javascript">
+      function showFailureSummary(id) {
+        var element = document.getElementById(id)
+        element.style.display = "";
+        document.getElementById(id + "-showlink").style.display = "none";
+        document.getElementById(id + "-hidelink").style.display = "";
+      }
+
+      function hideFailureSummary(id) {
+        document.getElementById(id).style.display = "none";
+        document.getElementById(id + "-showlink").style.display = "";
+        document.getElementById(id + "-hidelink").style.display = "none";
+      }
+    </script>
+    <style type="text/css">
+      .failure-summary {
+        margin-left: 2em;
+      }
+
+      .failure-summary h4 {
+        margin: 0.5em 0 0.5em 0;
+      }
+
+      .failure-summary h4 a {
+        text-decoration: none;
+        color: inherit;
+      }
+
+      .failure-summary h4 a img {
+        width: 8px;
+        height: 8px;
+      }
+
+      .failure-summary pre {
+        margin-left: 2em;
+      }
+    </style>
+  </st:once>
+  <j:set var="id" value="${h.jsStringEscape(group.id)}"/>
+  <j:set var="open" value="showFailureSummary('test-${id}')"/>
+  <j:set var="close" value="hideFailureSummary('test-${id}')"/>
+  <a id="test-${id}-showlink" onclick="${open}" title="${%Show list}">
+    <l:icon class="icon-document-add icon-sm"/>
+  </a>
+  <a id="test-${id}-hidelink" onclick="${close}" title="${%Hide lists}" style="display:none">
+    <l:icon class="icon-document-delete icon-sm"/>
+  </a>
+  <st:nbsp/>
+  <st:out value="${group.repErrorMessage}"/>
+  <j:set var="p" value="${it.getResultInRun(b)}"/>
+  <div id="test-${id}" class="failure-summary" style="display: none;">
+      <table>
+      <j:forEach var="f" items="${group.children}" varStatus="i">
+     	<tr>
+	    	<td class="pane"><a href="${app.rootUrl}${testObject.run.url}testReport${f.url}">${f.fullName}</a></td>
+     	</tr> 
+      </j:forEach>
+      </table>
+  </div>
+</j:jelly>

--- a/src/main/resources/lib/hudson/test/failed-tests-group.jelly
+++ b/src/main/resources/lib/hudson/test/failed-tests-group.jelly
@@ -86,11 +86,11 @@ THE SOFTWARE.
   <j:set var="p" value="${it.getResultInRun(b)}"/>
   <div id="test-${id}" class="failure-summary" style="display: none;">
       <table>
-      <j:forEach var="f" items="${group.children}" varStatus="i">
-     	<tr>
-	    	<td class="pane"><a href="${app.rootUrl}${testObject.run.url}testReport${f.url}">${f.fullName}</a></td>
-     	</tr> 
-      </j:forEach>
+      	<j:forEach var="f" items="${group.children}" varStatus="i">
+     		<tr>
+	    		<td class="pane"><a href="${app.rootUrl}${testObject.run.url}testReport${f.url}">${f.fullName}</a></td>
+     		</tr> 
+      	</j:forEach>
       </table>
   </div>
 </j:jelly>

--- a/src/test/java/hudson/tasks/junit/GroupTest.java
+++ b/src/test/java/hudson/tasks/junit/GroupTest.java
@@ -29,19 +29,28 @@ import hudson.model.BuildListener;
 import hudson.model.Result;
 import hudson.model.FreeStyleBuild;
 import hudson.Launcher;
-import org.jvnet.hudson.test.HudsonTestCase;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
+
 import java.io.IOException;
+
+import static org.junit.Assert.*;
 
 /**
  * Tests for {@link GroupByError, @link GroupedCaseResults}
  */
-public class GroupTest extends HudsonTestCase {
+public class GroupTest {
 
 
+    @Rule public JenkinsRule j = new JenkinsRule();
+    
     /**
      * Verifies that the failed tests are grouped by error message.
      */
+    @Test
     public void testFreestyleErrorMsgAndStacktraceRender() throws Exception {
         FreeStyleBuild b = configureTestBuild(null);
         TestResult tr = b.getAction(TestResultAction.class).getResult();
@@ -64,7 +73,7 @@ public class GroupTest extends HudsonTestCase {
     
 
     private FreeStyleBuild configureTestBuild(String projectName) throws Exception {
-        FreeStyleProject p = projectName == null ? createFreeStyleProject() : createFreeStyleProject(projectName);
+        FreeStyleProject p = projectName == null ? j.createFreeStyleProject() : j.createFreeStyleProject(projectName);
         p.getBuildersList().add(new TestBuilder() {
             public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
                 build.getWorkspace().child("junit.xml").copyFrom(
@@ -73,6 +82,6 @@ public class GroupTest extends HudsonTestCase {
             }
         });
         p.getPublishersList().add(new JUnitResultArchiver("*.xml"));
-        return assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
+        return j.assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
     }
 }

--- a/src/test/java/hudson/tasks/junit/GroupTest.java
+++ b/src/test/java/hudson/tasks/junit/GroupTest.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2015, Hyunil Shin
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.tasks.junit;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.model.FreeStyleBuild;
+import hudson.Launcher;
+import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.TestBuilder;
+import java.io.IOException;
+
+/**
+ * Tests for {@link GroupByError, @link GroupedCaseResults}
+ */
+public class GroupTest extends HudsonTestCase {
+
+
+    /**
+     * Verifies that the failed tests are grouped by error message.
+     */
+    public void testFreestyleErrorMsgAndStacktraceRender() throws Exception {
+        FreeStyleBuild b = configureTestBuild(null);
+        TestResult tr = b.getAction(TestResultAction.class).getResult();
+        assertEquals(4,tr.getFailedTests().size());
+
+        GroupByError groupByError = new GroupByError(tr);
+        assertEquals("Should have had two groups, but had " + groupByError.getGroups().size(), 2, groupByError.getGroups().size());
+        
+        
+        GroupedCaseResults group1 = groupByError.getGroups().get(0);
+        assertEquals("Should have had three elements, but had " + group1.getCount(), 3, group1.getCount());
+        assertEquals(true, group1.similar(new CaseResult(null, "ddd", "some.package.somewhere.WhooHoo: "
+        		+ "[ID : 245025], [TID : 3311e81d-c848-4d60-1111-f1fb2ff06a1f],"
+        		+ " - message : On Provision problem."), 0.9f));
+        
+        GroupedCaseResults group2 = groupByError.getGroups().get(1);
+        assertEquals("Should have had one elements, but had " + group2.getCount(), 1, group2.getCount());
+        assertEquals("java.lang.NullPointerException: null", group2.getRepErrorMessage());
+    }
+    
+
+    private FreeStyleBuild configureTestBuild(String projectName) throws Exception {
+        FreeStyleProject p = projectName == null ? createFreeStyleProject() : createFreeStyleProject(projectName);
+        p.getBuildersList().add(new TestBuilder() {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                build.getWorkspace().child("junit.xml").copyFrom(
+                    getClass().getResource("junit-report-group-by-error.xml"));
+                return true;
+            }
+        });
+        p.getPublishersList().add(new JUnitResultArchiver("*.xml"));
+        return assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
+    }
+}

--- a/src/test/resources/hudson/tasks/junit/junit-report-group-by-error.xml
+++ b/src/test/resources/hudson/tasks/junit/junit-report-group-by-error.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+The MIT License
+
+Copyright (c) 2015, Hyunil Shin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<testsuite name="bugdb.ME_116" time="0.008" tests="4" errors="4" skipped="0" failures="0">
+  <testcase classname="some.package.somewhere.WhooHoo" name="error1" time="0.016">
+    <error message="some.package.somewhere.WhooHoo: [ID : 245025], [TID : 2218e81c-c745-4d60-8966-f1fb2ff06a1f], - message : On Provision problem." type="org.junit.ComparisonFailure">	at some.package.somewhere.WhooHoo.testHudsonReporting(WhooHoo.java:48)
+</error>
+  </testcase>
+  <testcase classname="some.package.somewhere.WhooHoo" name="error2" time="0.016">
+    <error message="some.package.somewhere.WhooHoo: [ID : 245025], [TID : 3311e81d-c848-4d60-1111-f1fb2ff06a1f], - message : On Provision problem." type="org.junit.ComparisonFailure">	at some.package.somewhere.WhooHoo.testHudsonReporting(WhooHoo.java:48)
+</error>
+  </testcase>
+  <testcase classname="some.package.somewhere.Hello" name="error3" time="0.016">
+    <error message="some.package.somewhere.WhooHoo: [ID : 245025], [TID : 4d451951-adac-4daa-827a-f67c3f90d24f], - message : On Provision problem." type="org.junit.ComparisonFailure">	at some.package.somewhere.WhooHoo.testHudsonReporting(WhooHoo.java:48)
+</error>
+  </testcase>
+
+  <testcase name="test" classname="some.package.somewhere.Boy" time="3.486">
+    <error type="java.lang.NullPointerException:">java.lang.NullPointerException: null
+	at abc.def.ghi.AAAA(AAAA.java:398)
+	at qe.ert.tyy(BBBB.java:325)
+	at some.package.somewhere.Boy(Boy.java:91)
+</error>
+    <system-out><![CDATA[    	Test Method Start At: Fri Jun 19 15:45:53 KST 2015
+]]></system-out>
+  </testcase>
+
+</testsuite>


### PR DESCRIPTION
1. Add a column of error message to the failed test table.
2. Add a page (GroupByError/index.jelly) to display groups of failed
   tests, each of which has similar error message.

| Error Message | Count |
| --- | --- |
| +Some error message A | 33 |
| +Some exception A | 10 |
| -Some exception B <br> test1 <br> test2 <br> test3 | 3 |
| +Some error message B | 1 |
| +Some error message C | 1 |
