### PR TITLE
Move BlueJUnitTestResult to JUnit plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,9 @@
     <description>Allows JUnit-format test results to be published.</description>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/JUnit+Plugin</url>
     <properties>
-        <jenkins.version>1.580.1</jenkins.version>
-        <java.level>6</java.level>
+        <jenkins.version>2.7.4</jenkins.version>
+        <java.level>7</java.level>
+        <blueocean.version>1.2.0</blueocean.version>
     </properties>
     <licenses>
         <license>
@@ -44,7 +45,53 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.2</version>
+            <version>1.10</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.blueocean</groupId>
+            <artifactId>blueocean-rest</artifactId>
+            <version>${blueocean.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.blueocean</groupId>
+            <artifactId>blueocean-rest-impl</artifactId>
+            <version>${blueocean.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>2.11.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-api</artifactId>
+            <version>2.20</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>2.39</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>2.14</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>2.13</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
             <groupId>io.jenkins.blueocean</groupId>
             <artifactId>blueocean-rest</artifactId>
             <version>${blueocean.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.jenkins.blueocean</groupId>

--- a/src/main/java/hudson/tasks/junit/BlueJUnitTestResult.java
+++ b/src/main/java/hudson/tasks/junit/BlueJUnitTestResult.java
@@ -115,7 +115,7 @@ public class BlueJUnitTestResult extends BlueTestResult {
         return log;
     }
 
-    @Extension
+    @Extension(optional = true)
     public static class FactoryImpl extends BlueTestResultFactory {
         @Override
         public Result getBlueTestResults(Run<?, ?> run, final Reachable parent) {

--- a/src/main/java/hudson/tasks/junit/BlueJUnitTestResult.java
+++ b/src/main/java/hudson/tasks/junit/BlueJUnitTestResult.java
@@ -1,0 +1,137 @@
+package hudson.tasks.junit;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import hudson.Extension;
+import hudson.model.Run;
+import io.jenkins.blueocean.commons.ServiceException.NotFoundException;
+import io.jenkins.blueocean.rest.Reachable;
+import io.jenkins.blueocean.rest.factory.BlueTestResultFactory;
+import io.jenkins.blueocean.rest.hal.Link;
+import io.jenkins.blueocean.rest.model.BlueTestResult;
+
+import javax.annotation.Nullable;
+
+import static org.apache.commons.lang.StringUtils.isEmpty;
+
+public class BlueJUnitTestResult extends BlueTestResult {
+
+    protected final CaseResult testResult;
+
+    public BlueJUnitTestResult(CaseResult testResult, Link parent) {
+        super(parent);
+        this.testResult = testResult;
+    }
+
+    @Override
+    public String getName() {
+        return testResult.getName() + " – " + testResult.getClassName();
+    }
+
+    @Override
+    public Status getStatus() {
+        Status status;
+        switch (testResult.getStatus()) {
+            case SKIPPED:
+                status = Status.SKIPPED;
+                break;
+            case FAILED:
+            case REGRESSION:
+                status = Status.FAILED;
+                break;
+            case PASSED:
+            case FIXED:
+                status = Status.PASSED;
+                break;
+            default:
+                status = Status.UNKNOWN;
+                break;
+        }
+        return status;
+    }
+
+    @Override
+    public State getTestState() {
+        State state;
+        switch (testResult.getStatus()) {
+            case REGRESSION:
+                state = State.REGRESSION;
+                break;
+            case FIXED:
+                state = State.FIXED;
+                break;
+            default:
+                state = State.UNKNOWN;
+        }
+        return state;
+    }
+
+    @Override
+    public float getDuration() {
+        return testResult.getDuration();
+    }
+
+    @Override
+    public String getErrorStackTrace() {
+        return testResult.getErrorStackTrace();
+    }
+
+    @Override
+    public String getErrorDetails() {
+        return testResult.getErrorDetails();
+    }
+
+    @Override
+    protected String getUniqueId() {
+        return testResult.getId();
+    }
+
+    @Override
+    public int getAge() {
+        int age;
+        if (!testResult.isPassed() && testResult.getRun() != null) {
+            age = testResult.getRun().getNumber() - testResult.getFailedSince() + 1;
+        } else {
+            age = 0;
+        }
+        return age;
+    }
+
+    @Override
+    public String getStdErr() {
+        return serveLog(testResult.getStderr());
+    }
+
+    @Override
+    public String getStdOut() {
+        return serveLog(testResult.getStdout());
+    }
+
+    private String serveLog(String log) {
+        if (isEmpty(log)) {
+            throw new NotFoundException("No log");
+        }
+        return log;
+    }
+
+    @Extension
+    public static class FactoryImpl extends BlueTestResultFactory {
+        @Override
+        public Result getBlueTestResults(Run<?, ?> run, final Reachable parent) {
+            Iterable<BlueTestResult> results;
+            TestResultAction action = run.getAction(TestResultAction.class);
+            if (action != null) {
+                results = Iterables.transform(Iterables.concat(action.getFailedTests(), action.getSkippedTests(), action.getPassedTests()), new Function<CaseResult, BlueTestResult>() {
+                    @Override
+                    public BlueTestResult apply(@Nullable CaseResult input) {
+                        return new BlueJUnitTestResult(input, parent.getLink());
+                    }
+                });
+            } else {
+                results = ImmutableList.of();
+            }
+            return Result.of(results);
+        }
+    }
+}

--- a/src/test/java/hudson/tasks/junit/BlueJUnitTestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/BlueJUnitTestResultTest.java
@@ -1,0 +1,48 @@
+package hudson.tasks.junit;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.Iterators;
+import com.google.common.io.Resources;
+import hudson.model.Run;
+import io.jenkins.blueocean.rest.Reachable;
+import io.jenkins.blueocean.rest.factory.BlueRunFactory;
+import io.jenkins.blueocean.rest.hal.Link;
+import io.jenkins.blueocean.rest.model.BlueRun;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.net.URL;
+
+public class BlueJUnitTestResultTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void createsTestResult() throws Exception {
+        URL resource = Resources.getResource(getClass(), "BlueJUnitTestResultTest.jenkinsfile");
+        String jenkinsFile = Resources.toString(resource, Charsets.UTF_8);
+
+        WorkflowJob p = j.createProject(WorkflowJob.class, "project");
+        p.setDefinition(new CpsFlowDefinition(jenkinsFile, false));
+        p.save();
+
+        Run r = p.scheduleBuild2(0).waitForStart();
+        j.waitUntilNoActivity();
+
+        System.out.println(r.getLog());
+
+        BlueRun test = BlueRunFactory.getRun(r, new Reachable() {
+            @Override
+            public Link getLink() {
+                return new Link("test");
+            }
+        });
+
+        Assert.assertEquals(3, Iterators.size(test.getTests().iterator()));
+    }
+}

--- a/src/test/resources/hudson/tasks/junit/BlueJUnitTestResultTest.jenkinsfile
+++ b/src/test/resources/hudson/tasks/junit/BlueJUnitTestResultTest.jenkinsfile
@@ -1,0 +1,11 @@
+node {
+    test = "<testsuite tests=\"3\">\n" +
+        "    <testcase classname=\"foo1\" name=\"ASuccessfulTest\"/>\n" +
+        "    <testcase classname=\"foo2\" name=\"AnotherSuccessfulTest\"/>\n" +
+        "    <testcase classname=\"foo3\" name=\"AFailingTest\">\n" +
+        "        <failure type=\"NotEnoughFoo\"> details about failure </failure>\n" +
+        "    </testcase>\n" +
+        "</testsuite>";
+    writeFile file:'result.xml', text: test
+    junit 'result.xml'
+}


### PR DESCRIPTION
@jglick as discussed this afternoon. Tests currently fail because this implementation is already in Blue Ocean 1.2 (you end up with duplicate tests. 

We may have to do some sort of dance to make sure that we release 1.3.x without its JUnit dependency and then publish. PR for blueocean-plugin coming later.