### PR TITLE
Fix typo: resultadod -> resultados

### DIFF
--- a/src/main/resources/hudson/tasks/junit/Messages_es.properties
+++ b/src/main/resources/hudson/tasks/junit/Messages_es.properties
@@ -28,7 +28,7 @@ PackageResult.getTitle=Resultado de tests : {0}
 PackageResult.getChildTitle=Clases
 
 ClassResult.getTitle=Resultado de tests : {0}
-JUnitResultArchiver.DisplayName=Publicar los resultadod de tests JUnit
+JUnitResultArchiver.DisplayName=Publicar los resultados de tests JUnit
 JUnitResultArchiver.NoTestReportFound=No se encontraron ficheros con resultados de tests. ¿Hay algun error en la configuración?
 JUnitResultArchiver.Recording=Grabando resultados de tests
 JUnitResultArchiver.ResultIsEmpty=Ninguno de los informes de tests contiene resultados


### PR DESCRIPTION
Also GH warned: "We've detected the file encoding as ISO-8859-1. When you commit changes we will transcode it to UTF-8."