### PR TITLE
JENKINS-41281 Move BlueJUnitTestResult to JUnit plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <url>http://wiki.jenkins-ci.org/display/JENKINS/JUnit+Plugin</url>
     <properties>
         <jenkins.version>1.580.1</jenkins.version>
-        <java.level>6</java.level>
+        <java.level>7</java.level>
     </properties>
     <licenses>
         <license>
@@ -45,6 +45,11 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
             <version>1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.blueocean</groupId>
+            <artifactId>blueocean-rest</artifactId>
+            <version>1.1.0-beta-2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>io.jenkins.blueocean</groupId>
             <artifactId>blueocean-rest</artifactId>
-            <version>1.1.0-beta-2-SNAPSHOT</version>
+            <version>1.1.0-beta-2</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/hudson/tasks/junit/BlueJUnitTestResult.java
+++ b/src/main/java/hudson/tasks/junit/BlueJUnitTestResult.java
@@ -1,0 +1,138 @@
+package hudson.tasks.junit;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+import hudson.Extension;
+import hudson.model.Run;
+import io.jenkins.blueocean.commons.ServiceException.NotFoundException;
+import io.jenkins.blueocean.rest.Reachable;
+import io.jenkins.blueocean.rest.factory.BlueTestResultFactory;
+import io.jenkins.blueocean.rest.hal.Link;
+import io.jenkins.blueocean.rest.model.BlueTestResult;
+
+import javax.annotation.Nullable;
+
+import static org.apache.commons.lang.StringUtils.isEmpty;
+
+/**
+ * Implementation to provide CaseResults to for Blue Ocean's REST API
+ */
+public class BlueJUnitTestResult extends BlueTestResult {
+
+    protected final CaseResult testResult;
+
+    public BlueJUnitTestResult(CaseResult testResult, Link parent) {
+        super(parent);
+        this.testResult = testResult;
+    }
+
+    @Override
+    public String getName() {
+        return testResult.getName() + " – " + testResult.getClassName();
+    }
+
+    @Override
+    public Status getStatus() {
+        Status status;
+        switch (testResult.getStatus()) {
+            case SKIPPED:
+                status = Status.SKIPPED;
+                break;
+            case FAILED:
+            case REGRESSION:
+                status = Status.FAILED;
+                break;
+            case PASSED:
+            case FIXED:
+                status = Status.PASSED;
+                break;
+            default:
+                status = Status.UNKNOWN;
+                break;
+        }
+        return status;
+    }
+
+    @Override
+    public State getTestState() {
+        State state;
+        switch (testResult.getStatus()) {
+            case REGRESSION:
+                state = State.REGRESSION;
+                break;
+            case FIXED:
+                state = State.FIXED;
+                break;
+            default:
+                state = State.UNKNOWN;
+        }
+        return state;
+    }
+
+    @Override
+    public float getDuration() {
+        return testResult.getDuration();
+    }
+
+    @Override
+    public String getErrorStackTrace() {
+        return testResult.getErrorStackTrace();
+    }
+
+    @Override
+    public String getErrorDetails() {
+        return testResult.getErrorDetails();
+    }
+
+    @Override
+    protected String getUniqueId() {
+        return testResult.getId();
+    }
+
+    @Override
+    public int getAge() {
+        int age;
+        if (!testResult.isPassed() && testResult.getRun() != null) {
+            age = testResult.getRun().getNumber() - testResult.getFailedSince() + 1;
+        } else {
+            age = 0;
+        }
+        return age;
+    }
+
+    @Override
+    public String getStdErr() {
+        return serveLog(testResult.getStderr());
+    }
+
+    @Override
+    public String getStdOut() {
+        return serveLog(testResult.getStdout());
+    }
+
+    private String serveLog(String log) {
+        if (isEmpty(log)) {
+            throw new NotFoundException("No log");
+        }
+        return log;
+    }
+
+    @Extension
+    public static class FactoryImpl extends BlueTestResultFactory {
+        @Override
+        public Result getBlueTestResults(Run<?, ?> run, final Reachable parent) {
+            TestResultAction action = run.getAction(TestResultAction.class);
+            if (action != null) {
+                Iterable<CaseResult> allCaseResults = Iterables.concat(action.getFailedTests(), action.getSkippedTests(), action.getPassedTests());
+                return Result.of(Iterables.transform(allCaseResults, new Function<CaseResult, BlueTestResult>() {
+                    @Override
+                    public BlueTestResult apply(@Nullable CaseResult input) {
+                        return new BlueJUnitTestResult(input, parent.getLink());
+                    }
+                }));
+            } else {
+                return Result.notFound();
+            }
+        }
+    }
+}

