### PR TITLE
JENKINS-29649-related: AbstractTestResultAction may inadvertently pick action from different plugin

### DIFF
--- a/src/main/java/hudson/tasks/junit/JUnitTestResultProjectAction.java
+++ b/src/main/java/hudson/tasks/junit/JUnitTestResultProjectAction.java
@@ -1,0 +1,24 @@
+package hudson.tasks.junit;
+
+import hudson.model.AbstractProject;
+import hudson.model.Job;
+import hudson.tasks.test.TestResultProjectAction;
+
+
+public class JUnitTestResultProjectAction extends TestResultProjectAction<TestResultAction> {
+
+    public JUnitTestResultProjectAction(Job<?, ?> job) {
+        super(job);
+    }
+
+    @Deprecated
+    public JUnitTestResultProjectAction(AbstractProject<?, ?> project) {
+        super(project);
+    }
+
+
+    @Override
+    public Class<TestResultAction> getTestResultActionClass() {
+        return TestResultAction.class;
+    }
+}

--- a/src/main/java/hudson/tasks/junit/TestResultAction.java
+++ b/src/main/java/hudson/tasks/junit/TestResultAction.java
@@ -38,6 +38,7 @@ import hudson.tasks.test.TestObject;
 import hudson.tasks.test.TestResultProjectAction;
 import hudson.util.HeapSpaceStringConverter;
 import hudson.util.XStream2;
+import jenkins.tasks.SimpleBuildStep;
 import org.kohsuke.stapler.StaplerProxy;
 
 import java.io.File;
@@ -49,7 +50,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import jenkins.tasks.SimpleBuildStep;
 
 /**
  * {@link Action} that displays the JUnit test result.
@@ -97,7 +97,7 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
             // JENKINS-26077: someone like XUnitPublisher already added one
             return Collections.emptySet();
         }
-        return Collections.singleton(new TestResultProjectAction(job));
+        return Collections.singleton(new JUnitTestResultProjectAction(job));
     }
 
     /**

--- a/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
+++ b/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
@@ -336,7 +336,7 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
 
         int cap = Integer.getInteger(AbstractTestResultAction.class.getName() + ".test.trend.max", Integer.MAX_VALUE);
         int count = 0;
-        for (AbstractTestResultAction<?> a = this; a != null; a = a.getPreviousResult(AbstractTestResultAction.class, false)) {
+        for (AbstractTestResultAction<?> a = this; a != null; a = a.getPreviousResult(getClass(), false)) {
             if (++count > cap) {
                 LOGGER.log(Level.FINE, "capping test trend for {0} at {1}", new Object[] {run, cap});
                 break;
@@ -396,6 +396,8 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
         final NumberAxis rangeAxis = (NumberAxis) plot.getRangeAxis();
         rangeAxis.setStandardTickUnits(NumberAxis.createIntegerTickUnits());
 
+        final Class<? extends AbstractTestResultAction> actionClass = getClass();
+
         StackedAreaRenderer ar = new StackedAreaRenderer2() {
             @Override
             public String generateURL(CategoryDataset dataset, int row, int column) {
@@ -406,7 +408,7 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
             @Override
             public String generateToolTip(CategoryDataset dataset, int row, int column) {
                 NumberOnlyBuildLabel label = (NumberOnlyBuildLabel) dataset.getColumnKey(column);
-                AbstractTestResultAction a = label.getRun().getAction(AbstractTestResultAction.class);
+                AbstractTestResultAction a = label.getRun().getAction(actionClass);
                 switch (row) {
                     case 0:
                         return String.valueOf(Messages.AbstractTestResultAction_fail(label.getRun().getDisplayName(), a.getFailCount()));

--- a/src/main/java/hudson/tasks/test/TestResultProjectAction.java
+++ b/src/main/java/hudson/tasks/test/TestResultProjectAction.java
@@ -47,7 +47,7 @@ import java.util.List;
  *
  * @author Kohsuke Kawaguchi
  */
