### PR TITLE
[JENKINS-5393] Add option to allow old test results to be included

### DIFF
--- a/src/main/java/hudson/tasks/junit/JUnitParser.java
+++ b/src/main/java/hudson/tasks/junit/JUnitParser.java
@@ -46,6 +46,7 @@ public class JUnitParser extends TestResultParser {
 
     private final boolean keepLongStdio;
     private final boolean allowEmptyResults;
+    private final boolean allowOldResults;
 
     /** TODO TestResultParser.all does not seem to ever be called so why must this be an Extension? */
     @Deprecated
@@ -59,8 +60,7 @@ public class JUnitParser extends TestResultParser {
      */
     @Deprecated
     public JUnitParser(boolean keepLongStdio) {
-        this.keepLongStdio = keepLongStdio;
-        this.allowEmptyResults = false;
+        this(keepLongStdio, false, false);
     }
 
     /**
@@ -69,8 +69,19 @@ public class JUnitParser extends TestResultParser {
      * @since 1.10
      */
     public JUnitParser(boolean keepLongStdio, boolean allowEmptyResults) {
+        this(keepLongStdio, allowEmptyResults, false);
+    }
+
+    /**
+     * @param keepLongStdio if true, retain a suite's complete stdout/stderr even if this is huge and the suite passed
+     * @param allowEmptyResults if true, empty results are allowed
+     * @param allowOldResults
+     * @since 1.16
+     */
+    public JUnitParser(boolean keepLongStdio, boolean allowEmptyResults, boolean allowOldResults) {
         this.keepLongStdio = keepLongStdio;
         this.allowEmptyResults = allowEmptyResults;
+        this.allowOldResults = allowOldResults;
     }
 
     @Override
@@ -90,8 +101,8 @@ public class JUnitParser extends TestResultParser {
 
     @Override
     public TestResult parseResult(String testResultLocations,
-                                       Run<?,?> build, FilePath workspace, Launcher launcher,
-                                       TaskListener listener)
+                                  Run<?,?> build, FilePath workspace, Launcher launcher,
+                                  TaskListener listener)
             throws InterruptedException, IOException
     {
         final long buildTime = build.getTimestamp().getTimeInMillis();
@@ -101,7 +112,7 @@ public class JUnitParser extends TestResultParser {
         // also get code that deals with testDataPublishers from JUnitResultArchiver.perform
 
         return workspace.act(new ParseResultCallable(testResultLocations, buildTime,
-                                                     timeOnMaster, keepLongStdio, allowEmptyResults));
+                timeOnMaster, keepLongStdio, allowEmptyResults, allowOldResults));
     }
 
     private static final class ParseResultCallable extends MasterToSlaveFileCallable<TestResult> {
@@ -110,14 +121,16 @@ public class JUnitParser extends TestResultParser {
         private final long nowMaster;
         private final boolean keepLongStdio;
         private final boolean allowEmptyResults;
+        private final boolean allowOldResults;
 
         private ParseResultCallable(String testResults, long buildTime, long nowMaster,
-                                    boolean keepLongStdio, boolean allowEmptyResults) {
+                                    boolean keepLongStdio, boolean allowEmptyResults, boolean allowOldResults) {
             this.buildTime = buildTime;
             this.testResults = testResults;
             this.nowMaster = nowMaster;
             this.keepLongStdio = keepLongStdio;
             this.allowEmptyResults = allowEmptyResults;
+            this.allowOldResults = allowOldResults;
         }
 
         public TestResult invoke(File ws, VirtualChannel channel) throws IOException {
@@ -129,7 +142,7 @@ public class JUnitParser extends TestResultParser {
 
             String[] files = ds.getIncludedFiles();
             if (files.length > 0) {
-                result = new TestResult(buildTime + (nowSlave - nowMaster), ds, keepLongStdio);
+                result = new TestResult(buildTime + (nowSlave - nowMaster), ds, keepLongStdio, allowOldResults);
                 result.tally();
             } else {
                 if (this.allowEmptyResults) {

--- a/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
+++ b/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
@@ -89,6 +89,11 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep {
      */
     private boolean allowEmptyResults;
 
+    /**
+     * If true, don't ignore test results created before the build was run
+     */
+    private boolean allowOldResults;
+
     @DataBoundConstructor
     public JUnitResultArchiver(String testResults) {
         this.testResults = testResults;
@@ -125,7 +130,8 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep {
             throws IOException, InterruptedException
     {
         return new JUnitParser(this.isKeepLongStdio(),
-                               this.isAllowEmptyResults()).parseResult(expandedTestResults, run, workspace, launcher, listener);
+                               this.isAllowEmptyResults(),
+                               this.isAllowOldResults()).parseResult(expandedTestResults, run, workspace, launcher, listener);
     }
 
     @Deprecated
@@ -275,6 +281,17 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep {
         this.allowEmptyResults = allowEmptyResults;
     }
 
+    /**
+     *
+     * @return the allowOldResults
+     */
+    public boolean isAllowOldResults() {
+        return allowOldResults;
+    }
+
+    @DataBoundSetter public final void setAllowOldResults(boolean allowOldResults) {
+        this.allowOldResults = allowOldResults;
+    }
 
     private static final long serialVersionUID = 1L;
 

--- a/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
+++ b/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
@@ -46,4 +46,7 @@ THE SOFTWARE.
     <f:entry title="${%Allow empty results}" field="allowEmptyResults">
         <f:checkbox default="false" title="${%Do not fail the build on empty test results}"/>
     </f:entry>
+    <f:entry title="${%Allow old results}" field="allowOldResults">
+        <f:checkbox default="false" title="${%Do not ignore old test results}"/>
+    </f:entry>
 </j:jelly>


### PR DESCRIPTION
This would close JENKINS-5393, JENKINS-9438, and JENKINS-6268 by adding a toggle for the current behavior of ignoring any tests that predate the start of the build. This is based on an earlier pull request by @johnscancella. I made it pipeline friendly and fixed the merge conflict pointed out by @oleg-nenashev.

The new option is disabled by default to preserve backwards compatibility.