### PR TITLE
remove ambiguity in test errors

### DIFF
--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -222,7 +222,7 @@ public final class TestResult extends MetaTabulatedResult {
         if(reportFile.length()==0) {
             // this is a typical problem when JVM quits abnormally, like OutOfMemoryError during a test.
             SuiteResult sr = new SuiteResult(reportFile.getName(), "", "");
-            sr.addCase(new CaseResult(sr,"<init>","Test report file "+reportFile.getAbsolutePath()+" was length 0"));
+            sr.addCase(new CaseResult(sr,"[empty]","Test report file "+reportFile.getAbsolutePath()+" was length 0"));
             add(sr);
         } else {
             parse(reportFile);
@@ -294,7 +294,7 @@ public final class TestResult extends MetaTabulatedResult {
                 StringWriter writer = new StringWriter();
                 e.printStackTrace(new PrintWriter(writer));
                 String error = "Failed to read test report file "+reportFile.getAbsolutePath()+"\n"+writer.toString();
-                sr.addCase(new CaseResult(sr,"<init>",error));
+                sr.addCase(new CaseResult(sr,"[failed-to-read]",error));
                 add(sr);
             }
         }


### PR DESCRIPTION
The phrase `<init>` as a test name is used in three places to
represent three independent types of error.  This is needlessly
ambiguous.  This patch removes that ambiguity so it is clear
which case is under consideration.