### PR TITLE
JENKINS-42438 Correctly calculate test class duration.

### DIFF
--- a/src/main/java/hudson/tasks/junit/ClassResult.java
+++ b/src/main/java/hudson/tasks/junit/ClassResult.java
@@ -33,9 +33,7 @@ import org.kohsuke.stapler.export.Exported;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Cumulative test result of a test class.
@@ -178,7 +176,7 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
     @Override
     public void tally() {
         passCount=failCount=skipCount=0;
-        Set<SuiteResult>  suites=new HashSet<SuiteResult>();
+        duration = 0;
         for (CaseResult r : cases) {
             r.setClass(this);
             if (r.isSkipped()) {
@@ -190,13 +188,7 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
             else {
                 failCount++;
             }
-            suites.add( r.getSuiteResult() );
-        }
-
-        // retrieve the class duration from these cases' suite time
-        duration = 0;
-        for (SuiteResult s : suites) {
-            duration += s.getDuration();
+            duration += r.getDuration();
         }
     }
 

--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -197,6 +197,40 @@ public class TestResultTest {
         assertEquals(30, suite.getDuration(), 2);
     }
 
+    @Issue("JENKINS-42438")
+    @Test
+    public void testSuiteWithMultipleClasses() throws IOException, URISyntaxException {
+        TestResult testResult = new TestResult();
+        testResult.parse(getDataFile("JENKINS-42438/junit-report-1.xml"));
+        testResult.tally();
+
+        assertEquals("Wrong number of testsuites", 1, testResult.getSuites().size());
+        assertEquals("Wrong number of test cases", 11, testResult.getTotalCount());
+
+        // The suite duration is non-sensical for Android tests.
+        // This looks like a bug in the JUnit runner used by Android tests.
+        assertEquals("Wrong duration for test result", 2.0, testResult.getDuration(), 0.1);
+
+        SuiteResult suite = testResult.getSuite("org.catrobat.paintroid.test.integration.ActivityOpenedFromPocketCodeNewImageTest");
+        assertNotNull(suite);
+
+        assertEquals("Wrong number of test classes", 2, suite.getClassNames().size());
+
+        CaseResult case1 = suite.getCase("testDrawingSurfaceBitmapIsScreenSize");
+        assertNotNull(case1);
+        ClassResult class1 = case1.getParent();
+        assertNotNull(class1);
+        assertEquals("org.catrobat.paintroid.test.integration.BitmapIntegrationTest", class1.getFullName());
+        assertEquals("Wrong duration for test class", 5.0, class1.getDuration(),0.1);
+
+        CaseResult case2 = suite.getCase("testColorPickerDialogSwitchTabsInLandscape");
+        assertNotNull(case2);
+        ClassResult class2 = case2.getParent();
+        assertNotNull(class2);
+        assertEquals("org.catrobat.paintroid.test.integration.LandscapeTest", class2.getFullName());
+        assertEquals("Wrong duration for test class", 93.0, class2.getDuration(), 0.1);
+    }
+
     private static final XStream XSTREAM = new XStream2();
 
     static {

--- a/src/test/resources/hudson/tasks/junit/JENKINS-42438/junit-report-1.xml
+++ b/src/test/resources/hudson/tasks/junit/JENKINS-42438/junit-report-1.xml
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<testsuite name="org.catrobat.paintroid.test.integration.ActivityOpenedFromPocketCodeNewImageTest" tests="11" failures="0" errors="0" skipped="2" time="2.0" timestamp="2017-03-19T16:04:02" hostname="localhost">
+  <properties>
+    <property name="device" value="hudson_en-US_240_WVGA_android-18_x86(AVD) - 4.3.1" />
+    <property name="flavor" value="" />
+    <property name="project" value="Paintroid" />
+  </properties>
+  <testcase name="testDrawingSurfaceBitmapIsScreenSize" classname="org.catrobat.paintroid.test.integration.BitmapIntegrationTest" time="5.0" />
+  <testcase name="testCenterBitmapSimulateLoad" classname="org.catrobat.paintroid.test.integration.BitmapIntegrationTest" time="0.0">
+    <skipped />
+  </testcase>
+  <testcase name="testOpenColorPickerDialogChooseColorInLandscape" classname="org.catrobat.paintroid.test.integration.LandscapeTest" time="3.0" />
+  <testcase name="testToolBarOptionWidth" classname="org.catrobat.paintroid.test.integration.LandscapeTest" time="0.0">
+    <skipped />
+  </testcase>
+  <testcase name="testTools" classname="org.catrobat.paintroid.test.integration.LandscapeTest" time="0.0">
+    <skipped />
+  </testcase>
+  <testcase name="testColorPickerDialogSwitchTabsInLandscape" classname="org.catrobat.paintroid.test.integration.LandscapeTest" time="7.0" />
+  <testcase name="testOpenColorPickerDialogInLandscape" classname="org.catrobat.paintroid.test.integration.LandscapeTest" time="11.0" />
+  <testcase name="testLandscapeMode" classname="org.catrobat.paintroid.test.integration.LandscapeTest" time="13.0" />
+  <testcase name="testTopBarPosition" classname="org.catrobat.paintroid.test.integration.LandscapeTest" time="17.0" />
+  <testcase name="testBottomBarPosition" classname="org.catrobat.paintroid.test.integration.LandscapeTest" time="19.0" />
+  <testcase name="testToolBarOption" classname="org.catrobat.paintroid.test.integration.LandscapeTest" time="23.0" />
+</testsuite>


### PR DESCRIPTION
When running Android tests the <testsuite> in the generated xml file
can contain multiple classes.
Thus setting the test class duration to the value of the test-suite is wrong.