### PR TITLE
Fixing squid:AssignmentInSubExpressionCheck- Assignments should not be made from within sub-expressions

### DIFF
--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -308,7 +308,8 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
                 buf.setCharAt(i,'_');
         }
         Collection<CaseResult> siblings = (classResult ==null ? Collections.<CaseResult>emptyList(): classResult.getChildren());
-        return safeName = uniquifyName(siblings, buf.toString());
+        safeName = uniquifyName(siblings, buf.toString());
+        return safeName; 
     }
 
     /**

--- a/src/main/java/hudson/tasks/junit/ClassResult.java
+++ b/src/main/java/hudson/tasks/junit/ClassResult.java
@@ -115,7 +115,8 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
         if (safeName != null) {
             return safeName;
         }
-        return safeName = uniquifyName(parent.getChildren(), safe(getName()));
+        safeName = uniquifyName(parent.getChildren(), safe(getName()));
+        return safeName;
     }
     
     public CaseResult getCaseResult(String name) {

--- a/src/main/java/hudson/tasks/junit/PackageResult.java
+++ b/src/main/java/hudson/tasks/junit/PackageResult.java
@@ -74,9 +74,8 @@ public final class PackageResult extends MetaTabulatedResult implements Comparab
             return safeName;
         }
         Collection<PackageResult> siblings = (parent == null ? Collections.EMPTY_LIST : parent.getChildren());
-        return safeName = uniquifyName(
-                siblings,
-                safe(getName()));
+        safeName = uniquifyName(siblings, safe(getName()));
+        return safeName;
     }
 
     @Override
@@ -261,7 +260,8 @@ public final class PackageResult extends MetaTabulatedResult implements Comparab
         String n = r.getSimpleName(), sn = safe(n);
         ClassResult c = getClassResult(sn);
         if (c == null) {
-            classes.put(sn,c=new ClassResult(this,n));
+        	c=new ClassResult(this,n)
+            classes.put(sn, c);
         }
         c.add(r);
         duration += r.getDuration(); 

--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -619,8 +619,10 @@ public final class TestResult extends MetaTabulatedResult {
                 cr.tally();
                 String pkg = cr.getPackageName(), spkg = safe(pkg);
                 PackageResult pr = byPackage(spkg);
-                if(pr==null)
-                    byPackages.put(spkg,pr=new PackageResult(this,pkg));
+                if(pr==null) {
+                	pr=new PackageResult(this,pkg);
+                    byPackages.put(spkg, pr);
+                }
                 pr.add(cr);
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:AssignmentInSubExpressionCheck -    Assignments should not be made from within sub-expressions”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:AssignmentInSubExpressionCheck

Please let me know if you have any questions.
Sameer Misger