### PR TITLE
Convert to parent-pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.580.1</version>
+        <version>2.3</version>
     </parent>
     <artifactId>junit</artifactId>
     <version>1.11-SNAPSHOT</version>
@@ -17,6 +17,10 @@
             <url>http://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
+    <properties>
+        <jenkins.version>1.580.1</jenkins.version>
+        <jenkins-test-harness.version>1.580.1</jenkins-test-harness.version>
+    </properties>
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
     Allows JUnit-format test results to be published.
 </div>


### PR DESCRIPTION
Converted to parent pom to avoid test failures due to upgraded versions of htmlunit in core.  There are still test failures with junit, but those are unrelated to the parent pom.