### PR TITLE
[JENKINS-41710] Optionally annotate test results with a test run name

### DIFF
--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -95,7 +95,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         return new TimeToFloat(time).parse();
     }
 
-    CaseResult(SuiteResult parent, Element testCase, String testClassName, boolean keepLongStdio) {
+    CaseResult(SuiteResult parent, Element testCase, String testClassName, boolean keepLongStdio, String testRunName) {
         // schema for JUnit report XML format is not available in Ant,
         // so I don't know for sure what means what.
         // reports in http://www.nabble.com/difference-in-junit-publisher-and-ant-junitreport-tf4308604.html#a12265700
@@ -119,7 +119,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         }
 
         className = testClassName;
-        testName = nameAttr;
+        testName = testRunName == null ? nameAttr : nameAttr + " (" + testRunName + ")";
         errorStackTrace = getError(testCase);
         errorDetails = getErrorMessage(testCase);
         this.parent = parent;
@@ -200,9 +200,22 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
      * @param testName Test name.
      * @param errorStackTrace Error stack trace.
      */
+    @Deprecated
     public CaseResult(SuiteResult parent, String testName, String errorStackTrace) {
+        this(parent, testName, errorStackTrace, null);
+    }
+    
+    /**
+     * Used to create a fake failure, when Hudson fails to load data from XML files.
+     *
+     * @param parent Parent result.
+     * @param testName Test name.
+     * @param errorStackTrace Error stack trace.
+     * @since FIXME
+     */
+    public CaseResult(SuiteResult parent, String testName, String errorStackTrace, String testRunName) {
         this.className = parent == null ? "unnamed" : parent.getName();
-        this.testName = testName;
+        this.testName = testRunName == null ? testName : testName + " (" + testRunName + ")";
         this.errorStackTrace = errorStackTrace;
         this.errorDetails = "";
         this.parent = parent;
@@ -212,7 +225,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         this.skipped = false;
         this.skippedMessage = null;
     }
-    
+
     public ClassResult getParent() {
     	return classResult;
     }

--- a/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
+++ b/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
@@ -46,4 +46,9 @@ THE SOFTWARE.
     <f:entry title="${%Allow empty results}" field="allowEmptyResults">
         <f:checkbox default="false" title="${%Do not fail the build on empty test results}"/>
     </f:entry>
+    <j:if test="${descriptor.hasMultipleTestRunCapability(it)}">
+        <f:entry field="testRunName" title="${%Optional test run name}">
+            <f:textbox/>
+        </f:entry>
+    </j:if>
 </j:jelly>

--- a/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/help-testRunName.html
+++ b/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/help-testRunName.html
@@ -1,0 +1,3 @@
+<div>
+    Optional text to append to each test result to allow for distinguishing multiple test runs.
+</div>

--- a/src/test/java/hudson/tasks/junit/ClassResultTest.java
+++ b/src/test/java/hudson/tasks/junit/ClassResultTest.java
@@ -12,7 +12,7 @@ public class ClassResultTest {
 	public void testFindCorrespondingResult() {
 		ClassResult classResult = new ClassResult(null, "com.example.ExampleTest");
 	
-		CaseResult caseResult = new CaseResult(null, "testCase", null);
+		CaseResult caseResult = new CaseResult(null, "testCase", null, null);
 	
 		classResult.add(caseResult);
 	
@@ -24,7 +24,7 @@ public class ClassResultTest {
 	public void testFindCorrespondingResultWhereClassResultNameIsNotSubstring() {
 		ClassResult classResult = new ClassResult(null, "aaaa");
 	
-		CaseResult caseResult = new CaseResult(null, "tc_bbbb", null);
+		CaseResult caseResult = new CaseResult(null, "tc_bbbb", null, null);
 	
 		classResult.add(caseResult);
 	
@@ -36,7 +36,7 @@ public class ClassResultTest {
 	public void testFindCorrespondingResultWhereClassResultNameIsLastInCaseResultName() {
 		ClassResult classResult = new ClassResult(null, "aaaa");
 	
-		CaseResult caseResult = new CaseResult(null, "tc_aaaa", null);
+		CaseResult caseResult = new CaseResult(null, "tc_aaaa", null, null);
 	
 		classResult.add(caseResult);
 	

--- a/src/test/java/hudson/tasks/junit/JUnitResultArchiverTest.java
+++ b/src/test/java/hudson/tasks/junit/JUnitResultArchiverTest.java
@@ -109,6 +109,25 @@ public class JUnitResultArchiverTest {
 
     }
 
+    @LocalData
+    @Test
+    public void basicAnnotated() throws Exception {
+        archiver.setTestRunName("annotated");
+        FreeStyleBuild build = project.scheduleBuild2(0).get(10, TimeUnit.SECONDS);
+
+        assertTestResults(build);
+
+        WebClient wc = j.new WebClient();
+        wc.getPage(project); // project page
+        wc.getPage(build); // build page
+        wc.getPage(build, "testReport");  // test report
+        wc.getPage(build, "testReport/hudson.security"); // package
+        wc.getPage(build, "testReport/hudson.security/HudsonPrivateSecurityRealmTest/"); // class
+        wc.getPage(build, "testReport/hudson.security/HudsonPrivateSecurityRealmTest/testDataCompatibilityWith1_282__annotated_/"); // method
+
+
+    }
+
     @RandomlyFails("TimeoutException from basic")
    @LocalData
    @Test public void slave() throws Exception {

--- a/src/test/java/hudson/tasks/junit/SuiteResult2Test.java
+++ b/src/test/java/hudson/tasks/junit/SuiteResult2Test.java
@@ -97,7 +97,7 @@ public class SuiteResult2Test {
     }
 
     private SuiteResult parseOne(File file) throws Exception {
-        List<SuiteResult> results = SuiteResult.parse(file, false);
+        List<SuiteResult> results = SuiteResult.parse(file, false, null);
         assertEquals(1,results.size());
         return results.get(0);
     }

--- a/src/test/java/hudson/tasks/junit/SuiteResultTest.java
+++ b/src/test/java/hudson/tasks/junit/SuiteResultTest.java
@@ -54,13 +54,13 @@ public class SuiteResultTest {
     }
 
     private SuiteResult parseOne(File file) throws Exception {
-        List<SuiteResult> results = SuiteResult.parse(file, false);
+        List<SuiteResult> results = SuiteResult.parse(file, false, null);
         assertEquals(1,results.size());
         return results.get(0);
     }
     
     private List<SuiteResult> parseSuites(File file) throws Exception {
-        return SuiteResult.parse(file, false);
+        return SuiteResult.parse(file, false, null);
     }
 
     @Issue("JENKINS-1233")
@@ -101,7 +101,7 @@ public class SuiteResultTest {
     @Issue("JENKINS-1472")
     @Test
     public void testIssue1472() throws Exception {
-        List<SuiteResult> results = SuiteResult.parse(getDataFile("junit-report-1472.xml"), false);
+        List<SuiteResult> results = SuiteResult.parse(getDataFile("junit-report-1472.xml"), false, null);
         assertTrue(results.size()>20); // lots of data here
 
         SuiteResult sr0 = results.get(0);


### PR DESCRIPTION
See [JENKINS-41710](https://issues.jenkins-ci.org/browse/JENKINS-41710)

Here is the pipeline syntax screen with this change:

<img width="866" alt="screen shot 2017-02-03 at 15 50 14" src="https://cloud.githubusercontent.com/assets/209336/22597686/8bf173c8-ea28-11e6-83ff-1749712160c9.png">

The test run name does not make sense for non-pipeline jobs, so they do not see it:

<img width="1098" alt="screen shot 2017-02-03 at 15 50 33" src="https://cloud.githubusercontent.com/assets/209336/22597704/9dc55fa6-ea28-11e6-8468-5ca4d4c12b73.png">

When you have a pipeline with a testRunName assigned you see results like so:

<img width="886" alt="screen shot 2017-02-03 at 15 45 05" src="https://cloud.githubusercontent.com/assets/209336/22597724/b3c576b0-ea28-11e6-8f80-26a21384abb4.png">

If you mix `junit` steps with and without the `testRunName` parameter, you can get something like this:

<img width="879" alt="screen shot 2017-02-03 at 15 53 23" src="https://cloud.githubusercontent.com/assets/209336/22597777/ed8223da-ea28-11e6-84f2-89d72424f096.png">

(names in bold because these are new results from the previous run)

@reviewbybees 
