### PR TITLE
Allow to print Failure and Error messages together

### DIFF
--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -238,7 +238,8 @@ public final class TestResult extends MetaTabulatedResult {
         if(reportFile.length()==0) {
             // this is a typical problem when JVM quits abnormally, like OutOfMemoryError during a test.
             SuiteResult sr = new SuiteResult(reportFile.getName(), "", "");
-            sr.addCase(new CaseResult(sr,"[empty]","Test report file "+reportFile.getAbsolutePath()+" was length 0"));
+            sr.addCase(new CaseResult(sr,"[empty]",
+                                      "Test report file "+reportFile.getAbsolutePath()+" was length 0", null));
             add(sr);
         } else {
             parse(reportFile);
@@ -313,7 +314,7 @@ public final class TestResult extends MetaTabulatedResult {
                 StringWriter writer = new StringWriter();
                 e.printStackTrace(new PrintWriter(writer));
                 String error = "Failed to read test report file "+reportFile.getAbsolutePath()+"\n"+writer.toString();
-                sr.addCase(new CaseResult(sr,"[failed-to-read]",error));
+                sr.addCase(new CaseResult(sr,"[failed-to-read]", error, null));
                 add(sr);
             }
         }

--- a/src/main/java/hudson/tasks/test/TestResult.java
+++ b/src/main/java/hudson/tasks/test/TestResult.java
@@ -227,21 +227,39 @@ public abstract class TestResult extends TestObject {
     }
 
     /**
-     * If there was an error or a failure, this is the stack trace, or otherwise null.
+     * If there was an error, this is the stack trace, or otherwise null.
      *
-     * @return the stack trace of the error or failure.
+     * @return the stack trace of the error.
      */
     public String getErrorStackTrace() {
         return "";
     }
 
     /**
-     * If there was an error or a failure, this is the text from the message.
+     * If there was an error, this is the text from the message.
      *
-     * @return the message of the error or failure.
+     * @return the message of the error.
      */
     public String getErrorDetails() {
         return ""; 
+    }
+
+    /**
+     * If there was a failure, this is the stack trace, or otherwise null.
+     *
+     * @return the stack trace of the failure.
+     */
+    public String getFailureStackTrace() {
+        return "";
+    }
+
+    /**
+     * If there was a failure, this is the text from the message.
+     *
+     * @return the message of the failure.
+     */
+    public String getFailureDetails() {
+        return "";
     }
 
     /**

--- a/src/main/resources/hudson/tasks/junit/CaseResult/index.jelly
+++ b/src/main/resources/hudson/tasks/junit/CaseResult/index.jelly
@@ -83,6 +83,17 @@ THE SOFTWARE.
         <pre><j:out value="${it.annotate(it.errorStackTrace)}"/></pre>
       </j:if>
 
+      <j:if test="${!empty(it.failureDetails)}">
+        <br></br>
+        <h3>${%Failure Message}</h3>
+        <pre><j:out value="${it.annotate(it.failureDetails)}"/></pre>
+      </j:if>
+
+      <j:if test="${!empty(it.failureStackTrace)}">
+        <h3>${%Stacktrace}</h3>
+        <pre><j:out value="${it.annotate(it.failureStackTrace)}"/></pre>
+      </j:if>
+
       <j:if test="${!empty(it.stdout)}">
         <h3>${%Standard Output}</h3>
         <pre><j:out value="${it.annotate(it.stdout)}"/></pre>

--- a/src/test/java/hudson/tasks/junit/ClassResultTest.java
+++ b/src/test/java/hudson/tasks/junit/ClassResultTest.java
@@ -12,7 +12,7 @@ public class ClassResultTest {
 	public void testFindCorrespondingResult() {
 		ClassResult classResult = new ClassResult(null, "com.example.ExampleTest");
 	
-		CaseResult caseResult = new CaseResult(null, "testCase", null);
+		CaseResult caseResult = new CaseResult(null, "testCase", null, null);
 	
 		classResult.add(caseResult);
 	
@@ -24,7 +24,7 @@ public class ClassResultTest {
 	public void testFindCorrespondingResultWhereClassResultNameIsNotSubstring() {
 		ClassResult classResult = new ClassResult(null, "aaaa");
 	
-		CaseResult caseResult = new CaseResult(null, "tc_bbbb", null);
+		CaseResult caseResult = new CaseResult(null, "tc_bbbb", null, null);
 	
 		classResult.add(caseResult);
 	
@@ -36,7 +36,7 @@ public class ClassResultTest {
 	public void testFindCorrespondingResultWhereClassResultNameIsLastInCaseResultName() {
 		ClassResult classResult = new ClassResult(null, "aaaa");
 	
-		CaseResult caseResult = new CaseResult(null, "tc_aaaa", null);
+		CaseResult caseResult = new CaseResult(null, "tc_aaaa", null, null);
 	
 		classResult.add(caseResult);
 	

--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -150,6 +150,22 @@ public class TestResultTest {
         assertEquals("Wrong duration for test result", 1.0, testResult.getDuration(), 0.01);
     }
 
+    /**
+     * Check result when test failed with both error and failure messages,
+     * for example, with Error in teardown phase but with failure on the call
+     */
+    @Test
+    public void testErrorAndFailMessages() throws Exception {
+        TestResult testResult = new TestResult();
+        testResult.parse(getDataFile("junit-report-error-failure-details.xml"));
+        testResult.tally();
+
+        assertEquals("Just one test failed", 1, testResult.getFailCount());
+        CaseResult cr = testResult.getFailedTests().get(0);
+        assertEquals("Wrong error stacktrace", "error message for test WhooHoo", cr.getErrorDetails());
+        assertEquals("Wrong failure stacktrace", "failure message for test WhooHoo", cr.getFailureDetails());
+    }
+
     private static final XStream XSTREAM = new XStream2();
 
     static {

--- a/src/test/resources/hudson/tasks/junit/junit-report-error-failure-details.xml
+++ b/src/test/resources/hudson/tasks/junit/junit-report-error-failure-details.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<testsuite errors="1" failures="1" hostname="whocares" name="pytest" tests="1" time="0.016" timestamp="2008-07-03T15:42:30">
+  <testcase classname="some.package.somewhere.WhooHoo" name="test_fail_error" time="0.016">
+    <error message="error message for test WhooHoo"> E       assert 1 == 2</error>
+    <failure message="failure message for test WhooHoo"> E       Exception: test teardown Exception!</failure>
+  </testcase>
+</testsuite>


### PR DESCRIPTION
It happens when running tests with pytest that we can have a
test failing with both failure and error.

ex:
import pytest
import logging

@pytest.fixture()
def setup_class(request):
    def finalize():
        raise Exception("test teadown Exception")
    request.addfinalizer(finalize)

def test_1(setup_class):
    assert 1==2

In this case the XML report will contain two nodes, a failure
and an error and both messages are usefull in the jenkins TestReport.
Currently, the plugin chooses to display the error report over
the failure. This patch allows failure message to appear as well.