### PR TITLE
[JENKINS-27395] Removed per-run node tracking

### DIFF
--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -273,7 +273,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
             Run<?, ?> r = getRun();
             if (r != null) {
                 TestResultAction action = r.getAction(TestResultAction.class);
-                if (action != null && action.getResult().hasMultipleBlocksForRun(r.getExternalizableId())) {
+                if (action != null && action.getResult().hasMultipleBlocks()) {
                     return StringUtils.join(new ReverseListIterator(getEnclosingFlowNodeNames()), " / ") + " / " + getTransformedTestName();
                 }
             }
@@ -605,16 +605,17 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     public Run<?,?> getRun() {
         SuiteResult sr = getSuiteResult();
         if (sr==null) {
-            LOGGER.warning("In getOwner(), getSuiteResult is null"); return null; }
-        hudson.tasks.junit.TestResult tr = sr.getParent();
-        if (tr==null) {
-            if (sr.getRunId() != null) {
-                return Run.fromExternalizableId(sr.getRunId());
-            } else {
-                LOGGER.warning("In getOwner(), suiteResult.getParent() is null and suiteResult.getRunId() is null.");
-                return null;
-            }
+            LOGGER.warning("In getOwner(), getSuiteResult is null");
+            return null;
         }
+
+        hudson.tasks.junit.TestResult tr = sr.getParent();
+
+        if (tr == null) {
+            LOGGER.warning("In getOwner(), suiteResult.getParent() is null.");
+            return null;
+        }
+
         return tr.getRun();
     }
 

--- a/src/main/java/hudson/tasks/junit/JUnitParser.java
+++ b/src/main/java/hudson/tasks/junit/JUnitParser.java
@@ -24,7 +24,7 @@
 package hudson.tasks.junit;
 
 import hudson.model.TaskListener;
-import hudson.tasks.test.PipelineArgs;
+import hudson.tasks.test.PipelineTestDetails;
 import hudson.tasks.test.TestResultParser;
 import hudson.*;
 import hudson.model.AbstractBuild;
@@ -39,6 +39,7 @@ import jenkins.MasterToSlaveFileCallable;
 import org.apache.tools.ant.types.FileSet;
 import org.apache.tools.ant.DirectoryScanner;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 /**
@@ -97,11 +98,11 @@ public class JUnitParser extends TestResultParser {
     public TestResult parseResult(String testResultLocations, Run<?,?> build, FilePath workspace,
                                   Launcher launcher, TaskListener listener)
             throws InterruptedException, IOException {
-        return parseResult(testResultLocations, build, new PipelineArgs(), workspace, launcher, listener);
+        return parseResult(testResultLocations, build, null, workspace, launcher, listener);
     }
 
     @Override
-    public TestResult parseResult(String testResultLocations, Run<?,?> build, @Nonnull PipelineArgs pipelineArgs,
+    public TestResult parseResult(String testResultLocations, Run<?,?> build, PipelineTestDetails pipelineTestDetails,
                                   FilePath workspace, Launcher launcher, TaskListener listener)
             throws InterruptedException, IOException {
         final long buildTime = build.getTimestamp().getTimeInMillis();
@@ -111,7 +112,7 @@ public class JUnitParser extends TestResultParser {
         // also get code that deals with testDataPublishers from JUnitResultArchiver.perform
 
         return workspace.act(new ParseResultCallable(testResultLocations, buildTime, timeOnMaster, keepLongStdio,
-                allowEmptyResults, pipelineArgs));
+                allowEmptyResults, pipelineTestDetails));
     }
 
     private static final class ParseResultCallable extends MasterToSlaveFileCallable<TestResult> {
@@ -120,17 +121,17 @@ public class JUnitParser extends TestResultParser {
         private final long nowMaster;
         private final boolean keepLongStdio;
         private final boolean allowEmptyResults;
-        private final PipelineArgs pipelineArgs;
+        private final PipelineTestDetails pipelineTestDetails;
 
         private ParseResultCallable(String testResults, long buildTime, long nowMaster,
                                     boolean keepLongStdio, boolean allowEmptyResults,
-                                    @Nonnull PipelineArgs pipelineArgs) {
+                                    PipelineTestDetails pipelineTestDetails) {
             this.buildTime = buildTime;
             this.testResults = testResults;
             this.nowMaster = nowMaster;
             this.keepLongStdio = keepLongStdio;
             this.allowEmptyResults = allowEmptyResults;
-            this.pipelineArgs = pipelineArgs;
+            this.pipelineTestDetails = pipelineTestDetails;
         }
 
         public TestResult invoke(File ws, VirtualChannel channel) throws IOException {
@@ -142,7 +143,7 @@ public class JUnitParser extends TestResultParser {
 
             String[] files = ds.getIncludedFiles();
             if (files.length > 0) {
-                result = new TestResult(buildTime + (nowSlave - nowMaster), ds, keepLongStdio, pipelineArgs);
+                result = new TestResult(buildTime + (nowSlave - nowMaster), ds, keepLongStdio, pipelineTestDetails);
                 result.tally();
             } else {
                 if (this.allowEmptyResults) {

--- a/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
+++ b/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
@@ -41,7 +41,7 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.tasks.junit.TestResultAction.Data;
-import hudson.tasks.test.PipelineArgs;
+import hudson.tasks.test.PipelineTestDetails;
 import hudson.util.DescribableList;
 import hudson.util.FormValidation;
 import org.apache.tools.ant.DirectoryScanner;
@@ -124,16 +124,16 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
     private TestResult parse(String expandedTestResults, Run<?,?> run, @Nonnull FilePath workspace, Launcher launcher, TaskListener listener)
             throws IOException, InterruptedException
     {
-        return parse(this, new PipelineArgs(), expandedTestResults, run, workspace, launcher, listener);
+        return parse(this, null, expandedTestResults, run, workspace, launcher, listener);
 
     }
 
-    private static TestResult parse(@Nonnull JUnitTask task, @Nonnull PipelineArgs pipelineArgs,
+    private static TestResult parse(@Nonnull JUnitTask task, PipelineTestDetails pipelineTestDetails,
                                     String expandedTestResults, Run<?,?> run, @Nonnull FilePath workspace,
                                     Launcher launcher, TaskListener listener)
             throws IOException, InterruptedException {
         return new JUnitParser(task.isKeepLongStdio(), task.isAllowEmptyResults())
-                .parseResult(expandedTestResults, run, pipelineArgs, workspace, launcher, listener);
+                .parseResult(expandedTestResults, run, pipelineTestDetails, workspace, launcher, listener);
     }
 
     @Deprecated
@@ -150,20 +150,20 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
     @Override
     public void perform(Run build, FilePath workspace, Launcher launcher,
             TaskListener listener) throws InterruptedException, IOException {
-        TestResultAction action = parseAndAttach(this, new PipelineArgs(), build, workspace, launcher, listener);
+        TestResultAction action = parseAndAttach(this, null, build, workspace, launcher, listener);
 
         if (action != null && action.getResult().getFailCount() > 0)
             build.setResult(Result.UNSTABLE);
     }
 
-    public static TestResultAction parseAndAttach(@Nonnull JUnitTask task, @Nonnull PipelineArgs pipelineArgs,
+    public static TestResultAction parseAndAttach(@Nonnull JUnitTask task, PipelineTestDetails pipelineTestDetails,
                                                   Run build, FilePath workspace, Launcher launcher, TaskListener listener)
             throws InterruptedException, IOException {
         listener.getLogger().println(Messages.JUnitResultArchiver_Recording());
 
         final String testResults = build.getEnvironment(listener).expand(task.getTestResults());
 
-        TestResult result = parse(task, pipelineArgs, testResults, build, workspace, launcher, listener);
+        TestResult result = parse(task, pipelineTestDetails, testResults, build, workspace, launcher, listener);
 
         synchronized (build) {
             // TODO can the build argument be omitted now, or is it used prior to the call to addAction?

--- a/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
+++ b/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
@@ -41,6 +41,7 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.tasks.junit.TestResultAction.Data;
+import hudson.tasks.test.PipelineArgs;
 import hudson.util.DescribableList;
 import hudson.util.FormValidation;
 import org.apache.tools.ant.DirectoryScanner;
@@ -52,7 +53,6 @@ import org.kohsuke.stapler.QueryParameter;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jenkins.tasks.SimpleBuildStep;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -124,16 +124,16 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
     private TestResult parse(String expandedTestResults, Run<?,?> run, @Nonnull FilePath workspace, Launcher launcher, TaskListener listener)
             throws IOException, InterruptedException
     {
-        return parse(this, null, null, null, expandedTestResults, run, workspace, launcher, listener);
+        return parse(this, new PipelineArgs(), expandedTestResults, run, workspace, launcher, listener);
 
     }
 
-    private static TestResult parse(@Nonnull JUnitTask task, @CheckForNull String nodeId, List<String> enclosingBlocks,
-                                    List<String> enclosingBlockNames, String expandedTestResults, Run<?,?> run, @Nonnull FilePath workspace,
+    private static TestResult parse(@Nonnull JUnitTask task, @Nonnull PipelineArgs pipelineArgs,
+                                    String expandedTestResults, Run<?,?> run, @Nonnull FilePath workspace,
                                     Launcher launcher, TaskListener listener)
             throws IOException, InterruptedException {
         return new JUnitParser(task.isKeepLongStdio(), task.isAllowEmptyResults())
-                .parseResult(expandedTestResults, run, nodeId, enclosingBlocks, enclosingBlockNames, workspace, launcher, listener);
+                .parseResult(expandedTestResults, run, pipelineArgs, workspace, launcher, listener);
     }
 
     @Deprecated
@@ -150,21 +150,20 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
     @Override
     public void perform(Run build, FilePath workspace, Launcher launcher,
             TaskListener listener) throws InterruptedException, IOException {
-        TestResultAction action = parseAndAttach(this, null, null, null, build, workspace, launcher, listener);
+        TestResultAction action = parseAndAttach(this, new PipelineArgs(), build, workspace, launcher, listener);
 
         if (action != null && action.getResult().getFailCount() > 0)
             build.setResult(Result.UNSTABLE);
     }
 
-    public static TestResultAction parseAndAttach(@Nonnull JUnitTask task, @CheckForNull String nodeId,
-                                                  List<String> enclosingBlocks, List<String> enclosingBlockNames,
+    public static TestResultAction parseAndAttach(@Nonnull JUnitTask task, @Nonnull PipelineArgs pipelineArgs,
                                                   Run build, FilePath workspace, Launcher launcher, TaskListener listener)
             throws InterruptedException, IOException {
         listener.getLogger().println(Messages.JUnitResultArchiver_Recording());
 
         final String testResults = build.getEnvironment(listener).expand(task.getTestResults());
 
-        TestResult result = parse(task, nodeId, enclosingBlocks, enclosingBlockNames, testResults, build, workspace, launcher, listener);
+        TestResult result = parse(task, pipelineArgs, testResults, build, workspace, launcher, listener);
 
         synchronized (build) {
             // TODO can the build argument be omitted now, or is it used prior to the call to addAction?

--- a/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
+++ b/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
@@ -124,16 +124,16 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
     private TestResult parse(String expandedTestResults, Run<?,?> run, @Nonnull FilePath workspace, Launcher launcher, TaskListener listener)
             throws IOException, InterruptedException
     {
-        return parse(this, null, null, expandedTestResults, run, workspace, launcher, listener);
+        return parse(this, null, null, null, expandedTestResults, run, workspace, launcher, listener);
 
     }
 
     private static TestResult parse(@Nonnull JUnitTask task, @CheckForNull String nodeId, List<String> enclosingBlocks,
-                                    String expandedTestResults, Run<?,?> run, @Nonnull FilePath workspace,
+                                    List<String> enclosingBlockNames, String expandedTestResults, Run<?,?> run, @Nonnull FilePath workspace,
                                     Launcher launcher, TaskListener listener)
             throws IOException, InterruptedException {
         return new JUnitParser(task.isKeepLongStdio(), task.isAllowEmptyResults())
-                .parseResult(expandedTestResults, run, nodeId, enclosingBlocks, workspace, launcher, listener);
+                .parseResult(expandedTestResults, run, nodeId, enclosingBlocks, enclosingBlockNames, workspace, launcher, listener);
     }
 
     @Deprecated
@@ -150,21 +150,21 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
     @Override
     public void perform(Run build, FilePath workspace, Launcher launcher,
             TaskListener listener) throws InterruptedException, IOException {
-        TestResultAction action = parseAndAttach(this, null, null, build, workspace, launcher, listener);
+        TestResultAction action = parseAndAttach(this, null, null, null, build, workspace, launcher, listener);
 
         if (action != null && action.getResult().getFailCount() > 0)
             build.setResult(Result.UNSTABLE);
     }
 
     public static TestResultAction parseAndAttach(@Nonnull JUnitTask task, @CheckForNull String nodeId,
-                                                  List<String> enclosingBlocks, Run build, FilePath workspace,
-                                                  Launcher launcher, TaskListener listener)
+                                                  List<String> enclosingBlocks, List<String> enclosingBlockNames,
+                                                  Run build, FilePath workspace, Launcher launcher, TaskListener listener)
             throws InterruptedException, IOException {
         listener.getLogger().println(Messages.JUnitResultArchiver_Recording());
 
         final String testResults = build.getEnvironment(listener).expand(task.getTestResults());
 
-        TestResult result = parse(task, nodeId, enclosingBlocks, testResults, build, workspace, launcher, listener);
+        TestResult result = parse(task, nodeId, enclosingBlocks, enclosingBlockNames, testResults, build, workspace, launcher, listener);
 
         synchronized (build) {
             // TODO can the build argument be omitted now, or is it used prior to the call to addAction?

--- a/src/main/java/hudson/tasks/junit/SuiteResult.java
+++ b/src/main/java/hudson/tasks/junit/SuiteResult.java
@@ -92,11 +92,6 @@ public final class SuiteResult implements Serializable {
     private String time;
 
     /**
-     * Optional {@link Run#getExternalizableId()} this suite was generated in.
-     */
-    private String runId;
-
-    /**
      * Optional {@link FlowNode#getId()} this suite was generated in.
      */
     private String nodeId;
@@ -118,22 +113,23 @@ public final class SuiteResult implements Serializable {
     }
 
     /**
-     * @since 1.21
+     * @since 1.22
      */
-    SuiteResult(String name, String stdout, String stderr, @CheckForNull String runId, @CheckForNull String nodeId,
-                @CheckForNull List<String> enclosingBlocks) {
+    SuiteResult(String name, String stdout, String stderr, @CheckForNull String nodeId,
+                @CheckForNull List<String> enclosingBlocks, @CheckForNull List<String> enclosingBlockNames) {
         this.name = name;
         this.stderr = stderr;
         this.stdout = stdout;
         // runId is generally going to be not null, but we only care about it if both it and nodeId are not null.
-        if (runId != null && nodeId != null) {
-            this.runId = runId;
+        if (nodeId != null) {
             this.nodeId = nodeId;
             if (enclosingBlocks != null) {
                 this.enclosingBlocks.addAll(enclosingBlocks);
             }
+            if (enclosingBlockNames != null) {
+                this.enclosingBlockNames.addAll(enclosingBlockNames);
+            }
         } else {
-            this.runId = null;
             this.nodeId = null;
         }
         this.file = null;
@@ -169,8 +165,8 @@ public final class SuiteResult implements Serializable {
      * This method returns a collection, as a single XML may have multiple &lt;testsuite>
      * elements wrapped into the top-level &lt;testsuites>.
      */
-    static List<SuiteResult> parse(File xmlReport, boolean keepLongStdio, @CheckForNull String runId, @CheckForNull String nodeId,
-                                   @CheckForNull List<String> enclosingBlocks)
+    static List<SuiteResult> parse(File xmlReport, boolean keepLongStdio, @CheckForNull String nodeId,
+                                   @CheckForNull List<String> enclosingBlocks, @CheckForNull List<String> enclosingBlockNames)
             throws DocumentException, IOException, InterruptedException {
         List<SuiteResult> r = new ArrayList<SuiteResult>();
 
@@ -183,7 +179,7 @@ public final class SuiteResult implements Serializable {
             Document result = saxReader.read(xmlReportStream);
             Element root = result.getRootElement();
 
-            parseSuite(xmlReport, keepLongStdio, r, root, runId, nodeId, enclosingBlocks);
+            parseSuite(xmlReport, keepLongStdio, r, root, nodeId, enclosingBlocks, enclosingBlockNames);
         } finally {
             xmlReportStream.close();
         }
@@ -191,26 +187,27 @@ public final class SuiteResult implements Serializable {
         return r;
     }
 
-    private static void parseSuite(File xmlReport, boolean keepLongStdio, List<SuiteResult> r, Element root, @CheckForNull String runId,
-                                   @CheckForNull String nodeId, @CheckForNull List<String> enclosingBlocks) throws DocumentException, IOException {
+    private static void parseSuite(File xmlReport, boolean keepLongStdio, List<SuiteResult> r, Element root,
+                                   @CheckForNull String nodeId, @CheckForNull List<String> enclosingBlocks,
+                                   @CheckForNull List<String> enclosingBlockNames) throws DocumentException, IOException {
         // nested test suites
         @SuppressWarnings("unchecked")
         List<Element> testSuites = (List<Element>) root.elements("testsuite");
         for (Element suite : testSuites)
-            parseSuite(xmlReport, keepLongStdio, r, suite, runId, nodeId, enclosingBlocks);
+            parseSuite(xmlReport, keepLongStdio, r, suite, nodeId, enclosingBlocks, enclosingBlockNames);
 
         // child test cases
         // FIXME: do this also if no testcases!
         if (root.element("testcase") != null || root.element("error") != null)
-            r.add(new SuiteResult(xmlReport, root, keepLongStdio, runId, nodeId, enclosingBlocks));
+            r.add(new SuiteResult(xmlReport, root, keepLongStdio, nodeId, enclosingBlocks, enclosingBlockNames));
     }
 
     /**
      * @param xmlReport A JUnit XML report file whose top level element is 'testsuite'.
      * @param suite     The parsed result of {@code xmlReport}
      */
-    private SuiteResult(File xmlReport, Element suite, boolean keepLongStdio, @CheckForNull String runId,
-                        @CheckForNull String nodeId, @CheckForNull List<String> enclosingBlocks)
+    private SuiteResult(File xmlReport, Element suite, boolean keepLongStdio, @CheckForNull String nodeId,
+                        @CheckForNull List<String> enclosingBlocks, @CheckForNull List<String> enclosingBlockNames)
             throws DocumentException, IOException {
         this.file = xmlReport.getAbsolutePath();
         String name = suite.attributeValue("name");
@@ -225,17 +222,13 @@ public final class SuiteResult implements Serializable {
         this.name = TestObject.safe(name);
         this.timestamp = suite.attributeValue("timestamp");
         this.id = suite.attributeValue("id");
-        if (runId != null && nodeId != null) {
-            this.runId = runId;
+        if (nodeId != null) {
             this.nodeId = nodeId;
             if (enclosingBlocks != null) {
-                Run<?, ?> r = Run.fromExternalizableId(runId);
-                if (r instanceof WorkflowRun) {
-                    for (String enc : enclosingBlocks) {
-                        this.enclosingBlockNames.add(getEnclosingNodeDisplayName((WorkflowRun)r, enc));
-                    }
-                }
                 this.enclosingBlocks.addAll(enclosingBlocks);
+            }
+            if (enclosingBlockNames != null) {
+                this.enclosingBlockNames.addAll(enclosingBlockNames);
             }
         }
 
@@ -307,28 +300,6 @@ public final class SuiteResult implements Serializable {
         }
     }
 
-    @Nonnull
-    private String getEnclosingNodeDisplayName(@Nonnull WorkflowRun run, @Nonnull String nodeId) {
-        FlowExecution execution = run.getExecution();
-        if (execution != null) {
-            try {
-                FlowNode node = execution.getNode(nodeId);
-                if (node != null) {
-                    if (node.getAction(LabelAction.class) != null) {
-                        ThreadNameAction threadNameAction = node.getAction(ThreadNameAction.class);
-                        if (threadNameAction != null) {
-                            return threadNameAction.getThreadName();
-                        }
-                    }
-                    return node.getDisplayName();
-                }
-            } catch (Exception e) {
-                // TODO: Something in that odd case where we can get an NPE
-            }
-        }
-        return "";
-    }
-
     /**
      * Returns true if the time attribute is present in this Suite.
      */
@@ -347,20 +318,9 @@ public final class SuiteResult implements Serializable {
     }
 
     /**
-     * The possibly-null {@link Run#getExternalizableId()} this suite was generated in.
-     *
-     * @since 1.21
-     */
-    @CheckForNull
-    @Exported(visibility=9)
-    public String getRunId() {
-        return runId;
-    }
-
-    /**
      * The possibly-null {@link FlowNode#id} this suite was generated in.
      *
-     * @since 1.21
+     * @since 1.22
      */
     @Exported(visibility=9)
     @CheckForNull
@@ -371,7 +331,7 @@ public final class SuiteResult implements Serializable {
     /**
      * The possibly-empty list of {@link FlowNode#id}s for enclosing blocks within which this suite was generated.
      *
-     * @since 1.21
+     * @since 1.22
      */
     @Exported(visibility=9)
     @Nonnull
@@ -386,7 +346,7 @@ public final class SuiteResult implements Serializable {
     /**
      * The possibly-empty list of display names of enclosing blocks within which this suite was generated.
      *
-     * @since 1.21
+     * @since 1.22
      */
     @Exported(visibility=9)
     @Nonnull

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
@@ -5,7 +5,7 @@ import hudson.Launcher;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import hudson.tasks.test.PipelineArgs;
+import hudson.tasks.test.PipelineTestDetails;
 import hudson.tasks.junit.JUnitResultArchiver;
 import hudson.tasks.junit.TestResultAction;
 import hudson.tasks.junit.TestResultSummary;
@@ -43,11 +43,11 @@ public class JUnitResultsStepExecution extends SynchronousNonBlockingStepExecuti
 
         List<FlowNode> enclosingBlocks = getEnclosingStagesAndParallels(node);
 
-        PipelineArgs pipelineArgs = new PipelineArgs();
-        pipelineArgs.setNodeId(nodeId);
-        pipelineArgs.setEnclosingBlocks(getEnclosingBlockIds(enclosingBlocks));
-        pipelineArgs.setEnclosingBlockNames(getEnclosingBlockNames(enclosingBlocks));
-        TestResultAction testResultAction = JUnitResultArchiver.parseAndAttach(step, pipelineArgs, run, workspace, launcher, listener);
+        PipelineTestDetails pipelineTestDetails = new PipelineTestDetails();
+        pipelineTestDetails.setNodeId(nodeId);
+        pipelineTestDetails.setEnclosingBlocks(getEnclosingBlockIds(enclosingBlocks));
+        pipelineTestDetails.setEnclosingBlockNames(getEnclosingBlockNames(enclosingBlocks));
+        TestResultAction testResultAction = JUnitResultArchiver.parseAndAttach(step, pipelineTestDetails, run, workspace, launcher, listener);
 
         if (testResultAction != null) {
             // TODO: Once JENKINS-43995 lands, update this to set the step status instead of the entire build.

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
@@ -11,6 +11,7 @@ import hudson.tasks.junit.JUnitResultArchiver;
 import hudson.tasks.junit.TestResultAction;
 import hudson.tasks.junit.TestResultSummary;
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
+import org.jenkinsci.plugins.workflow.actions.StageAction;
 import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
@@ -92,10 +93,11 @@ public class JUnitResultsStepExecution extends SynchronousNonBlockingStepExecuti
         List<String> names = new ArrayList<>();
         for (FlowNode n : nodes) {
             ThreadNameAction threadNameAction = n.getAction(ThreadNameAction.class);
-            if (n.getAction(LabelAction.class) != null && threadNameAction != null) {
+            StageAction stageAction = n.getAction(StageAction.class);
+            if (threadNameAction != null) {
                 names.add(threadNameAction.getThreadName());
-            } else {
-                names.add(n.getDisplayName());
+            } else if (stageAction != null) {
+                names.add(stageAction.getStageName());
             }
         }
         return names;

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
@@ -42,15 +42,17 @@ public class JUnitResultsStepExecution extends SynchronousNonBlockingStepExecuti
 
         String nodeId = node.getId();
 
-        TestResultAction testResultAction = JUnitResultArchiver.parseAndAttach(step, nodeId, getEnclosingStagesAndParallels(node),
-                run, workspace, launcher, listener);
+        List<FlowNode> enclosingBlocks = getEnclosingStagesAndParallels(node);
+
+        TestResultAction testResultAction = JUnitResultArchiver.parseAndAttach(step, nodeId, getEnclosingBlockIds(enclosingBlocks),
+                getEnclosingBlockNames(enclosingBlocks), run, workspace, launcher, listener);
 
         if (testResultAction != null) {
             // TODO: Once JENKINS-43995 lands, update this to set the step status instead of the entire build.
             if (testResultAction.getResult().getFailCount() > 0) {
                 getContext().setResult(Result.UNSTABLE);
             }
-            return new TestResultSummary(testResultAction.getResult().getResultByRunAndNode(run.getExternalizableId(), nodeId));
+            return new TestResultSummary(testResultAction.getResult().getResultByNode(nodeId));
         }
 
         return new TestResultSummary();
@@ -59,21 +61,44 @@ public class JUnitResultsStepExecution extends SynchronousNonBlockingStepExecuti
     /**
      * Get the stage and parallel branch start node IDs (not the body nodes) for this node, innermost first.
      * @param node A flownode.
-     * @return A nonnull, possibly empty list of stage/parallel branch start node IDs, innermost first.
+     * @return A nonnull, possibly empty list of stage/parallel branch start nodes, innermost first.
      */
     @Nonnull
-    public static List<String> getEnclosingStagesAndParallels(FlowNode node) {
-        List<String> enclosingBlocks = new ArrayList<>();
+    public static List<FlowNode> getEnclosingStagesAndParallels(FlowNode node) {
+        List<FlowNode> enclosingBlocks = new ArrayList<>();
         for (FlowNode enclosing : node.getEnclosingBlocks()) {
             if (enclosing != null && enclosing.getAction(LabelAction.class) != null) {
                 if ((enclosing instanceof StepStartNode && ((StepStartNode) enclosing).getDescriptor() instanceof StageStep.DescriptorImpl) ||
                         (enclosing.getAction(ThreadNameAction.class) != null)) {
-                    enclosingBlocks.add(enclosing.getId());
+                    enclosingBlocks.add(enclosing);
                 }
             }
         }
 
         return enclosingBlocks;
+    }
+
+    @Nonnull
+    public static List<String> getEnclosingBlockIds(@Nonnull List<FlowNode> nodes) {
+        List<String> ids = new ArrayList<>();
+        for (FlowNode n : nodes) {
+            ids.add(n.getId());
+        }
+        return ids;
+    }
+
+    @Nonnull
+    public static List<String> getEnclosingBlockNames(@Nonnull List<FlowNode> nodes) {
+        List<String> names = new ArrayList<>();
+        for (FlowNode n : nodes) {
+            ThreadNameAction threadNameAction = n.getAction(ThreadNameAction.class);
+            if (n.getAction(LabelAction.class) != null && threadNameAction != null) {
+                names.add(threadNameAction.getThreadName());
+            } else {
+                names.add(n.getDisplayName());
+            }
+        }
+        return names;
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/tasks/test/PipelineArgs.java
+++ b/src/main/java/hudson/tasks/test/PipelineArgs.java
@@ -1,0 +1,42 @@
+package hudson.tasks.test;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builder class for recording additional Pipeline-related arguments needed for test parsing and test results.
+ */
+public class PipelineArgs {
+    private String nodeId;
+    private List<String> enclosingBlocks = new ArrayList<>();
+    private List<String> enclosingBlockNames = new ArrayList<>();
+
+    @CheckForNull
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public void setNodeId(@Nonnull String nodeId) {
+        this.nodeId = nodeId;
+    }
+
+    @Nonnull
+    public List<String> getEnclosingBlocks() {
+        return enclosingBlocks;
+    }
+
+    public void setEnclosingBlocks(@Nonnull List<String> enclosingBlocks) {
+        this.enclosingBlocks.addAll(enclosingBlocks);
+    }
+
+    @Nonnull
+    public List<String> getEnclosingBlockNames() {
+        return enclosingBlockNames;
+    }
+
+    public void setEnclosingBlockNames(@Nonnull List<String> enclosingBlockNames) {
+        this.enclosingBlockNames.addAll(enclosingBlockNames);
+    }
+}

--- a/src/main/java/hudson/tasks/test/PipelineArgs.java
+++ b/src/main/java/hudson/tasks/test/PipelineArgs.java
@@ -2,13 +2,14 @@ package hudson.tasks.test;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Builder class for recording additional Pipeline-related arguments needed for test parsing and test results.
  */
-public class PipelineArgs {
+public class PipelineArgs implements Serializable {
     private String nodeId;
     private List<String> enclosingBlocks = new ArrayList<>();
     private List<String> enclosingBlockNames = new ArrayList<>();
@@ -39,4 +40,6 @@ public class PipelineArgs {
     public void setEnclosingBlockNames(@Nonnull List<String> enclosingBlockNames) {
         this.enclosingBlockNames.addAll(enclosingBlockNames);
     }
+
+    private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/hudson/tasks/test/PipelineTestDetails.java
+++ b/src/main/java/hudson/tasks/test/PipelineTestDetails.java
@@ -9,7 +9,7 @@ import java.util.List;
 /**
  * Builder class for recording additional Pipeline-related arguments needed for test parsing and test results.
  */
-public class PipelineArgs implements Serializable {
+public class PipelineTestDetails implements Serializable {
     private String nodeId;
     private List<String> enclosingBlocks = new ArrayList<>();
     private List<String> enclosingBlockNames = new ArrayList<>();

--- a/src/main/java/hudson/tasks/test/TestResultParser.java
+++ b/src/main/java/hudson/tasks/test/TestResultParser.java
@@ -93,7 +93,7 @@ public abstract class TestResultParser implements ExtensionPoint {
                                   Run<?,?> run, @Nonnull FilePath workspace, Launcher launcher,
                                   TaskListener listener)
             throws InterruptedException, IOException {
-        return parseResult(testResultLocations, run, null, null, workspace, launcher, listener);
+        return parseResult(testResultLocations, run, null, null, null, workspace, launcher, listener);
     }
 
     /**
@@ -122,6 +122,7 @@ public abstract class TestResultParser implements ExtensionPoint {
      * @param nodeId
      *      Possibly null FlowNode ID for the step where these tests were parsed.
      * @param enclosingBlocks Optional, possibly null list of enclosing {@link FlowNode#getId()}
+     * @param enclosingBlockNames Optional, possibly null list of enclosing block names
      * @param workspace the workspace in which tests can be found
      * @param launcher
      *      Can be used to fork processes on the machine where the build is running. Never null.
@@ -139,11 +140,11 @@ public abstract class TestResultParser implements ExtensionPoint {
      * @throws AbortException
      *      If you encounter an error that you handled gracefully, throw this exception and Hudson
      *      will not show a stack trace.
-     * @since 1.21
+     * @since 1.22
      */
     public TestResult parseResult(String testResultLocations,
-                                  Run<?,?> run, String nodeId, List<String> enclosingBlocks, @Nonnull FilePath workspace,
-                                  Launcher launcher, TaskListener listener)
+                                  Run<?,?> run, String nodeId, List<String> enclosingBlocks, List<String> enclosingBlockNames,
+                                  @Nonnull FilePath workspace, Launcher launcher, TaskListener listener)
             throws InterruptedException, IOException {
         if (run instanceof AbstractBuild) {
             return parse(testResultLocations, (AbstractBuild) run, launcher, listener);

--- a/src/main/java/hudson/tasks/test/TestResultParser.java
+++ b/src/main/java/hudson/tasks/test/TestResultParser.java
@@ -91,7 +91,7 @@ public abstract class TestResultParser implements ExtensionPoint {
                                   Run<?,?> run, @Nonnull FilePath workspace, Launcher launcher,
                                   TaskListener listener)
             throws InterruptedException, IOException {
-        return parseResult(testResultLocations, run, new PipelineArgs(), workspace, launcher, listener);
+        return parseResult(testResultLocations, run, null, workspace, launcher, listener);
     }
 
     /**
@@ -117,7 +117,7 @@ public abstract class TestResultParser implements ExtensionPoint {
      *      specifies the locations of the test result files. Never null.
      * @param run
      *      Build for which these tests are parsed. Never null.
-     * @param pipelineArgs A non-null {@link PipelineArgs} instance containing Pipeline-related additional arguments.
+     * @param pipelineTestDetails A {@link PipelineTestDetails} instance containing Pipeline-related additional arguments.
      * @param workspace the workspace in which tests can be found
      * @param launcher
      *      Can be used to fork processes on the machine where the build is running. Never null.
@@ -138,7 +138,7 @@ public abstract class TestResultParser implements ExtensionPoint {
      * @since 1.22
      */
     public TestResult parseResult(String testResultLocations,
-                                  Run<?,?> run, @Nonnull PipelineArgs pipelineArgs,
+                                  Run<?,?> run, PipelineTestDetails pipelineTestDetails,
                                   @Nonnull FilePath workspace, Launcher launcher, TaskListener listener)
             throws InterruptedException, IOException {
         if (run instanceof AbstractBuild) {

--- a/src/main/java/hudson/tasks/test/TestResultParser.java
+++ b/src/main/java/hudson/tasks/test/TestResultParser.java
@@ -33,10 +33,8 @@ import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.Publisher;
-import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
 import java.io.IOException;
-import java.util.List;
 import javax.annotation.Nonnull;
 
 /**
@@ -93,7 +91,7 @@ public abstract class TestResultParser implements ExtensionPoint {
                                   Run<?,?> run, @Nonnull FilePath workspace, Launcher launcher,
                                   TaskListener listener)
             throws InterruptedException, IOException {
-        return parseResult(testResultLocations, run, null, null, null, workspace, launcher, listener);
+        return parseResult(testResultLocations, run, new PipelineArgs(), workspace, launcher, listener);
     }
 
     /**
@@ -119,10 +117,7 @@ public abstract class TestResultParser implements ExtensionPoint {
      *      specifies the locations of the test result files. Never null.
      * @param run
      *      Build for which these tests are parsed. Never null.
-     * @param nodeId
-     *      Possibly null FlowNode ID for the step where these tests were parsed.
-     * @param enclosingBlocks Optional, possibly null list of enclosing {@link FlowNode#getId()}
-     * @param enclosingBlockNames Optional, possibly null list of enclosing block names
+     * @param pipelineArgs A non-null {@link PipelineArgs} instance containing Pipeline-related additional arguments.
      * @param workspace the workspace in which tests can be found
      * @param launcher
      *      Can be used to fork processes on the machine where the build is running. Never null.
@@ -143,7 +138,7 @@ public abstract class TestResultParser implements ExtensionPoint {
      * @since 1.22
      */
     public TestResult parseResult(String testResultLocations,
-                                  Run<?,?> run, String nodeId, List<String> enclosingBlocks, List<String> enclosingBlockNames,
+                                  Run<?,?> run, @Nonnull PipelineArgs pipelineArgs,
                                   @Nonnull FilePath workspace, Launcher launcher, TaskListener listener)
             throws InterruptedException, IOException {
         if (run instanceof AbstractBuild) {

--- a/src/test/java/hudson/tasks/junit/JUnitParserTest.java
+++ b/src/test/java/hudson/tasks/junit/JUnitParserTest.java
@@ -30,6 +30,7 @@ import hudson.model.BuildListener;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.tasks.Builder;
+import hudson.tasks.test.PipelineArgs;
 import hudson.tasks.test.TestResult;
 import org.junit.Before;
 import org.junit.Rule;
@@ -75,8 +76,8 @@ public class JUnitParserTest {
             }
 
             System.out.println("...touched everything");
-            hudson.tasks.junit.TestResult result = (new JUnitParser()).parseResult(testResultLocation, build, null,
-                    null, null, build.getWorkspace(), launcher, listener);
+            hudson.tasks.junit.TestResult result = (new JUnitParser()).parseResult(testResultLocation, build,
+                    new PipelineArgs(), build.getWorkspace(), launcher, listener);
 
             System.out.println("back from parse");
             assertNotNull("we should have a non-null result", result);

--- a/src/test/java/hudson/tasks/junit/JUnitParserTest.java
+++ b/src/test/java/hudson/tasks/junit/JUnitParserTest.java
@@ -76,7 +76,7 @@ public class JUnitParserTest {
 
             System.out.println("...touched everything");
             hudson.tasks.junit.TestResult result = (new JUnitParser()).parseResult(testResultLocation, build, null,
-                    null, build.getWorkspace(), launcher, listener);
+                    null, null, build.getWorkspace(), launcher, listener);
 
             System.out.println("back from parse");
             assertNotNull("we should have a non-null result", result);

--- a/src/test/java/hudson/tasks/junit/JUnitParserTest.java
+++ b/src/test/java/hudson/tasks/junit/JUnitParserTest.java
@@ -30,7 +30,7 @@ import hudson.model.BuildListener;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.tasks.Builder;
-import hudson.tasks.test.PipelineArgs;
+import hudson.tasks.test.PipelineTestDetails;
 import hudson.tasks.test.TestResult;
 import org.junit.Before;
 import org.junit.Rule;
@@ -77,7 +77,7 @@ public class JUnitParserTest {
 
             System.out.println("...touched everything");
             hudson.tasks.junit.TestResult result = (new JUnitParser()).parseResult(testResultLocation, build,
-                    new PipelineArgs(), build.getWorkspace(), launcher, listener);
+                    null, build.getWorkspace(), launcher, listener);
 
             System.out.println("back from parse");
             assertNotNull("we should have a non-null result", result);

--- a/src/test/java/hudson/tasks/junit/JUnitResultArchiverTest.java
+++ b/src/test/java/hudson/tasks/junit/JUnitResultArchiverTest.java
@@ -138,7 +138,6 @@ public class JUnitResultArchiverTest {
         assertEquals("should have 132 total tests", 132, result.getTotalCount());
 
         for (SuiteResult suite : result.getSuites()) {
-            assertNull("No runId should be present on the SuiteResult", suite.getRunId());
             assertNull("No nodeId should be present on the SuiteResult", suite.getNodeId());
         }
     }

--- a/src/test/java/hudson/tasks/junit/SuiteResult2Test.java
+++ b/src/test/java/hudson/tasks/junit/SuiteResult2Test.java
@@ -33,7 +33,7 @@ import java.util.List;
 import static org.jvnet.hudson.test.MemoryAssert.*;
 import static org.junit.Assert.*;
 
-import hudson.tasks.test.PipelineArgs;
+import hudson.tasks.test.PipelineTestDetails;
 import org.junit.Test;
 
 public class SuiteResult2Test {
@@ -99,7 +99,7 @@ public class SuiteResult2Test {
     }
 
     private SuiteResult parseOne(File file) throws Exception {
-        List<SuiteResult> results = SuiteResult.parse(file, false, new PipelineArgs());
+        List<SuiteResult> results = SuiteResult.parse(file, false, null);
         assertEquals(1,results.size());
         return results.get(0);
     }

--- a/src/test/java/hudson/tasks/junit/SuiteResult2Test.java
+++ b/src/test/java/hudson/tasks/junit/SuiteResult2Test.java
@@ -32,6 +32,8 @@ import java.io.Writer;
 import java.util.List;
 import static org.jvnet.hudson.test.MemoryAssert.*;
 import static org.junit.Assert.*;
+
+import hudson.tasks.test.PipelineArgs;
 import org.junit.Test;
 
 public class SuiteResult2Test {
@@ -97,7 +99,7 @@ public class SuiteResult2Test {
     }
 
     private SuiteResult parseOne(File file) throws Exception {
-        List<SuiteResult> results = SuiteResult.parse(file, false, null, null, null);
+        List<SuiteResult> results = SuiteResult.parse(file, false, new PipelineArgs());
         assertEquals(1,results.size());
         return results.get(0);
     }

--- a/src/test/java/hudson/tasks/junit/SuiteResultTest.java
+++ b/src/test/java/hudson/tasks/junit/SuiteResultTest.java
@@ -30,7 +30,7 @@ import java.net.URISyntaxException;
 
 import hudson.XmlFile;
 
-import hudson.tasks.test.PipelineArgs;
+import hudson.tasks.test.PipelineTestDetails;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -55,13 +55,13 @@ public class SuiteResultTest {
     }
 
     private SuiteResult parseOne(File file) throws Exception {
-        List<SuiteResult> results = SuiteResult.parse(file, false, new PipelineArgs());
+        List<SuiteResult> results = SuiteResult.parse(file, false, null);
         assertEquals(1,results.size());
         return results.get(0);
     }
     
     private List<SuiteResult> parseSuites(File file) throws Exception {
-        return SuiteResult.parse(file, false, new PipelineArgs());
+        return SuiteResult.parse(file, false, null);
     }
 
     @Issue("JENKINS-1233")
@@ -102,7 +102,7 @@ public class SuiteResultTest {
     @Issue("JENKINS-1472")
     @Test
     public void testIssue1472() throws Exception {
-        List<SuiteResult> results = SuiteResult.parse(getDataFile("junit-report-1472.xml"), false, new PipelineArgs());
+        List<SuiteResult> results = SuiteResult.parse(getDataFile("junit-report-1472.xml"), false, null);
         assertTrue(results.size()>20); // lots of data here
 
         SuiteResult sr0 = results.get(0);

--- a/src/test/java/hudson/tasks/junit/SuiteResultTest.java
+++ b/src/test/java/hudson/tasks/junit/SuiteResultTest.java
@@ -30,6 +30,7 @@ import java.net.URISyntaxException;
 
 import hudson.XmlFile;
 
+import hudson.tasks.test.PipelineArgs;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -54,13 +55,13 @@ public class SuiteResultTest {
     }
 
     private SuiteResult parseOne(File file) throws Exception {
-        List<SuiteResult> results = SuiteResult.parse(file, false, null, null, null);
+        List<SuiteResult> results = SuiteResult.parse(file, false, new PipelineArgs());
         assertEquals(1,results.size());
         return results.get(0);
     }
     
     private List<SuiteResult> parseSuites(File file) throws Exception {
-        return SuiteResult.parse(file, false, null, null, null);
+        return SuiteResult.parse(file, false, new PipelineArgs());
     }
 
     @Issue("JENKINS-1233")
@@ -101,7 +102,7 @@ public class SuiteResultTest {
     @Issue("JENKINS-1472")
     @Test
     public void testIssue1472() throws Exception {
-        List<SuiteResult> results = SuiteResult.parse(getDataFile("junit-report-1472.xml"), false, null, null, null);
+        List<SuiteResult> results = SuiteResult.parse(getDataFile("junit-report-1472.xml"), false, new PipelineArgs());
         assertTrue(results.size()>20); // lots of data here
 
         SuiteResult sr0 = results.get(0);

--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -24,6 +24,7 @@
 package hudson.tasks.junit;
 
 import hudson.XmlFile;
+import hudson.tasks.test.PipelineArgs;
 import hudson.util.HeapSpaceStringConverter;
 import hudson.util.XStream2;
 
@@ -58,7 +59,7 @@ public class TestResultTest {
     @Test
     public void testIpsTests() throws Exception {
         TestResult testResult = new TestResult();
-        testResult.parse(getDataFile("eclipse-plugin-test-report.xml"), null, null, null);
+        testResult.parse(getDataFile("eclipse-plugin-test-report.xml"), new PipelineArgs());
 
         Collection<SuiteResult> suites = testResult.getSuites();
         assertEquals("Wrong number of test suites", 16, suites.size());
@@ -112,9 +113,9 @@ public class TestResultTest {
     @Test
     public void testDuplicateTestMethods() throws IOException, URISyntaxException {
         TestResult testResult = new TestResult();
-        testResult.parse(getDataFile("JENKINS-13214/27449.xml"), null, null, null);
-        testResult.parse(getDataFile("JENKINS-13214/27540.xml"), null, null, null);
-        testResult.parse(getDataFile("JENKINS-13214/29734.xml"), null, null, null);
+        testResult.parse(getDataFile("JENKINS-13214/27449.xml"), new PipelineArgs());
+        testResult.parse(getDataFile("JENKINS-13214/27540.xml"), new PipelineArgs());
+        testResult.parse(getDataFile("JENKINS-13214/29734.xml"), new PipelineArgs());
         testResult.tally();
         
         assertEquals("Wrong number of test suites", 1, testResult.getSuites().size());
@@ -124,8 +125,8 @@ public class TestResultTest {
     @Bug(12457)
     public void testTestSuiteDistributedOverMultipleFilesIsCountedAsOne() throws IOException, URISyntaxException {
         TestResult testResult = new TestResult();
-        testResult.parse(getDataFile("JENKINS-12457/TestSuite_a1.xml"), null, null, null);
-        testResult.parse(getDataFile("JENKINS-12457/TestSuite_a2.xml"), null, null, null);
+        testResult.parse(getDataFile("JENKINS-12457/TestSuite_a1.xml"), new PipelineArgs());
+        testResult.parse(getDataFile("JENKINS-12457/TestSuite_a2.xml"), new PipelineArgs());
         testResult.tally();
         
         assertEquals("Wrong number of testsuites", 1, testResult.getSuites().size());
@@ -141,8 +142,8 @@ public class TestResultTest {
      */
     public void testDuplicatedTestSuiteIsNotCounted() throws IOException, URISyntaxException {
         TestResult testResult = new TestResult();
-        testResult.parse(getDataFile("JENKINS-12457/TestSuite_b.xml"), null, null, null);
-        testResult.parse(getDataFile("JENKINS-12457/TestSuite_b_duplicate.xml"), null, null, null);
+        testResult.parse(getDataFile("JENKINS-12457/TestSuite_b.xml"), new PipelineArgs());
+        testResult.parse(getDataFile("JENKINS-12457/TestSuite_b_duplicate.xml"), new PipelineArgs());
         testResult.tally();
         
         assertEquals("Wrong number of testsuites", 1, testResult.getSuites().size());
@@ -156,16 +157,16 @@ public class TestResultTest {
         TestResult first = new TestResult();
         TestResult second = new TestResult();
 
-        first.parse(getDataFile("JENKINS-41134/TestSuite_first.xml"), null, null, null);
-        second.parse(getDataFile("JENKINS-41134/TestSuite_second.xml"), null, null, null);
+        first.parse(getDataFile("JENKINS-41134/TestSuite_first.xml"), new PipelineArgs());
+        second.parse(getDataFile("JENKINS-41134/TestSuite_second.xml"), new PipelineArgs());
         assertEquals("Fail count should be 0", 0, first.getFailCount());
         first.merge(second);
         assertEquals("Fail count should now be 1", 1, first.getFailCount());
 
         first = new TestResult();
         second = new TestResult();
-        first.parse(getDataFile("JENKINS-41134/TestSuite_first.xml"), null, null, null);
-        second.parse(getDataFile("JENKINS-41134/TestSuite_second_dup_first.xml"), null, null, null);
+        first.parse(getDataFile("JENKINS-41134/TestSuite_first.xml"), new PipelineArgs());
+        second.parse(getDataFile("JENKINS-41134/TestSuite_second_dup_first.xml"), new PipelineArgs());
         assertEquals("Fail count should be 0", 0, first.getFailCount());
         first.merge(second);
         assertEquals("Fail count should now be 1", 1, first.getFailCount());

--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -24,7 +24,7 @@
 package hudson.tasks.junit;
 
 import hudson.XmlFile;
-import hudson.tasks.test.PipelineArgs;
+import hudson.tasks.test.PipelineTestDetails;
 import hudson.util.HeapSpaceStringConverter;
 import hudson.util.XStream2;
 
@@ -59,7 +59,7 @@ public class TestResultTest {
     @Test
     public void testIpsTests() throws Exception {
         TestResult testResult = new TestResult();
-        testResult.parse(getDataFile("eclipse-plugin-test-report.xml"), new PipelineArgs());
+        testResult.parse(getDataFile("eclipse-plugin-test-report.xml"), new PipelineTestDetails());
 
         Collection<SuiteResult> suites = testResult.getSuites();
         assertEquals("Wrong number of test suites", 16, suites.size());
@@ -113,9 +113,9 @@ public class TestResultTest {
     @Test
     public void testDuplicateTestMethods() throws IOException, URISyntaxException {
         TestResult testResult = new TestResult();
-        testResult.parse(getDataFile("JENKINS-13214/27449.xml"), new PipelineArgs());
-        testResult.parse(getDataFile("JENKINS-13214/27540.xml"), new PipelineArgs());
-        testResult.parse(getDataFile("JENKINS-13214/29734.xml"), new PipelineArgs());
+        testResult.parse(getDataFile("JENKINS-13214/27449.xml"), null);
+        testResult.parse(getDataFile("JENKINS-13214/27540.xml"), null);
+        testResult.parse(getDataFile("JENKINS-13214/29734.xml"), null);
         testResult.tally();
         
         assertEquals("Wrong number of test suites", 1, testResult.getSuites().size());
@@ -125,8 +125,8 @@ public class TestResultTest {
     @Bug(12457)
     public void testTestSuiteDistributedOverMultipleFilesIsCountedAsOne() throws IOException, URISyntaxException {
         TestResult testResult = new TestResult();
-        testResult.parse(getDataFile("JENKINS-12457/TestSuite_a1.xml"), new PipelineArgs());
-        testResult.parse(getDataFile("JENKINS-12457/TestSuite_a2.xml"), new PipelineArgs());
+        testResult.parse(getDataFile("JENKINS-12457/TestSuite_a1.xml"), null);
+        testResult.parse(getDataFile("JENKINS-12457/TestSuite_a2.xml"), null);
         testResult.tally();
         
         assertEquals("Wrong number of testsuites", 1, testResult.getSuites().size());
@@ -142,8 +142,8 @@ public class TestResultTest {
      */
     public void testDuplicatedTestSuiteIsNotCounted() throws IOException, URISyntaxException {
         TestResult testResult = new TestResult();
-        testResult.parse(getDataFile("JENKINS-12457/TestSuite_b.xml"), new PipelineArgs());
-        testResult.parse(getDataFile("JENKINS-12457/TestSuite_b_duplicate.xml"), new PipelineArgs());
+        testResult.parse(getDataFile("JENKINS-12457/TestSuite_b.xml"), null);
+        testResult.parse(getDataFile("JENKINS-12457/TestSuite_b_duplicate.xml"), null);
         testResult.tally();
         
         assertEquals("Wrong number of testsuites", 1, testResult.getSuites().size());
@@ -157,16 +157,16 @@ public class TestResultTest {
         TestResult first = new TestResult();
         TestResult second = new TestResult();
 
-        first.parse(getDataFile("JENKINS-41134/TestSuite_first.xml"), new PipelineArgs());
-        second.parse(getDataFile("JENKINS-41134/TestSuite_second.xml"), new PipelineArgs());
+        first.parse(getDataFile("JENKINS-41134/TestSuite_first.xml"), null);
+        second.parse(getDataFile("JENKINS-41134/TestSuite_second.xml"), null);
         assertEquals("Fail count should be 0", 0, first.getFailCount());
         first.merge(second);
         assertEquals("Fail count should now be 1", 1, first.getFailCount());
 
         first = new TestResult();
         second = new TestResult();
-        first.parse(getDataFile("JENKINS-41134/TestSuite_first.xml"), new PipelineArgs());
-        second.parse(getDataFile("JENKINS-41134/TestSuite_second_dup_first.xml"), new PipelineArgs());
+        first.parse(getDataFile("JENKINS-41134/TestSuite_first.xml"), null);
+        second.parse(getDataFile("JENKINS-41134/TestSuite_second_dup_first.xml"), null);
         assertEquals("Fail count should be 0", 0, first.getFailCount());
         first.merge(second);
         assertEquals("Fail count should now be 1", 1, first.getFailCount());

--- a/src/test/java/hudson/tasks/junit/pipeline/JUnitResultsStepTest.java
+++ b/src/test/java/hudson/tasks/junit/pipeline/JUnitResultsStepTest.java
@@ -340,7 +340,7 @@ public class JUnitResultsStepTest {
         TestResultAction action = run.getAction(TestResultAction.class);
         assertNotNull(action);
 
-        TestResult aResult = action.getResult().getResultForPipelineBlock(run.getExternalizableId(), blockNode.getId());
+        TestResult aResult = action.getResult().getResultForPipelineBlock(blockNode.getId());
         assertNotNull(aResult);
 
         assertEquals(suiteCount, aResult.getSuites().size());
@@ -349,11 +349,11 @@ public class JUnitResultsStepTest {
             assertEquals(failCount, aResult.getFailCount());
         }
 
-        PipelineBlockWithTests aBlock = action.getResult().getPipelineBlockWithTests(run.getExternalizableId(), blockNode.getId());
+        PipelineBlockWithTests aBlock = action.getResult().getPipelineBlockWithTests(blockNode.getId());
 
         assertNotNull(aBlock);
         List<String> aTestNodes = new ArrayList<>(aBlock.nodesWithTests());
-        TestResult aFromNodes = action.getResult().getResultByRunAndNodes(run.getExternalizableId(), aTestNodes);
+        TestResult aFromNodes = action.getResult().getResultByNodes(aTestNodes);
         assertNotNull(aFromNodes);
         assertEquals(aResult.getSuites().size(), aFromNodes.getSuites().size());
         assertEquals(aResult.getFailCount(), aFromNodes.getFailCount());
@@ -367,7 +367,7 @@ public class JUnitResultsStepTest {
         TestResultAction action = run.getAction(TestResultAction.class);
         assertNotNull(action);
 
-        TestResult result = action.getResult().getResultByRunAndNodes(run.getExternalizableId(), Arrays.asList(nodeIds));
+        TestResult result = action.getResult().getResultByNodes(Arrays.asList(nodeIds));
         assertNotNull(result);
         assertEquals(suiteCount, result.getSuites().size());
         assertEquals(testCount, result.getTotalCount());


### PR DESCRIPTION
Yet more for [JENKINS-27395](https://issues.jenkins-ci.org/browse/JENKINS-27395)

On further inspection, I came to the conclusion that since
multiple-runs-per-TestResult was only possible for
`AggregatedTestResultAction`, which doesn't support Pipeline jobs in
the first place, it made more sense to simplify things and get rid of
the run-and-nodes tracking of suites in favor of just nodes.

This also necessitated gathreing the enclosing block names earlier,
but that's probably a good change anyway.

cc @reviewbybees 