### PR TITLE
Fixing squid:UselessParenthesesCheck-Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -307,7 +307,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
             if(!Character.isJavaIdentifierPart(ch))
                 buf.setCharAt(i,'_');
         }
-        Collection<CaseResult> siblings = (classResult ==null ? Collections.<CaseResult>emptyList(): classResult.getChildren());
+        Collection<CaseResult> siblings = classResult ==null ? Collections.<CaseResult>emptyList(): classResult.getChildren();
         return safeName = uniquifyName(siblings, buf.toString());
     }
 

--- a/src/main/java/hudson/tasks/junit/ClassResult.java
+++ b/src/main/java/hudson/tasks/junit/ClassResult.java
@@ -59,7 +59,7 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
 
     @Override
     public Run<?, ?> getRun() {
-        return (parent==null ? null: parent.getRun());
+        return parent==null ? null: parent.getRun();
     }
 
     public PackageResult getParent() {
@@ -143,7 +143,7 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
     }
 
     public boolean hasChildren() {
-        return ((cases != null) && (cases.size() > 0));
+        return (cases != null) && (cases.size() > 0);
     }
 
     // TODO: wait for stapler 1.60     @Exported

--- a/src/main/java/hudson/tasks/junit/PackageResult.java
+++ b/src/main/java/hudson/tasks/junit/PackageResult.java
@@ -56,7 +56,7 @@ public final class PackageResult extends MetaTabulatedResult implements Comparab
     
     @Override
     public Run<?,?> getRun() {
-        return (parent == null ? null : parent.getRun());
+        return parent == null ? null : parent.getRun();
     }
 
     public hudson.tasks.junit.TestResult getParent() {
@@ -73,7 +73,7 @@ public final class PackageResult extends MetaTabulatedResult implements Comparab
         if (safeName != null) {
             return safeName;
         }
-        Collection<PackageResult> siblings = (parent == null ? Collections.EMPTY_LIST : parent.getChildren());
+        Collection<PackageResult> siblings = parent == null ? Collections.EMPTY_LIST : parent.getChildren();
         return safeName = uniquifyName(
                 siblings,
                 safe(getName()));
@@ -167,7 +167,7 @@ public final class PackageResult extends MetaTabulatedResult implements Comparab
     @Override
     public boolean hasChildren() {
         int totalTests = passCount + failCount + skipCount;
-        return (totalTests != 0);
+        return totalTests != 0;
     }
 
     /**
@@ -254,7 +254,7 @@ public final class PackageResult extends MetaTabulatedResult implements Comparab
      */
     @Override
     public boolean isPassed() {
-        return (failCount == 0 && skipCount == 0);
+        return failCount == 0 && skipCount == 0;
     }
 
     void add(CaseResult r) {

--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -163,7 +163,7 @@ public final class TestResult extends MetaTabulatedResult {
         for (String value : reportFiles) {
             File reportFile = new File(baseDir, value);
             // only count files that were actually updated during this build
-            if ( (buildTime-3000/*error margin*/ <= reportFile.lastModified())) {
+            if (buildTime-3000/*error margin*/ <= reportFile.lastModified()) {
                 parsePossiblyEmpty(reportFile);
                 parsed = true;
             }
@@ -197,7 +197,7 @@ public final class TestResult extends MetaTabulatedResult {
 
         for (File reportFile : reportFiles) {
             // only count files that were actually updated during this build
-            if ( (buildTime-3000/*error margin*/ <= reportFile.lastModified())) {
+            if (buildTime-3000/*error margin*/ <= reportFile.lastModified()) {
                 parsePossiblyEmpty(reportFile);
                 parsed = true;
             }
@@ -310,7 +310,7 @@ public final class TestResult extends MetaTabulatedResult {
 
     @Override
     public Run<?,?> getRun() {
-        return (parentAction == null? null: parentAction.run);
+        return parentAction == null? null: parentAction.run;
     }
 
     @Override
@@ -531,7 +531,7 @@ public final class TestResult extends MetaTabulatedResult {
      */
     @Override
     public boolean isPassed() {
-       return (getFailCount() == 0);
+       return getFailCount() == 0;
     }
 
     @Override

--- a/src/main/java/hudson/tasks/test/TestObject.java
+++ b/src/main/java/hudson/tasks/test/TestObject.java
@@ -104,7 +104,7 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
     public hudson.tasks.junit.TestResult getTestResult() {
         TestObject parent = getParent();
 
-        return (parent == null ? null : getParent().getTestResult());
+        return parent == null ? null : getParent().getTestResult();
     }
 
     /**
@@ -113,7 +113,7 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
     public TestResult getTopLevelTestResult() {
         TestObject parent = getParent();
 
-        return (parent == null ? null : getParent().getTopLevelTestResult());
+        return parent == null ? null : getParent().getTopLevelTestResult();
     }
     
     /**

--- a/src/test/java/hudson/tasks/junit/JUnitParserTest.java
+++ b/src/test/java/hudson/tasks/junit/JUnitParserTest.java
@@ -73,7 +73,7 @@ public class JUnitParserTest extends HudsonTestCase {
             assertTrue("result should be a TestResult", result instanceof hudson.tasks.junit.TestResult);
             System.out.println("We passed some assertions in the JUnitParserTestBuilder");
             theResult = result;
-            return (result != null);
+            return result != null;
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule " UselessParenthesesCheck -     Useless parentheses around expressions should be removed to prevent any misunderstanding". You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.
Sameer Misger