--- a/src/test/java/hudson/tasks/junit/BlueJUnitTestResultArchiverTest.java
+++ b/src/test/java/hudson/tasks/junit/BlueJUnitTestResultArchiverTest.java
@@ -23,62 +23,62 @@
  */
 package hudson.tasks.junit;
 
+import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.FilePath;
+import hudson.Launcher;
 import hudson.matrix.AxisList;
 import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixProject;
 import hudson.matrix.TextAxis;
-import hudson.model.FreeStyleBuild;
-import hudson.model.FreeStyleProject;
-import hudson.slaves.DumbSlave;
-import hudson.tasks.test.TestObject;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.concurrent.TimeUnit;
-
-import org.jenkinsci.plugins.structs.describable.DescribableModel;
-import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.TouchBuilder;
-import org.jvnet.hudson.test.recipes.LocalData;
-
-import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-
-import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.slaves.DumbSlave;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
-
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.PrintWriter;
-import java.util.Collections;
-import java.util.List;
-
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.*;
-
+import hudson.tasks.test.TestObject;
+import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.RandomlyFails;
 import org.jvnet.hudson.test.SingleFileSCM;
 import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.TouchBuilder;
+import org.jvnet.hudson.test.recipes.LocalData;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-public class JUnitResultArchiverTest {
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class BlueJUnitTestResultArchiverTest {
 
     @Rule public JenkinsRule j = new JenkinsRule();
     private FreeStyleProject project;

--- a/src/test/java/hudson/tasks/junit/BlueJUnitTestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/BlueJUnitTestResultTest.java
@@ -1,0 +1,167 @@
+package hudson.tasks.junit;
+
+import com.google.common.collect.Lists;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.model.Run;
+import io.jenkins.blueocean.commons.ServiceException.NotFoundException;
+import io.jenkins.blueocean.rest.Reachable;
+import io.jenkins.blueocean.rest.factory.BlueTestResultFactory;
+import io.jenkins.blueocean.rest.hal.Link;
+import io.jenkins.blueocean.rest.model.BlueTestResult;
+import io.jenkins.blueocean.rest.model.BlueTestResult.State;
+import io.jenkins.blueocean.rest.model.BlueTestResult.Status;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestBuilder;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class BlueJUnitTestResultTest {
+
+    private static final Reachable REACHABLE = new Reachable() {
+        @Override
+        public Link getLink() {
+            return new Link("foo");
+        }
+    };
+
+    @Rule
+    public final JenkinsRule rule = new JenkinsRule();
+
+    @Test
+    public void testFactoryReturnsCaseResults() throws Exception {
+        FreeStyleProject p = rule.createFreeStyleProject("testRemoteApi");
+        p.getBuildersList().add(new TestBuilder() {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                build.getWorkspace().child("junit.xml").copyFrom(
+                        getClass().getResource("junit-report-20090516.xml"));
+                return true;
+            }
+        });
+        p.getPublishersList().add(new JUnitResultArchiver("*.xml"));
+        Run run = rule.assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
+
+        BlueTestResultFactory.Result resolved = BlueTestResultFactory.resolve(run, REACHABLE);
+        assertNotNull(resolved.results);
+        assertNotNull(resolved.summary);
+        assertEquals(Lists.newArrayList(resolved.results).size(), 8);
+        assertEquals(resolved.summary.getExistingFailedTotal(), 3);
+        assertEquals(resolved.summary.getFailedTotal(), 3);
+        assertEquals(resolved.summary.getFixedTotal(), 0);
+        assertEquals(resolved.summary.getPassedTotal(), 5);
+        assertEquals(resolved.summary.getRegressionsTotal(), 0);
+        assertEquals(resolved.summary.getSkippedTotal(), 0);
+        assertEquals(resolved.summary.getTotal(), 8);
+
+        BlueTestResult next = resolved.results.iterator().next();
+        assertEquals("hudson.tasks.junit.BlueJUnitTestResult:junit%2Forg.twia.vendor%2FVendorManagerTest%2FtestGetVendorFirmKeyForVendorRep", next.getId());
+        assertEquals("testGetVendorFirmKeyForVendorRep – org.twia.vendor.VendorManagerTest", next.getName());
+        assertEquals(1, next.getAge());
+        assertEquals(null, next.getErrorDetails());
+        assertEquals(ERROR, next.getErrorStackTrace());
+        String expectedLink = "foo/tests/hudson.tasks.junit.BlueJUnitTestResult%3Ajunit%252Forg.twia.vendor%252FVendorManagerTest%252FtestGetVendorFirmKeyForVendorRep/";
+        assertEquals(expectedLink, next.getLink().toString());
+        assertEquals(Status.FAILED, next.getStatus());
+        assertEquals(State.UNKNOWN, next.getTestState());
+
+        boolean noStdOut = false;
+        try {
+            assertEquals(null, next.getStdOut());
+        } catch (NotFoundException e) {
+            noStdOut = true;
+        }
+        assertTrue(noStdOut);
+
+
+        boolean noStdErr = false;
+        try {
+            assertEquals(null, next.getStdErr());
+        } catch (NotFoundException e) {
+            noStdErr = true;
+        }
+        assertTrue(noStdErr);
+    }
+
+    @Test
+    public void testDoesNotHaveTestResultAction() throws Exception {
+        FreeStyleProject p = rule.createFreeStyleProject();
+        Run run = rule.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0).get());
+
+        BlueTestResultFactory.Result resolved = BlueTestResultFactory.resolve(run, REACHABLE);
+        assertNull(resolved.results);
+        assertNull(resolved.summary);
+    }
+
+    private final static String ERROR = "java.lang.NullPointerException\n" +
+            "       at org.twia.vendor.VendorManagerTest.testGetVendorFirmKeyForVendorRep(VendorManagerTest.java:104)\n" +
+            "       at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+            "       at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)\n" +
+            "       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\n" +
+            "       at java.lang.reflect.Method.invoke(Method.java:585)\n" +
+            "       at junit.framework.TestCase.runTest(TestCase.java:166)\n" +
+            "       at org.unitils.UnitilsJUnit3.runTest(UnitilsJUnit3.java:171)\n" +
+            "       at junit.framework.TestCase.runBare(TestCase.java:140)\n" +
+            "       at org.unitils.UnitilsJUnit3.runBare(UnitilsJUnit3.java:138)\n" +
+            "       at junit.framework.TestResult$1.protect(TestResult.java:106)\n" +
+            "       at junit.framework.TestResult.runProtected(TestResult.java:124)\n" +
+            "       at junit.framework.TestResult.run(TestResult.java:109)\n" +
+            "       at junit.framework.TestCase.run(TestCase.java:131)\n" +
+            "       at org.unitils.UnitilsJUnit3.run(UnitilsJUnit3.java:101)\n" +
+            "       at junit.framework.TestSuite.runTest(TestSuite.java:173)\n" +
+            "       at junit.framework.TestSuite.run(TestSuite.java:168)\n" +
+            "       at junit.framework.TestSuite.runTest(TestSuite.java:173)\n" +
+            "       at junit.framework.TestSuite.run(TestSuite.java:168)\n" +
+            "       at junit.textui.TestRunner.doRun(TestRunner.java:74)\n" +
+            "       at org.twia.junit.CustomTestRunner.run(CustomTestRunner.java:76)\n" +
+            "       at org.twia.test.ejb.JunitCallerEJB.testSuites(JunitCallerEJB.java:136)\n" +
+            "       at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+            "       at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)\n" +
+            "       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\n" +
+            "       at java.lang.reflect.Method.invoke(Method.java:585)\n" +
+            "       at org.jboss.invocation.Invocation.performCall(Invocation.java:359)\n" +
+            "       at org.jboss.ejb.StatelessSessionContainer$ContainerInterceptor.invoke(StatelessSessionContainer.java:237)\n" +
+            "       at org.jboss.resource.connectionmanager.CachedConnectionInterceptor.invoke(CachedConnectionInterceptor.java:158)\n" +
+            "       at org.jboss.ejb.plugins.StatelessSessionInstanceInterceptor.invoke(StatelessSessionInstanceInterceptor.java:169)\n" +
+            "       at org.jboss.ejb.plugins.CallValidationInterceptor.invoke(CallValidationInterceptor.java:63)\n" +
+            "       at org.jboss.ejb.plugins.AbstractTxInterceptor.invokeNext(AbstractTxInterceptor.java:121)\n" +
+            "       at org.jboss.ejb.plugins.TxInterceptorCMT.runWithTransactions(TxInterceptorCMT.java:315)\n" +
+            "       at org.jboss.ejb.plugins.TxInterceptorCMT.invoke(TxInterceptorCMT.java:181)\n" +
+            "       at org.jboss.ejb.plugins.SecurityInterceptor.invoke(SecurityInterceptor.java:168)\n" +
+            "       at org.jboss.ejb.plugins.LogInterceptor.invoke(LogInterceptor.java:205)\n" +
+            "       at org.jboss.ejb.plugins.ProxyFactoryFinderInterceptor.invoke(ProxyFactoryFinderInterceptor.java:138)\n" +
+            "       at org.jboss.ejb.SessionContainer.internalInvoke(SessionContainer.java:648)\n" +
+            "       at org.jboss.ejb.Container.invoke(Container.java:960)\n" +
+            "       at sun.reflect.GeneratedMethodAccessor289.invoke(Unknown Source)\n" +
+            "       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\n" +
+            "       at java.lang.reflect.Method.invoke(Method.java:585)\n" +
+            "       at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)\n" +
+            "       at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)\n" +
+            "       at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)\n" +
+            "       at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)\n" +
+            "       at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)\n" +
+            "       at org.jboss.invocation.unified.server.UnifiedInvoker.invoke(UnifiedInvoker.java:231)\n" +
+            "       at sun.reflect.GeneratedMethodAccessor288.invoke(Unknown Source)\n" +
+            "       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\n" +
+            "       at java.lang.reflect.Method.invoke(Method.java:585)\n" +
+            "       at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)\n" +
+            "       at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)\n" +
+            "       at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)\n" +
+            "       at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)\n" +
+            "       at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)\n" +
+            "       at javax.management.MBeanServerInvocationHandler.invoke(MBeanServerInvocationHandler.java:201)\n" +
+            "       at $Proxy16.invoke(Unknown Source)\n" +
+            "       at org.jboss.remoting.ServerInvoker.invoke(ServerInvoker.java:795)\n" +
+            "       at org.jboss.remoting.transport.socket.ServerThread.processInvocation(ServerThread.java:573)\n" +
+            "       at org.jboss.remoting.transport.socket.ServerThread.dorun(ServerThread.java:387)\n" +
+            "       at org.jboss.remoting.transport.socket.ServerThread.run(ServerThread.java:166)\n";
+}

