### PR TITLE
[JENKINS-34598] - Hardening time attribute checks

### DIFF
--- a/src/main/java/hudson/tasks/junit/SuiteResult.java
+++ b/src/main/java/hudson/tasks/junit/SuiteResult.java
@@ -165,7 +165,8 @@ public final class SuiteResult implements Serializable {
         this.timestamp = suite.attributeValue("timestamp");
         this.id = suite.attributeValue("id");
         // check for test suite time attribute
-        if( ( this.time = suite.attributeValue("time") ) != null ){
+        this.time = suite.attributeValue("time");
+        if(this.time!=null &&  !this.time.equals("")){
             duration = new TimeToFloat(this.time).parse();
         }
         
@@ -227,7 +228,7 @@ public final class SuiteResult implements Serializable {
         casesByName().put(cr.getName(), cr);
         
         //if suite time was not specified use sum of the cases' times
-        if(this.time == null){
+        if(this.time == null || this.time.equals("")){
             duration += cr.getDuration();
         }
     }


### PR DESCRIPTION
This change is a bug fix for the case when the time attribute of a test suit is empty. This can happen when all tests of a test suite are ignored. Currently an `java.io.IOException` / `java.lang.NumberFormatException` is thrown (see [JENKINS-34598](https://issues.jenkins-ci.org/browse/JENKINS-34598) - JUnit plugin: archiving of test reports fails when time attribute of test suite is empty)
