### PR TITLE
[FIXED JENKINS-29736] removed divide by 1000

### DIFF
--- a/src/main/java/hudson/tasks/junit/History.java
+++ b/src/main/java/hudson/tasks/junit/History.java
@@ -113,7 +113,7 @@ public class History {
                }
                
 			for (hudson.tasks.test.TestResult o: list) {
-                   data.add(((double) o.getDuration()) / (1000), "", new ChartLabel(o)  {
+                   data.add(((double) o.getDuration()), "", new ChartLabel(o)  {
                        @Override
                        public Color getColor() {
                            if (o.getFailCount() > 0)


### PR DESCRIPTION
This is meant to fix a bug at duration axis on history charts.