### PR TITLE
Align headers where fields are aligned

### DIFF
--- a/src/main/resources/hudson/tasks/junit/ClassResult/list.jelly
+++ b/src/main/resources/hudson/tasks/junit/ClassResult/list.jelly
@@ -29,10 +29,10 @@ THE SOFTWARE.
       <tr>
         <td class="pane-header">${%Build}</td>
         <td class="pane-header">${%Description}</td>
-        <td class="pane-header" style="width:5em">${%Duration}</td>
-        <td class="pane-header" style="width:5em">${%Fail}</td>
-        <td class="pane-header" style="width:5em">${%Skip}</td>
-        <td class="pane-header" style="width:5em">${%Total}</td>
+        <td class="pane-header" style="width:5em; text-align:right;">${%Duration}</td>
+        <td class="pane-header" style="width:5em; text-align:right;">${%Fail}</td>
+        <td class="pane-header" style="width:5em; text-align:right;">${%Skip}</td>
+        <td class="pane-header" style="width:5em; text-align:right;">${%Total}</td>
       </tr>
       <tbody>
 	        <j:forEach var="b" items="${it.run.parent.builds}" begin="${start}" end="${end}">

--- a/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
+++ b/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
@@ -52,15 +52,15 @@ THE SOFTWARE.
     <table class="pane sortable bigtable stripped" id="testresult">
       <tr>
         <td class="pane-header">${it.childTitle}</td>
-        <td class="pane-header" style="width:5em">${%Duration}</td>
-        <td class="pane-header" style="width:5em">${%Fail}</td>
-        <td class="pane-header" style="width:1em; font-size:smaller; white-space:nowrap;">(${%diff})</td>
-        <td class="pane-header" style="width:5em">${%Skip}</td>
-        <td class="pane-header" style="width:1em; font-size:smaller; white-space:nowrap;">(${%diff})</td>
-        <td class="pane-header" style="width:5em">${%Pass}</td>
-        <td class="pane-header" style="width:1em; font-size:smaller; white-space:nowrap;">(${%diff})</td>
-        <td class="pane-header" style="width:5em">${%Total}</td>
-        <td class="pane-header" style="width:1em; font-size:smaller; white-space:nowrap;">(${%diff})</td>
+        <td class="pane-header" style="width:5em; text-align:right">${%Duration}</td>
+        <td class="pane-header" style="width:5em; text-align:right">${%Fail}</td>
+        <td class="pane-header" style="width:1em; text-align:right; font-size:smaller; white-space:nowrap;">(${%diff})</td>
+        <td class="pane-header" style="width:5em; text-align:right">${%Skip}</td>
+        <td class="pane-header" style="width:1em; text-align:right; font-size:smaller; white-space:nowrap;">(${%diff})</td>
+        <td class="pane-header" style="width:5em; text-align:right">${%Pass}</td>
+        <td class="pane-header" style="width:1em; text-align:right; font-size:smaller; white-space:nowrap;">(${%diff})</td>
+        <td class="pane-header" style="width:5em; text-align:right">${%Total}</td>
+        <td class="pane-header" style="width:1em; text-align:right; font-size:smaller; white-space:nowrap;">(${%diff})</td>
       </tr>
       <tbody>
         <j:set var="prevAll" value="${it.previousResult}" />

--- a/src/main/resources/hudson/tasks/test/MetaTabulatedResult/list.jelly
+++ b/src/main/resources/hudson/tasks/test/MetaTabulatedResult/list.jelly
@@ -29,10 +29,10 @@ THE SOFTWARE.
       <tr>
         <td class="pane-header">${%Build}</td>
         <td class="pane-header">${%Description}</td>
-        <td class="pane-header" style="width:5em">${%Duration}</td>
-        <td class="pane-header" style="width:5em">${%Fail}</td>
-        <td class="pane-header" style="width:5em">${%Skip}</td>
-        <td class="pane-header" style="width:5em">${%Total}</td>
+        <td class="pane-header" style="width:5em; text-align:right">${%Duration}</td>
+        <td class="pane-header" style="width:5em; text-align:right">${%Fail}</td>
+        <td class="pane-header" style="width:5em; text-align:right">${%Skip}</td>
+        <td class="pane-header" style="width:5em; text-align:right">${%Total}</td>
       </tr>
       <tbody>
 	        <j:forEach var="b" items="${it.run.parent.builds}" begin="${start}" end="${end}">

--- a/src/main/resources/lib/hudson/test/aggregated-failed-tests.jelly
+++ b/src/main/resources/lib/hudson/test/aggregated-failed-tests.jelly
@@ -47,8 +47,8 @@ THE SOFTWARE.
         <table class="pane sortable bigtable stripped">
           <tr>
             <td class="pane-header">Test Name</td>
-            <td class="pane-header" style="width:4em">Duration</td>
-            <td class="pane-header" style="width:4em">Age</td>
+            <td class="pane-header" style="width:4em; text-align:right;">Duration</td>
+            <td class="pane-header" style="width:4em; text-align:right;">Age</td>
           </tr>
           <j:forEach var="f" items="${report.result.failedTests}" varStatus="i">
             <tr>


### PR DESCRIPTION
We are aligning values to the right but column headers are centered. It can get tricky to navigate in bigger tables.

Before:
![junit-orig](https://user-images.githubusercontent.com/206841/28717706-2ee510f4-73a3-11e7-82f8-8074212e656e.png)

After:
![junit-new](https://user-images.githubusercontent.com/206841/28717707-2ee75148-73a3-11e7-9066-7f03844c289e.png)

