### PR TITLE
Fixing squid:squid:HiddenFieldCheck --  Local variables should not shadow class fields

### DIFF
--- a/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
+++ b/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
@@ -139,9 +139,9 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep {
             TaskListener listener) throws InterruptedException, IOException {
         listener.getLogger().println(Messages.JUnitResultArchiver_Recording());
 
-        final String testResults = build.getEnvironment(listener).expand(this.testResults);
+        final String testResultsLocal = build.getEnvironment(listener).expand(this.testResults);
 
-        TestResult result = parse(testResults, build, workspace, launcher, listener);
+        TestResult result = parse(testResultsLocal, build, workspace, launcher, listener);
 
         synchronized (build) {
             // TODO can the build argument be omitted now, or is it used prior to the call to addAction?

--- a/src/main/java/hudson/tasks/junit/SuiteResult.java
+++ b/src/main/java/hudson/tasks/junit/SuiteResult.java
@@ -149,16 +149,16 @@ public final class SuiteResult implements Serializable {
      */
     private SuiteResult(File xmlReport, Element suite, boolean keepLongStdio) throws DocumentException, IOException {
     	this.file = xmlReport.getAbsolutePath();
-        String name = suite.attributeValue("name");
-        if(name==null)
+        String nameLocal = suite.attributeValue("name");
+        if(nameLocal==null)
             // some user reported that name is null in their environment.
             // see http://www.nabble.com/Unexpected-Null-Pointer-Exception-in-Hudson-1.131-tf4314802.html
-            name = '('+xmlReport.getName()+')';
+        	nameLocal = '('+xmlReport.getName()+')';
         else {
             String pkg = suite.attributeValue("package");
-            if(pkg!=null&& pkg.length()>0)   name=pkg+'.'+name;
+            if(pkg!=null&& pkg.length()>0)   nameLocal=pkg+'.'+nameLocal;
         }
-        this.name = TestObject.safe(name);
+        this.name = TestObject.safe(nameLocal);
         this.timestamp = suite.attributeValue("timestamp");
         this.id = suite.attributeValue("id");
 
@@ -193,9 +193,9 @@ public final class SuiteResult implements Serializable {
             addCase(new CaseResult(this, e, classname, keepLongStdio));
         }
 
-        String stdout = CaseResult.possiblyTrimStdio(cases, keepLongStdio, suite.elementText("system-out"));
-        String stderr = CaseResult.possiblyTrimStdio(cases, keepLongStdio, suite.elementText("system-err"));
-        if (stdout==null && stderr==null) {
+        String stdoutLocal = CaseResult.possiblyTrimStdio(cases, keepLongStdio, suite.elementText("system-out"));
+        String stderrLocal = CaseResult.possiblyTrimStdio(cases, keepLongStdio, suite.elementText("system-err"));
+        if (stdoutLocal==null && stderrLocal==null) {
             // Surefire never puts stdout/stderr in the XML. Instead, it goes to a separate file (when ${maven.test.redirectTestOutputToFile}).
             Matcher m = SUREFIRE_FILENAME.matcher(xmlReport.getName());
             if (m.matches()) {
@@ -203,7 +203,7 @@ public final class SuiteResult implements Serializable {
                 File mavenOutputFile = new File(xmlReport.getParentFile(),m.group(1)+"-output.txt");
                 if (mavenOutputFile.exists()) {
                     try {
-                        stdout = CaseResult.possiblyTrimStdio(cases, keepLongStdio, mavenOutputFile);
+                    	stdoutLocal = CaseResult.possiblyTrimStdio(cases, keepLongStdio, mavenOutputFile);
                     } catch (IOException e) {
                         throw new IOException("Failed to read "+mavenOutputFile,e);
                     }
@@ -211,8 +211,8 @@ public final class SuiteResult implements Serializable {
             }
         }
 
-        this.stdout = stdout;
-        this.stderr = stderr;
+        this.stdout = stdoutLocal;
+        this.stderr = stderrLocal;
     }
 
     /*package*/ void addCase(CaseResult cr) {

--- a/src/main/java/hudson/tasks/junit/TestResultAction.java
+++ b/src/main/java/hudson/tasks/junit/TestResultAction.java
@@ -217,15 +217,15 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
     }
 
     public List<TestAction> getActions(TestObject object) {
-        List<TestAction> result = new ArrayList<TestAction>();
+        List<TestAction> resultLocal = new ArrayList<TestAction>();
         // Added check for null testData to avoid NPE from issue 4257.
         if (testData != null) {
             for (Data data : testData)
                 for (TestAction ta : data.getTestAction(object))
                     if (ta != null)
-                        result.add(ta);
+                    	resultLocal.add(ta);
         }
-        return Collections.unmodifiableList(result);
+        return Collections.unmodifiableList(resultLocal);
     }
 
     List<Data> getData() {

--- a/src/main/java/hudson/tasks/test/AggregatedTestResultPublisher.java
+++ b/src/main/java/hudson/tasks/test/AggregatedTestResultPublisher.java
@@ -255,11 +255,11 @@ public class AggregatedTestResultPublisher extends Recorder {
             if(lastUpdated>lastChanged)     return;
             lastUpdated = lastChanged+1;
 
-            int failCount = 0;
-            int totalCount = 0;
-            List<AbstractTestResultAction> individuals = new ArrayList<AbstractTestResultAction>();
-            List<AbstractProject> didntRun = new ArrayList<AbstractProject>();
-            List<AbstractProject> noFingerprints = new ArrayList<AbstractProject>();
+            int failCountLocal = 0;
+            int totalCountLocal = 0;
+            List<AbstractTestResultAction> individualsLocal = new ArrayList<AbstractTestResultAction>();
+            List<AbstractProject> didntRunLocal = new ArrayList<AbstractProject>();
+            List<AbstractProject> noFingerprintsLocal = new ArrayList<AbstractProject>();
             for (AbstractProject job : getJobs()) {
                 RangeSet rs = owner.getDownstreamRelationship(job);
                 if(rs.isEmpty()) {
@@ -272,9 +272,9 @@ public class AggregatedTestResultPublisher extends Recorder {
                     }
                     if(b!=null && b.getAction(AbstractTestResultAction.class)!=null) {
                         if(b.getAction(FingerprintAction.class)!=null) {
-                            didntRun.add(job);
+                        	didntRunLocal.add(job);
                         } else {
-                            noFingerprints.add(job);
+                        	noFingerprintsLocal.add(job);
                         }
                     }
                 } else {
@@ -292,20 +292,20 @@ public class AggregatedTestResultPublisher extends Recorder {
                             continue;   // don't count them
 
                         for( AbstractTestResultAction ta : b.getActions(AbstractTestResultAction.class)) {
-                            failCount += ta.getFailCount();
-                            totalCount += ta.getTotalCount();
-                            individuals.add(ta);
+                        	failCountLocal += ta.getFailCount();
+                        	totalCountLocal += ta.getTotalCount();
+                        	individualsLocal.add(ta);
                         }
                         break;
                     }
                 }
             }
 
-            this.failCount = failCount;
-            this.totalCount = totalCount;
-            this.individuals = individuals;
-            this.didntRun = didntRun;
-            this.noFingerprints = noFingerprints;
+            this.failCount = failCountLocal;
+            this.totalCount = totalCountLocal;
+            this.individuals = individualsLocal;
+            this.didntRun = didntRunLocal;
+            this.noFingerprints = noFingerprintsLocal;
         }
 
         public boolean getHasFingerprintAction() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "  squid:HiddenFieldCheck --  Local variables should not shadow class fields"  information about the issues here:

https://dev.eclipse.org/sonar/rules/show/squid:HiddenFieldCheck

Please let me know if you have any questions.
Sameer Misger
