### PR TITLE
Allow to show long message for skipped TestCase

### DIFF
--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Daniel Dyer, Seiji Sogabe, Tom Huybrechts, Yahoo!, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -218,7 +218,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         this.skipped = false;
         this.skippedMessage = null;
     }
-    
+
     public ClassResult getParent() {
     	return classResult;
     }
@@ -257,6 +257,12 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
 
         if (skippedElement != null) {
             message = skippedElement.attributeValue("message");
+            String longMessage = skippedElement.getText();
+            if (!longMessage.isEmpty()) {
+                message = String.format(
+                    "%s , Full msg: %s", message, longMessage
+                );
+            }
         }
 
         return message;
@@ -355,12 +361,12 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         if(idx<0)       return "(root)";
         else            return className.substring(0,idx);
     }
-    
+
     @Override
     public String getFullName() {
     	return className+'.'+getName();
     }
-    
+
     /**
      * @since 1.515
      */
@@ -399,12 +405,12 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
                 this.failedSince = getRun().getNumber();
             } else {
                 LOGGER.warning("trouble calculating getFailedSince. We've got prev, but no owner.");
-                // failedSince will be 0, which isn't correct. 
+                // failedSince will be 0, which isn't correct.
             }
         }
         return failedSince;
     }
-    
+
     public Run<?,?> getFailedSinceRun() {
     	return getRun().getParent().getBuildByNumber(getFailedSince());
     }
@@ -423,7 +429,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
             return getRun().getNumber()-getFailedSince()+1;
         } else {
             LOGGER.fine("Trying to get age of a CaseResult without an owner");
-            return 0; 
+            return 0;
     }
     }
 
@@ -444,7 +450,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     public String getStdout() {
         if(stdout!=null)    return stdout;
         SuiteResult sr = getSuiteResult();
-        if (sr==null) return "";         
+        if (sr==null) return "";
         return getSuiteResult().getStdout();
     }
 
@@ -469,7 +475,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         if(pr==null)    return null;
         return pr.getCase(getDisplayName());
     }
-    
+
     /**
      * Case results have no children
      * @return null
@@ -552,7 +558,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     public boolean isSkipped() {
         return skipped;
     }
-    
+
     /**
      * @return true if the test was not skipped and did not pass, false otherwise.
      * @since 1.520
@@ -680,7 +686,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     /*package*/ void setClass(ClassResult classResult) {
         this.classResult = classResult;
     }
-    
+
     void replaceParent(SuiteResult parent) {
         this.parent = parent;
     }


### PR DESCRIPTION
When pytest skip test during collection it put long message with all information to data of skipped element. Junit plugin cannot just read message attribute but doesn't write long message. This patch check if it's set, and if so it just extend skippedMessage with this long msg.

Issue: https://issues.jenkins-ci.org/browse/JENKINS-47796

Change-Id: Ieb9bcd8d402ded43472862ff7aaa292d2c973fad