### PR TITLE
Testsuite duration may be parsed from time attr

### DIFF
--- a/src/main/java/hudson/tasks/junit/ClassResult.java
+++ b/src/main/java/hudson/tasks/junit/ClassResult.java
@@ -188,10 +188,12 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
             else {
                 failCount++;
             }
-            duration += r.getDuration();
+            //retrieve the class duration from these cases' suite time
+            if(duration == 0){
+                duration = r.getSuiteResult().getDuration();
+            }
         }
     }
-
 
     void freeze() {
         this.tally();

--- a/src/main/java/hudson/tasks/junit/SuiteResult.java
+++ b/src/main/java/hudson/tasks/junit/SuiteResult.java
@@ -72,6 +72,9 @@ public final class SuiteResult implements Serializable {
     /** Optional ID attribute of a test suite. E.g., Eclipse plug-ins tests always have the name 'tests' but a different id. **/
     private String id;
 
+    /** Optional time attribute of a test suite. E.g., Suites can use their own time attribute or the sum of their cases' times as before.**/
+    private String time;
+
     /**
      * All test cases.
      */
@@ -161,7 +164,12 @@ public final class SuiteResult implements Serializable {
         this.name = TestObject.safe(name);
         this.timestamp = suite.attributeValue("timestamp");
         this.id = suite.attributeValue("id");
-
+        
+        // check for test suite time attribute
+        if( ( this.time = suite.attributeValue("time") ) != null ){
+            duration = Float.parseFloat(this.time);
+        }
+        
         Element ex = suite.element("error");
         if(ex!=null) {
             // according to junit-noframes.xsl l.229, this happens when the test class failed to load
@@ -218,7 +226,11 @@ public final class SuiteResult implements Serializable {
     /*package*/ void addCase(CaseResult cr) {
         cases.add(cr);
         casesByName().put(cr.getName(), cr);
-        duration += cr.getDuration();
+        
+        //if suite time was not specified use sum of the cases' times
+        if(this.time == null){
+            duration += cr.getDuration();
+        }
     }
 
     @Exported(visibility=9)

--- a/src/test/java/hudson/tasks/junit/SuiteResultTest.java
+++ b/src/test/java/hudson/tasks/junit/SuiteResultTest.java
@@ -314,4 +314,12 @@ public class SuiteResultTest extends TestCase {
             assertEquals(1, result.getCases().size());
         }
     }
+    public void testTestSuiteTimeAttribute() throws Exception {
+        // A report with blocks of testsuites some with and some without time attrs  
+        List<SuiteResult> results = parseSuites(getDataFile("junit-report-testsuite-time-attrs.xml"));
+        assertEquals(results.get(0).getDuration(),25.0f); //testsuit time
+        assertEquals(results.get(1).getDuration(),22.0f); //sum of test cases time
+        assertEquals(results.get(2).getDuration(),40.0f); //testsuit time 
+        assertEquals(results.get(3).getDuration(),20.0f); //sum of test cases time
+    }
 }

--- a/src/test/resources/hudson/tasks/junit/junit-report-testsuite-time-attrs.xml
+++ b/src/test/resources/hudson/tasks/junit/junit-report-testsuite-time-attrs.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Automation Tests" tests="8" errors="0" failures="0" ignored="0">
+    <testsuite name="test.fs.FileSystemTests" time="25">
+      <testcase name="testPrefix" classname="test.fs.FileSystemTest1" time="10"/>
+      <testcase name="testPrefix" classname="test.fs.FileSystemTest2" time="11"/>
+    </testsuite>
+    <testsuite name="test.db.DatabaseTests" >
+      <testcase name="testTable" classname="test.db.DatabaseTest1" time="10"/>
+      <testcase name="testTable" classname="test.db.DatabaseTest2" time="12"/>
+    </testsuite>
+    <testsuite name="test.lib.Rest" >
+        <testsuite name="test.RestMethods" time="40">
+          <testcase name="testInterface" classname="test.Rest.post" time="12"/>
+          <testcase name="testInterface" classname="test.Rest.get" time="13"/>
+          <testcase name="testInterface" classname="test.Rest.delete" time="13"/>
+      </testsuite>
+      <testcase name="testFinish" classname="test.Rest.cleanup" time="20"/>
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
Testsuite duration can be retrieved from its time attribute if
it exists. Otherwise it will continue to be calculated from the sum
of it's testcases. ClassResult duration is now obtained from it's
cases' SuiteResult since it was just re-summing case durations.