### PR TITLE
Don't bury AllowEmptyResults in Advanced

### DIFF
--- a/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
+++ b/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
@@ -43,9 +43,7 @@ THE SOFTWARE.
             <f:repeatableHeteroProperty field="testDataPublishers" hasHeader="true" oneEach="true"/>
     </f:entry>
     </j:if>
-    <f:advanced>
-        <f:entry title="${%Allow empty results}" field="allowEmptyResults">
-            <f:checkbox default="false" title="${%Do not fail the build on empty test results}"/>
-        </f:entry>
-    </f:advanced>
+    <f:entry title="${%Allow empty results}" field="allowEmptyResults">
+        <f:checkbox default="false" title="${%Do not fail the build on empty test results}"/>
+    </f:entry>
 </j:jelly>


### PR DESCRIPTION
I'm not sure if this actually works -- I was taking a 1-minute stab at fixing a usability annoyance. But the 1-item advanced section has caused usability... issues.