### PR TITLE
Make script-security dependency optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
             <version>1.30</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
There's no scenario I can come up with where the `@Whitelisted` annotation on `TestResultSummary` would be relevant if you don't have `script-security` installed, so let's just make `script-security` optional like all the Pipeline plugins.

cc @reviewbybees 