### PR TITLE
Update parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.3</version>
+        <version>2.4</version>
     </parent>
     <artifactId>junit</artifactId>
     <version>1.12-SNAPSHOT</version>


### PR DESCRIPTION
Allows `mvn hpi:run` to work, via https://github.com/jenkinsci/maven-hpi-plugin/pull/29.

@reviewbybees esp. @andresrc and CC @emanuelez