### PR TITLE
Prevent wrapping for test name table cell

### DIFF
--- a/src/main/resources/lib/hudson/test/aggregated-failed-tests.jelly
+++ b/src/main/resources/lib/hudson/test/aggregated-failed-tests.jelly
@@ -52,7 +52,7 @@ THE SOFTWARE.
           </tr>
           <j:forEach var="f" items="${report.result.failedTests}" varStatus="i">
             <tr>
-              <td class="pane"><t:failed-test result="${f}" url="../${report.child.project.shortUrl}testReport/${f.getRelativePathFrom(report.result)}"/></td>
+              <td class="pane no-wrap"><t:failed-test result="${f}" url="../${report.child.project.shortUrl}testReport/${f.getRelativePathFrom(report.result)}"/></td>
               <td class="pane no-wrap" style="text-align:right;" data="${f.duration}">${f.durationString}</td>
               <td class="pane" style="text-align:right;">${f.age}</td>
             </tr>


### PR DESCRIPTION
The no-wrap class attribute was added some time ago to prevent the duration column from wrapping its text.
But for long test names the test name column still inserts a line break between the plus icon (to show/hide the failure details) and the test name.
This change should fix that.