### PR TITLE
Expose test data publicly

### DIFF
--- a/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
+++ b/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
@@ -177,12 +177,11 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep {
             }
 
             // TODO: Move into JUnitParser [BUG 3123310]
-            List<Data> data = action.getData();
             if (testDataPublishers != null) {
                 for (TestDataPublisher tdp : testDataPublishers) {
                     Data d = tdp.contributeTestData(build, workspace, launcher, listener, result);
                     if (d != null) {
-                        data.add(d);
+                        action.addData(d);
                     }
                 }
             }

--- a/src/main/java/hudson/tasks/junit/TestResultAction.java
+++ b/src/main/java/hudson/tasks/junit/TestResultAction.java
@@ -222,10 +222,12 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
         List<TestAction> result = new ArrayList<TestAction>();
         // Added check for null testData to avoid NPE from issue 4257.
         if (testData != null) {
-            for (Data data : testData)
-                for (TestAction ta : data.getTestAction(object))
-                    if (ta != null)
-                        result.add(ta);
+            synchronized (testData) {
+                for (Data data : testData)
+                    for (TestAction ta : data.getTestAction(object))
+                        if (ta != null)
+                            result.add(ta);
+            }
         }
         return Collections.unmodifiableList(result);
     }
@@ -242,7 +244,7 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
      *
      */
     public void setData(List<Data> testData) {
-	this.testData = testData;
+	      this.testData = testData;
     }
 
     /**
@@ -254,7 +256,9 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
      * @since TODO
      */
     public void addData(Data data) {
-        this.testData.add(data);
+        synchronized (testData) {
+            this.testData.add(data);
+        }
     }
 
     /**
@@ -277,7 +281,7 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
     public static abstract class Data {
     	/**
     	 * Returns all TestActions for the testObject.
-         * 
+         *
          * @return
          *      Can be empty but never null. The caller must assume that the returned list is read-only.
     	 */
@@ -289,10 +293,10 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
     	if (testData == null) {
     		testData = new ArrayList<Data>(0);
     	}
-    	
+
     	return this;
     }
-    
+
     private static final Logger logger = Logger.getLogger(TestResultAction.class.getName());
 
     private static final XStream XSTREAM = new XStream2();

--- a/src/main/java/hudson/tasks/junit/TestResultAction.java
+++ b/src/main/java/hudson/tasks/junit/TestResultAction.java
@@ -230,12 +230,19 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
         return Collections.unmodifiableList(result);
     }
 
-    public List<Data> getData() {
+    List<Data> getData() {
         return testData;
     }
 
     public void setData(List<Data> testData) {
 	this.testData = testData;
+    }
+
+    /**
+     * Adds a {@link Data} to the collection data associated with this action.
+     */
+    public void addData(Data data) {
+        this.testData.add(data);
     }
 
     /**

--- a/src/main/java/hudson/tasks/junit/TestResultAction.java
+++ b/src/main/java/hudson/tasks/junit/TestResultAction.java
@@ -230,7 +230,7 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
         return Collections.unmodifiableList(result);
     }
 
-    List<Data> getData() {
+    public List<Data> getData() {
         return testData;
     }
 

--- a/src/main/java/hudson/tasks/junit/TestResultAction.java
+++ b/src/main/java/hudson/tasks/junit/TestResultAction.java
@@ -234,12 +234,24 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
         return testData;
     }
 
+    /**
+     * Replaces to collection of test data associated with this action.
+     *
+     * <p>
+     * This method will not automatically persist the data at the time of addition.
+     *
+     */
     public void setData(List<Data> testData) {
 	this.testData = testData;
     }
 
     /**
-     * Adds a {@link Data} to the collection data associated with this action.
+     * Adds a {@link Data} to the test data associated with this action.
+     *
+     * <p>
+     * This method will not automatically persist the data at the time of addition.
+     *
+     * @since TODO
      */
     public void addData(Data data) {
         this.testData.add(data);


### PR DESCRIPTION
This will allow dependent plugins (like xunit one) to run TestDataPublishers