--- a/src/test/java/hudson/tasks/junit/JUnitTestResultArchiverTest.java
+++ b/src/test/java/hudson/tasks/junit/JUnitTestResultArchiverTest.java
@@ -78,7 +78,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class BlueJUnitTestResultArchiverTest {
+public class JUnitTestResultArchiverTest {
 
     @Rule public JenkinsRule j = new JenkinsRule();
     private FreeStyleProject project;


### PR DESCRIPTION
We've implemented a small API that provides data to Blue Ocean's REST API for test reporting and restructured `blueocean-rest` so that it is only an API for our REST model.

We needed increase the minimum java version to 7 from 6 for this plugin as the min Java version for Blue Ocean is 7.

The following dependencies have been added to junit plugin for this change:
```
[INFO] +- io.jenkins.blueocean:blueocean-rest:jar:1.1.0-beta-2-SNAPSHOT:compile
[INFO] |  +- io.jenkins.blueocean:blueocean-commons:jar:1.1.0-beta-2-SNAPSHOT:compile
[INFO] |  |  \- com.fasterxml.jackson.core:jackson-databind:jar:2.8.7:compile
[INFO] |  |     +- com.fasterxml.jackson.core:jackson-annotations:jar:2.8.0:compile
[INFO] |  |     \- com.fasterxml.jackson.core:jackson-core:jar:2.8.7:compile
[INFO] |  \- io.jenkins.blueocean.rest.annotation:capability-annotation:jar:1.2:compile
```

PTAL @vivek @jglick @michaelneale  