### PR TITLE
Fix a file descriptor leak

### DIFF
--- a/src/main/java/hudson/tasks/junit/SuiteResult.java
+++ b/src/main/java/hudson/tasks/junit/SuiteResult.java
@@ -33,6 +33,7 @@ import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -123,10 +124,19 @@ public final class SuiteResult implements Serializable {
         SAXReader saxReader = new SAXReader();
         ParserConfigurator.applyConfiguration(saxReader,new SuiteResultParserConfigurationContext(xmlReport));
 
-        Document result = saxReader.read(xmlReport);
-        Element root = result.getRootElement();
+        FileInputStream xmlReportStream = null;
+        try {
+            xmlReportStream = new FileInputStream(xmlReport);
 
-        parseSuite(xmlReport,keepLongStdio,r,root);
+            Document result = saxReader.read(xmlReportStream);
+            Element root = result.getRootElement();
+
+            parseSuite(xmlReport,keepLongStdio,r,root);
+        } finally {
+            if (xmlReportStream != null) {
+                xmlReportStream.close();
+            }
+        }
 
         return r;
     }


### PR DESCRIPTION
Dom4j leaks a fd when SaxReader.read(File) is used.
Let's rather use SaxReader.read(FileInputStream)
and close the stream ourself.

This file descriptor leak is specially annoying
on a Windows slave because it prevents from 
deleting the xml report at the end of the build

Signed-off-by: David Gageot <david@gageot.net>