### PR TITLE
[FIXED JENKINS-48196] Remove redundant branch names from case displays

### DIFF
--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
@@ -101,10 +101,14 @@ public class JUnitResultsStepExecution extends SynchronousNonBlockingStepExecuti
     public static List<String> getEnclosingBlockNames(@Nonnull List<FlowNode> nodes) {
         List<String> names = new ArrayList<>();
         for (FlowNode n : nodes) {
-            ThreadNameAction threadNameAction = n.getAction(ThreadNameAction.class);
-            LabelAction labelAction = n.getAction(LabelAction.class);
+            ThreadNameAction threadNameAction = n.getPersistentAction(ThreadNameAction.class);
+            LabelAction labelAction = n.getPersistentAction(LabelAction.class);
             if (threadNameAction != null) {
-                names.add(threadNameAction.getThreadName());
+                // If we're on a parallel branch with the same name as the previous (inner) node, that generally
+                // means we're in a Declarative parallel stages situation, so don't add the redundant branch name.
+                if (names.isEmpty() || !threadNameAction.getThreadName().equals(names.get(names.size()-1))) {
+                    names.add(threadNameAction.getThreadName());
+                }
             } else if (labelAction != null) {
                 names.add(labelAction.getDisplayName());
             }


### PR DESCRIPTION
[JENKINS-48196](https://issues.jenkins-ci.org/browse/JENKINS-48196)

If we've got a suite with a stage inside a parallel branch where the
stage and parallel branch have the same name, we should only include
that name once in the suite/case/etc display name - it's redundant to
display it twice.

There is a potential gotcha here if you've got multiple stages inside
a branch and one of those stages has the same name as the branch, but
I think that's an edge case we can live with for now.

cc @reviewbybees 