### PR TITLE
[FIXED JENKINS-48178] Set run result rather than context result

### DIFF
--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
@@ -50,8 +50,8 @@ public class JUnitResultsStepExecution extends SynchronousNonBlockingStepExecuti
 
         if (testResultAction != null) {
             // TODO: Once JENKINS-43995 lands, update this to set the step status instead of the entire build.
-            if (testResultAction.getResult().getFailCount() > 0) {
-                getContext().setResult(Result.UNSTABLE);
+            if (testResultAction.getResult().getFailCount() > 0 && run != null) {
+                run.setResult(Result.UNSTABLE);
             }
             return new TestResultSummary(testResultAction.getResult().getResultByNode(nodeId));
         }

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
@@ -50,7 +50,7 @@ public class JUnitResultsStepExecution extends SynchronousNonBlockingStepExecuti
 
         if (testResultAction != null) {
             // TODO: Once JENKINS-43995 lands, update this to set the step status instead of the entire build.
-            if (testResultAction.getResult().getFailCount() > 0 && run != null) {
+            if (testResultAction.getResult().getFailCount() > 0) {
                 run.setResult(Result.UNSTABLE);
             }
             return new TestResultSummary(testResultAction.getResult().getResultByNode(nodeId));

--- a/src/test/java/hudson/tasks/junit/pipeline/JUnitResultsStepTest.java
+++ b/src/test/java/hudson/tasks/junit/pipeline/JUnitResultsStepTest.java
@@ -312,7 +312,7 @@ public class JUnitResultsStepTest {
                 "  node {\n" +
                 "    def results = junit(testResults: '*.xml')\n" + // node id 7
                 "    assert results.totalCount == 8\n" +
-                "    assert currentBuild.result == 'SUCCESS'\n" +
+                "    assert currentBuild.result == 'UNSTABLE'\n" +
                 "  }\n" +
                 "}\n", true));
         FilePath ws = rule.jenkins.getWorkspaceFor(j);


### PR DESCRIPTION
[JENKINS-48178](https://issues.jenkins-ci.org/browse/JENKINS-48178)

This fixes currentBuild.result to be UNSTABLE after test failures are
encountered. We'll want to revisit this in the future once we have
more granular stage/step status, but going with
getContext().setResult(...) was, in retrospect, premature optimization.

cc @reviewbybees 