### PR TITLE
[JENKINS-37598] Inaccurate aggregation of multiple xmls containing case information about the same testsuite

### DIFF
--- a/src/main/java/hudson/tasks/junit/ClassResult.java
+++ b/src/main/java/hudson/tasks/junit/ClassResult.java
@@ -33,7 +33,9 @@ import org.kohsuke.stapler.export.Exported;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Cumulative test result of a test class.
@@ -176,7 +178,7 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
     @Override
     public void tally() {
         passCount=failCount=skipCount=0;
-        duration=0;
+        Set<SuiteResult>  suites=new HashSet<SuiteResult>();
         for (CaseResult r : cases) {
             r.setClass(this);
             if (r.isSkipped()) {
@@ -188,10 +190,13 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
             else {
                 failCount++;
             }
-            //retrieve the class duration from these cases' suite time
-            if(duration == 0){
-                duration = r.getSuiteResult().getDuration();
-            }
+            suites.add( r.getSuiteResult() );
+        }
+
+        // retrieve the class duration from these cases' suite time
+        duration = 0;
+        for (SuiteResult s : suites) {
+            duration += s.getDuration();
         }
     }
 

--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -256,12 +256,9 @@ public final class TestResult extends MetaTabulatedResult {
                 if(strictEq(s.getTimestamp(),sr.getTimestamp())) {
                     return;
                 }
-            
-                for (CaseResult cr: sr.getCases()) {
-                    s.addCase(cr);
-                    cr.replaceParent(s);
-                }
+
                 duration += sr.getDuration();
+                s.merge(sr);
                 return;
             }
         }

--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -171,6 +171,40 @@ public class TestResultTest {
         assertEquals("Fail count should now be 1", 1, first.getFailCount());
     }
 
+    @Issue("JENKINS-37598")
+    @Test
+    public void testMergeWithTime() throws Exception {
+        TestResult testResult = new TestResult();
+        testResult.parse(getDataFile("junit-report-time-aggregation.xml"));
+        testResult.tally();
+
+        assertEquals(1, testResult.getSuites().size());
+        SuiteResult suite = testResult.getSuite("test.fs.FileSystemTests");
+        assertEquals(3, suite.getCases().size());
+        assertEquals(100, suite.getDuration(), 2);
+    }
+
+    @Issue("JENKINS-37598")
+    @Test
+    public void testMergeWithoutTime() throws Exception {
+        TestResult testResult = new TestResult();
+        testResult.parse(getDataFile("junit-report-time-aggregation2.xml"));
+        testResult.tally();
+
+        assertEquals(1, testResult.getSuites().size());
+        SuiteResult suite = testResult.getSuite("test.fs.FileSystemTests");
+        assertEquals(3, suite.getCases().size());
+        assertEquals(30, suite.getDuration(), 2);
+    }
+
+    @Issue("JENKINS-37598")
+    @Test(expected=Exception.class)
+    public void testMergeWithInconsistency() throws Exception {
+        TestResult testResult = new TestResult();
+        testResult.parse(getDataFile("junit-report-time-aggregation-invalid.xml"));
+        testResult.tally();
+    }
+
     private static final XStream XSTREAM = new XStream2();
 
     static {

--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -197,14 +197,6 @@ public class TestResultTest {
         assertEquals(30, suite.getDuration(), 2);
     }
 
-    @Issue("JENKINS-37598")
-    @Test(expected=Exception.class)
-    public void testMergeWithInconsistency() throws Exception {
-        TestResult testResult = new TestResult();
-        testResult.parse(getDataFile("junit-report-time-aggregation-invalid.xml"));
-        testResult.tally();
-    }
-
     private static final XStream XSTREAM = new XStream2();
 
     static {

--- a/src/test/resources/hudson/tasks/junit/junit-report-time-aggregation-invalid.xml
+++ b/src/test/resources/hudson/tasks/junit/junit-report-time-aggregation-invalid.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Automation Tests" tests="2" errors="0" failures="0" ignored="0">
-    <testsuite name="test.fs.FileSystemTests" time="99">
-      <testcase name="testPrefix1" classname="test.fs.FileSystemTest1" time="10"/>
-    </testsuite>
-    <testsuite name="test.fs.FileSystemTests">
-      <testcase name="testPrefix2" classname="test.fs.FileSystemTest1" time="10"/>
-    </testsuite>
-</testsuites>

--- a/src/test/resources/hudson/tasks/junit/junit-report-time-aggregation-invalid.xml
+++ b/src/test/resources/hudson/tasks/junit/junit-report-time-aggregation-invalid.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Automation Tests" tests="2" errors="0" failures="0" ignored="0">
+    <testsuite name="test.fs.FileSystemTests" time="99">
+      <testcase name="testPrefix1" classname="test.fs.FileSystemTest1" time="10"/>
+    </testsuite>
+    <testsuite name="test.fs.FileSystemTests">
+      <testcase name="testPrefix2" classname="test.fs.FileSystemTest1" time="10"/>
+    </testsuite>
+</testsuites>

--- a/src/test/resources/hudson/tasks/junit/junit-report-time-aggregation.xml
+++ b/src/test/resources/hudson/tasks/junit/junit-report-time-aggregation.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Automation Tests" tests="2" errors="0" failures="0" ignored="0">
+    <testsuite name="test.fs.FileSystemTests" time="50">
+      <testcase name="testPrefix1" classname="test.fs.FileSystemTest1" time="10"/>
+      <testcase name="testPrefix1A" classname="test.fs.FileSystemTest1" time="10"/>
+    </testsuite>
+    <testsuite name="test.fs.FileSystemTests" time="50">
+      <testcase name="testPrefix2" classname="test.fs.FileSystemTest1" time="10"/>
+    </testsuite>
+</testsuites>

--- a/src/test/resources/hudson/tasks/junit/junit-report-time-aggregation2.xml
+++ b/src/test/resources/hudson/tasks/junit/junit-report-time-aggregation2.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Automation Tests" tests="2" errors="0" failures="0" ignored="0">
+    <testsuite name="test.fs.FileSystemTests">
+      <testcase name="testPrefix1" classname="test.fs.FileSystemTest1" time="10"/>
+      <testcase name="testPrefix1A" classname="test.fs.FileSystemTest1" time="10"/>
+    </testsuite>
+    <testsuite name="test.fs.FileSystemTests">
+      <testcase name="testPrefix2" classname="test.fs.FileSystemTest1" time="10"/>
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
[JENKINS-37598](https://issues.jenkins-ci.org/browse/JENKINS-37598)
- [x] change logic to account for all suites involved during time aggregation in `ClassResult`
- [X] moved `TestSuite` merging code from `TestResult` to `TestSuite.merge()`
- [X] replaced `TestSuite.time` field with a boolean
- [X] added 2 testcases - 1 with time attributes; and 1 without them...added to `TestResultTest` (because of `TestSuite.merge()` call location)
