### PR TITLE
[JENKINS-32148] use alternate background for table rows, highlight row on hover

### DIFF
--- a/src/main/resources/hudson/tasks/junit/CaseResult/list.jelly
+++ b/src/main/resources/hudson/tasks/junit/CaseResult/list.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <table class="pane sortable bigtable" id="testresult">
+  <table class="pane sortable bigtable stripped" id="testresult">
     <tr>
       <td class="pane-header" style="width:10em">${%Build}</td>
       <td class="pane-header" style="width:10em">${%Test Description}</td>

--- a/src/main/resources/hudson/tasks/junit/ClassResult/body.jelly
+++ b/src/main/resources/hudson/tasks/junit/ClassResult/body.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:if test="${it.totalCount!=0}">
     <h2>${%All Tests}</h2>
-    <table class="pane sortable bigtable" id="testresult">
+    <table class="pane sortable bigtable stripped" id="testresult">
       <tr>
         <td class="pane-header">${%Test name}</td>
         <td class="pane-header" style="width:6em">${%Duration}</td>

--- a/src/main/resources/hudson/tasks/junit/ClassResult/list.jelly
+++ b/src/main/resources/hudson/tasks/junit/ClassResult/list.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <table class="pane sortable bigtable" id="testresult">
+    <table class="pane sortable bigtable stripped" id="testresult">
       <tr>
         <td class="pane-header">${%Build}</td>
         <td class="pane-header">${%Description}</td>

--- a/src/main/resources/hudson/tasks/test/AggregatedTestResultPublisher/TestResultAction/index.jelly
+++ b/src/main/resources/hudson/tasks/test/AggregatedTestResultPublisher/TestResultAction/index.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
         <j:otherwise>
           <test:bar/>
           <h2>${%Drill Down}</h2>
-          <table class="pane sortable">
+          <table class="pane sortable stripped">
             <tr>
               <td class="pane-header">${%Test}</td>
               <td class="pane-header" style="text-align:right">${%Fail}</td>

--- a/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
+++ b/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson/test" xmlns:f="/lib/form">
   <j:if test="${it.failCount!=0}">
     <h2>${%All Failed Tests}</h2>
-    <table class="pane sortable bigtable">
+    <table class="pane sortable bigtable stripped">
       <tr>
         <td class="pane-header">${%Test Name}</td>
         <td class="pane-header" style="width:4em">${%Duration}</td>
@@ -49,7 +49,7 @@ THE SOFTWARE.
 
   <j:if test="${it.totalCount!=0}">
     <h2>${%All Tests}</h2>
-    <table class="pane sortable bigtable" id="testresult">
+    <table class="pane sortable bigtable stripped" id="testresult">
       <tr>
         <td class="pane-header">${it.childTitle}</td>
         <td class="pane-header" style="width:5em">${%Duration}</td>

--- a/src/main/resources/hudson/tasks/test/MetaTabulatedResult/list.jelly
+++ b/src/main/resources/hudson/tasks/test/MetaTabulatedResult/list.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <table class="pane sortable bigtable" id="testresult">
+    <table class="pane sortable bigtable stripped" id="testresult">
       <tr>
         <td class="pane-header">${%Build}</td>
         <td class="pane-header">${%Description}</td>

--- a/src/main/resources/lib/hudson/test/aggregated-failed-tests.jelly
+++ b/src/main/resources/lib/hudson/test/aggregated-failed-tests.jelly
@@ -44,7 +44,7 @@ THE SOFTWARE.
           <a href="../${report.child.project.shortUrl}testReport" class="model-link inside">${report.child.project.name}</a>
         </h3>
 
-        <table class="pane sortable bigtable">
+        <table class="pane sortable bigtable stripped">
           <tr>
             <td class="pane-header">Test Name</td>
             <td class="pane-header" style="width:4em">Duration</td>

--- a/src/test/resources/hudson/tasks/test/TrivialTestResult/body.jelly
+++ b/src/test/resources/hudson/tasks/test/TrivialTestResult/body.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
 
   <j:if test="${it.failCount!=0}">
     <h2>${%All Failed Tests}</h2>
-    <table class="pane sortable">
+    <table class="pane sortable stripped">
       <tr>
         <td class="pane-header">${%Test Name}</td>
         <td class="pane-header" style="width:4em">${%Duration}</td>
@@ -65,7 +65,7 @@ THE SOFTWARE.
 
   <j:if test="${it.totalCount!=0}">
     <h2>${%All Tests}</h2>
-    <table class="pane sortable bigtable" id="testresult">
+    <table class="pane sortable bigtable stripped" id="testresult">
       <tr>
         <td class="pane-header">${it.childTitle}</td>
         <td class="pane-header" style="width:5em">${%Duration}</td>


### PR DESCRIPTION
This patch uses the `stripped` class for tables to give alternate rows a slightly different background color. Additionally it highlights the current row on hover.

Both effects are also used in other parts of the Jenkins UI, e.g. the build history panel on the left side.

This addresses https://issues.jenkins-ci.org/browse/JENKINS-32148