### PR TITLE
[FIXED JENKINS-48020] Show stage in failed tests, fix warnings

### DIFF
--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -271,6 +271,10 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     }
 
     public String getDisplayName() {
+        return getNameWithEnclosingBlocks(getTransformedTestName());
+    }
+
+    private String getNameWithEnclosingBlocks(String rawName) {
         // Only prepend the enclosing flow node names if there are any and the run this is in has multiple blocks directly containing
         // test results.
         if (!getEnclosingFlowNodeNames().isEmpty()) {
@@ -278,11 +282,11 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
             if (r != null) {
                 TestResultAction action = r.getAction(TestResultAction.class);
                 if (action != null && action.getResult().hasMultipleBlocks()) {
-                    return StringUtils.join(new ReverseListIterator(getEnclosingFlowNodeNames()), " / ") + " / " + getTransformedTestName();
+                    return StringUtils.join(new ReverseListIterator(getEnclosingFlowNodeNames()), " / ") + " / " + rawName;
                 }
             }
         }
-        return getTransformedTestName();
+        return rawName;
     }
 
     /**
@@ -369,7 +373,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
      * @since 1.515
      */
     public String getFullDisplayName() {
-    	return TestNameTransformer.getTransformedName(getFullName());
+    	return getNameWithEnclosingBlocks(TestNameTransformer.getTransformedName(getFullName()));
     }
 
     @Override
@@ -471,7 +475,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         if (parent == null) return null;
         SuiteResult pr = parent.getPreviousResult();
         if(pr==null)    return null;
-        return pr.getCase(getDisplayName());
+        return pr.getCase(getTransformedTestName());
     }
     
     /**

--- a/src/main/java/hudson/tasks/junit/SuiteResult.java
+++ b/src/main/java/hudson/tasks/junit/SuiteResult.java
@@ -130,7 +130,7 @@ public final class SuiteResult implements Serializable {
         if (casesByName == null) {
             casesByName = new HashMap<>();
             for (CaseResult c : cases) {
-                casesByName.put(c.getDisplayName(), c);
+                casesByName.put(c.getTransformedTestName(), c);
             }
         }
         return casesByName;
@@ -276,7 +276,7 @@ public final class SuiteResult implements Serializable {
 
     /*package*/ void addCase(CaseResult cr) {
         cases.add(cr);
-        casesByName().put(cr.getDisplayName(), cr);
+        casesByName().put(cr.getTransformedTestName(), cr);
 
         //if suite time was not specified use sum of the cases' times
         if( !hasTimeAttr() ){


### PR DESCRIPTION
[JENKINS-48020](https://issues.jenkins-ci.org/browse/JENKINS-48020)

First, this changes `CaseResult#getFullDisplayName()` to include
stage/branch names like `CaseResult#getDisplayName()`, so that the
full information will show up in lists of failed tests, for example.

Second, stop using `CaseResult#getDisplayName()` for indexing
`CaseResult`s in `SuiteResult`. That method will spam warnings if
called too early in the run now due to `CaseResult#getRun()` being
called before the `SuiteResult`'s parent is set.

Third, fix `JUnitResultsStepTest#testTrends` to actually test what
it's supposed to, to fail if it doesn't find the expected display
names, to test full display names as well, and to use the same
filename for the test results each time due to one of the stages' test
file not containing an explicit suite name, leading to its suite's
name being set to the filename, breaking `SuiteResult#getPreviousResult()`.

cc @reviewbybees 