-public class TestResultProjectAction implements Action {
+public class TestResultProjectAction<T extends AbstractTestResultAction> implements Action {
     /**
      * Project that owns this action.
      * @since 1.2-beta-1
@@ -85,12 +85,12 @@ public class TestResultProjectAction implements Action {
         return "test";
     }
 
-    public AbstractTestResultAction getLastTestResultAction() {
+    public T getLastTestResultAction() {
         final Run<?,?> tb = job.getLastSuccessfulBuild();
 
         Run<?,?> b = job.getLastBuild();
         while(b!=null) {
-            AbstractTestResultAction a = b.getAction(AbstractTestResultAction.class);
+            T a = b.getAction(getTestResultActionClass());
             if(a!=null && (!b.isBuilding())) return a;
             if(b==tb)
                 // if even the last successful build didn't produce the test result,
@@ -100,6 +100,12 @@ public class TestResultProjectAction implements Action {
         }
 
         return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    public Class<T> getTestResultActionClass() {
+        // To keep backward compatibility.
+        return (Class<T>) AbstractTestResultAction.class;
     }
 
     /**

--- a/src/main/java/hudson/tasks/test/TestResultProjectAction.java
+++ b/src/main/java/hudson/tasks/test/TestResultProjectAction.java
@@ -102,6 +102,26 @@ public class TestResultProjectAction<T extends AbstractTestResultAction> impleme
         return null;
     }
 
+    /**
+     * <p>
+     * Plugins implementing junit-plugin API should override this method to indicate test result action type to look
+     * for when drawing their own plots.
+     * </p>
+     * <p>
+     * A sample use case: a project uses 2 plugins derived from junit-plugin, say A and B, both produce test result
+     * actions during a build. When A and B are about to draw their respective test trend plots, they fetch last test
+     * result action via {@link #getLastTestResultAction()}. The latter method should therefore be capable to understand
+     * which test result action is relevant, hence this method is introduced.
+     * </p>
+     * <p>
+     * Related <a href="https://github.com/jenkinsci/tap-plugin/pull/14#issuecomment-249346957">bug discussion</a>
+     * </p>
+     * <p>
+     * For backward compatibility reason, this default implementation returns {@link AbstractTestResultAction} class.
+     * </p>
+     *
+     * @return test result action class which this plugin produces.
+     */
     @SuppressWarnings("unchecked")
     public Class<T> getTestResultActionClass() {
         // To keep backward compatibility.

--- a/src/main/resources/hudson/tasks/test/TestResultProjectAction/jobMain.jelly
+++ b/src/main/resources/hudson/tasks/test/TestResultProjectAction/jobMain.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson" xmlns:test="/lib/hudson/test">
     <table style="margin-top: 1em; margin-left: 1em;">
-        <j:set var="tr" value="${it.job.lastCompletedBuild.getAction(it.class.classLoader.loadClass('hudson.tasks.test.AbstractTestResultAction'))}"/>
+        <j:set var="tr" value="${it.job.lastCompletedBuild.getAction(it.testResultActionClass)}"/>
         <j:if test="${tr != null}">
             <t:summary icon="clipboard.png">
                 <a href="lastCompletedBuild/${tr.urlName}/">${%Latest Test Result}</a>


### PR DESCRIPTION
When a job uses 2 or more publishers which depend on "junit-plugin" API (e.g. JUnit plugin + TAP plugin), [this check](https://github.com/jenkinsci/junit-plugin/blob/master/src/main/java/hudson/tasks/test/TestResultProjectAction.java#L93) may cause situation when test result actions from one plugin are used to plot graph for another plugin.
 
This was causing [JENKINS-29649](https://issues.jenkins-ci.org/browse/JENKINS-29649), but for that specific one we managed to find work-around on TAP plugin side.

As outlined by @oleg-nenashev in the following discussion thread, one may want to fix this on JUnit plugin side:
* https://github.com/jenkinsci/tap-plugin/pull/14#issuecomment-249346957
* https://github.com/jenkinsci/tap-plugin/pull/14#issuecomment-249355315

Would appreciate you could have a look on that.
Thanks.