### PR TITLE
optionally configure ignore old tests

### DIFF
--- a/src/main/java/hudson/tasks/junit/JUnitParser.java
+++ b/src/main/java/hudson/tasks/junit/JUnitParser.java
@@ -46,6 +46,7 @@ public class JUnitParser extends TestResultParser {
 
     private final boolean keepLongStdio;
     private final boolean allowEmptyResults;
+    private final boolean allowOldResults;
 
     /** TODO TestResultParser.all does not seem to ever be called so why must this be an Extension? */
     @Deprecated
@@ -59,8 +60,7 @@ public class JUnitParser extends TestResultParser {
      */
     @Deprecated
     public JUnitParser(boolean keepLongStdio) {
-        this.keepLongStdio = keepLongStdio;
-        this.allowEmptyResults = false;
+        this(keepLongStdio, false, false);
     }
 
     /**
@@ -69,8 +69,19 @@ public class JUnitParser extends TestResultParser {
      * @since 1.10
      */
     public JUnitParser(boolean keepLongStdio, boolean allowEmptyResults) {
-        this.keepLongStdio = keepLongStdio;
-        this.allowEmptyResults = allowEmptyResults;
+        this(keepLongStdio, allowEmptyResults, false);
+    }
+    
+    /**
+     * @param keepLongStdio if true, retain a suite's complete stdout/stderr even if this is huge and the suite passed
+     * @param allowEmptyResults if true, empty results are allowed
+     * @param allowOldResults
+     * @since 1.16
+     */
+    public JUnitParser(boolean keepLongStdio, boolean allowEmptyResults, boolean allowOldResults) {
+      this.keepLongStdio = keepLongStdio;
+      this.allowEmptyResults = allowEmptyResults;
+      this.allowOldResults = allowEmptyResults;
     }
 
     @Override
@@ -101,7 +112,7 @@ public class JUnitParser extends TestResultParser {
         // also get code that deals with testDataPublishers from JUnitResultArchiver.perform
 
         return workspace.act(new ParseResultCallable(testResultLocations, buildTime,
-                                                     timeOnMaster, keepLongStdio, allowEmptyResults));
+                                                     timeOnMaster, keepLongStdio, allowEmptyResults, allowOldResults));
     }
 
     private static final class ParseResultCallable extends MasterToSlaveFileCallable<TestResult> {
@@ -110,14 +121,16 @@ public class JUnitParser extends TestResultParser {
         private final long nowMaster;
         private final boolean keepLongStdio;
         private final boolean allowEmptyResults;
+        private final boolean allowOldResults;
 
         private ParseResultCallable(String testResults, long buildTime, long nowMaster,
-                                    boolean keepLongStdio, boolean allowEmptyResults) {
+                                    boolean keepLongStdio, boolean allowEmptyResults, boolean allowOldResults) {
             this.buildTime = buildTime;
             this.testResults = testResults;
             this.nowMaster = nowMaster;
             this.keepLongStdio = keepLongStdio;
             this.allowEmptyResults = allowEmptyResults;
+            this.allowOldResults = allowOldResults;
         }
 
         public TestResult invoke(File ws, VirtualChannel channel) throws IOException {

--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -95,6 +95,7 @@ public final class TestResult extends MetaTabulatedResult {
     private transient List<CaseResult> failedTests;
 
     private final boolean keepLongStdio;
+    private final boolean allowOldResults;
 
     /**
      * Creates an empty result.
@@ -108,6 +109,15 @@ public final class TestResult extends MetaTabulatedResult {
      */
     public TestResult(boolean keepLongStdio) {
         this.keepLongStdio = keepLongStdio;
+        this.allowOldResults = false;
+    }
+    
+    /**
+     * @since 1.6
+     */
+    public TestResult(boolean keepLongStdio, boolean allowOldResults) {
+        this.keepLongStdio = keepLongStdio;
+        this.allowOldResults = allowOldResults;
     }
 
     @Deprecated
@@ -123,6 +133,7 @@ public final class TestResult extends MetaTabulatedResult {
      */
     public TestResult(long buildTime, DirectoryScanner results, boolean keepLongStdio) throws IOException {
         this.keepLongStdio = keepLongStdio;
+        this.allowOldResults = false;
         parse(buildTime, results);
     }
 
@@ -170,8 +181,8 @@ public final class TestResult extends MetaTabulatedResult {
 
         for (String value : reportFiles) {
             File reportFile = new File(baseDir, value);
-            // only count files that were actually updated during this build
-            if (buildTime-3000/*error margin*/ <= reportFile.lastModified()) {
+            // only count files that were actually updated during this build, unless configured to include all
+            if (buildTime-3000/*error margin*/ <= reportFile.lastModified() || allowOldResults) {
                 parsePossiblyEmpty(reportFile);
                 parsed = true;
             }

--- a/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
+++ b/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
@@ -47,5 +47,8 @@ THE SOFTWARE.
         <f:entry title="${%Allow empty results}" field="allowEmptyResults">
             <f:checkbox default="false" title="${%Do not fail the build on empty test results}"/>
         </f:entry>
+        <f:entry title="${%Allow old results}" field="allowOldResults">
+            <f:checkbox default="false" title="${%Do not fail the build on old test results}"/>
+        </f:entry>
     </f:advanced>
 </j:jelly>


### PR DESCRIPTION
would close JENKINS-5393, JENKINS-9438, and JENKINS-6268
allow for ignoring that tests are old and not failing the build

I am unable to test since the master repo also fails to test. I get an error about class org.w3c.dom.ElementTraversal missing.