### PR TITLE
Prevent unsafe cast to TestResult.

### DIFF
--- a/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
+++ b/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
@@ -249,7 +249,11 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
     }
 
     public TestResult findCorrespondingResult(String id) {
-        return ((TestResult)getResult()).findCorrespondingResult(id);
+        final Object testResult = getResult();
+        if (!(testResult instanceof TestResult)) {
+            return null;
+        }
+        return ((TestResult)testResult).findCorrespondingResult(id);
     }
     
     /**


### PR DESCRIPTION
There are already null checks in TestResult.getPreviousResult() that calls AbstractRestResultAction.findCorrespondingResult() so presumably it's safe to return null here if the results aren't available.

The jenkins cucumber test result plugin (https://wiki.jenkins.io/display/JENKINS/Cucumber+Test+Result+Plugin) was getting a ClassCastException. This was being caused after having just installed the plugin and trying to call the json api as it was trying to get results from a previous build from before the plugin was installed:

Caused by: java.lang.ClassCastException: hudson.tasks.test.AggregatedTestResultAction$1 cannot be cast to hudson.tasks.test.TestResult
        at hudson.tasks.test.AbstractTestResultAction.findCorrespondingResult(AbstractTestResultAction.java:252)
        at hudson.tasks.test.TestResult.getPreviousResult(TestResult.java:146)
        ... 125 more