### PR TITLE
Added '<' and '>' as unsafe URI characters.

### DIFF
--- a/src/main/java/hudson/tasks/test/TestObject.java
+++ b/src/main/java/hudson/tasks/test/TestObject.java
@@ -399,7 +399,7 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
             return "(empty)";
         } else {
             // this still seems to be a bit faster than a single replace with regexp
-            return s.replace('/', '_').replace('\\', '_').replace(':', '_').replace('?', '_').replace('#', '_').replace('%', '_');
+            return s.replace('/', '_').replace('\\', '_').replace(':', '_').replace('?', '_').replace('#', '_').replace('%', '_').replace('<', '_').replace('>', '_');
             // Note: we probably should some helpers like Commons URIEscapeUtils here to escape all invalid URL chars, but then we
             // still would have to escape /, ? and so on
         }

--- a/src/test/java/hudson/tasks/test/TestObjectTest.java
+++ b/src/test/java/hudson/tasks/test/TestObjectTest.java
@@ -11,7 +11,7 @@ public class TestObjectTest {
 
     @Test
     public void testSafe() {
-        String name = "Foo#approve! is called by approve_on_foo?xyz/\\: 50%";
+        String name = "Foo#approve! is <called> by approve_on_foo?xyz/\\: 50%";
         String encoded = TestObject.safe(name);
         
         Assert.assertFalse(encoded.contains("#"));
@@ -20,6 +20,8 @@ public class TestObjectTest {
         Assert.assertFalse(encoded.contains("/"));
         Assert.assertFalse(encoded.contains(":"));
         Assert.assertFalse(encoded.contains("%"));
+        Assert.assertFalse(encoded.contains("<"));
+        Assert.assertFalse(encoded.contains(">"));
     }
 
     @Test public void uniquifyName() {


### PR DESCRIPTION
I opened this pull request due to the `safe()` function not replacing the `<` and `>` characters. This was triggered due to the `cucumber-testresult-plugin` using the `getSafeName()` for Scenarios and Features as file names when publishing reports (https://github.com/jenkinsci/cucumber-testresult-plugin/blob/master/src/main/java/org/jenkinsci/plugins/cucumber/jsontestsupport/CucumberTestResultArchiver.java).

Cucumber Scenarios can have the `<` and `>` characters in the scenario names (https://github.com/cucumber/cucumber/wiki/Scenario-Outlines) and as such these unsafe characters were preventing the results from being published to Jenkins.