### PR TITLE
[FIXED JENKINS-48372] Allow ignoring enclosing nodes for results.

### DIFF
--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -815,7 +815,7 @@ public final class TestResult extends MetaTabulatedResult {
         if (block != null) {
             return (TestResult)blockToTestResult(block, this);
         } else {
-            return this;
+            return new TestResult();
         }
     }
 

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStep.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStep.java
@@ -53,6 +53,11 @@ public class JUnitResultsStep extends Step implements JUnitTask {
      */
     private boolean allowEmptyResults;
 
+    /**
+     * Optional value for number of enclosing nodes (from inside) to ignore. Defaults to 0.
+     */
+    private int ignoreEnclosingDepth;
+
     @DataBoundConstructor
     public JUnitResultsStep(String testResults) {
         this.testResults = testResults;
@@ -119,6 +124,21 @@ public class JUnitResultsStep extends Step implements JUnitTask {
         this.allowEmptyResults = allowEmptyResults;
     }
 
+    /**
+     * @return The number of enclosing nodes (from the inside) to ignore. Defaults to 0.
+     */
+    public int getIgnoreEnclosingDepth() {
+        // Just to be safe, return 0 for any value <0.
+        return ignoreEnclosingDepth < 0 ? 0 : ignoreEnclosingDepth;
+    }
+
+    /**
+     * @param ignoreEnclosingDepth The number of enclosing nodes (from the inside) to ignore. Defaults to 0.
+     */
+    @DataBoundSetter public final void setIgnoreEnclosingDepth(int ignoreEnclosingDepth) {
+        this.ignoreEnclosingDepth = ignoreEnclosingDepth;
+    }
+
     @Override
     public StepExecution start(StepContext context) throws Exception {
         return new JUnitResultsStepExecution(this, context);
@@ -150,6 +170,14 @@ public class JUnitResultsStep extends Step implements JUnitTask {
                     5,
                     (int) (100.0 - Math.max(0.0, Math.min(100.0, 5 * value)))
             ));
+        }
+
+        public FormValidation doCheckIgnoreEnclosingDepth(@QueryParameter int value) {
+            if (value < 0) {
+                return FormValidation.error(Messages.JUnitResultsStep_IgnoreEnclosingDepthLessThanZero());
+            } else {
+                return FormValidation.ok();
+            }
         }
 
     }

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
@@ -40,7 +40,7 @@ public class JUnitResultsStepExecution extends SynchronousNonBlockingStepExecuti
 
         String nodeId = node.getId();
 
-        List<FlowNode> enclosingBlocks = getEnclosingStagesAndParallels(node);
+        List<FlowNode> enclosingBlocks = getEnclosingStagesAndParallels(node, step.getIgnoreEnclosingDepth());
 
         PipelineTestDetails pipelineTestDetails = new PipelineTestDetails();
         pipelineTestDetails.setNodeId(nodeId);
@@ -59,13 +59,19 @@ public class JUnitResultsStepExecution extends SynchronousNonBlockingStepExecuti
         return new TestResultSummary();
     }
 
+    @Nonnull
+    public static List<FlowNode> getEnclosingStagesAndParallels(FlowNode node) {
+        return getEnclosingStagesAndParallels(node, 0);
+    }
+
     /**
      * Get the stage and parallel branch start node IDs (not the body nodes) for this node, innermost first.
      * @param node A flownode.
+     * @param ignoreDepth optional number of enclosing nodes, from inside, to ignore.
      * @return A nonnull, possibly empty list of stage/parallel branch start nodes, innermost first.
      */
     @Nonnull
-    public static List<FlowNode> getEnclosingStagesAndParallels(FlowNode node) {
+    public static List<FlowNode> getEnclosingStagesAndParallels(FlowNode node, int ignoreDepth) {
         List<FlowNode> enclosingBlocks = new ArrayList<>();
         for (FlowNode enclosing : node.getEnclosingBlocks()) {
             if (enclosing != null && enclosing.getAction(LabelAction.class) != null) {
@@ -76,7 +82,7 @@ public class JUnitResultsStepExecution extends SynchronousNonBlockingStepExecuti
             }
         }
 
-        return enclosingBlocks;
+        return enclosingBlocks.subList(ignoreDepth, enclosingBlocks.size());
     }
 
     private static boolean isStageNode(@Nonnull FlowNode node) {

--- a/src/main/resources/hudson/tasks/junit/Messages.properties
+++ b/src/main/resources/hudson/tasks/junit/Messages.properties
@@ -41,3 +41,5 @@ CaseResult.Status.Failed=Failed
 CaseResult.Status.Skipped=Skipped
 CaseResult.Status.Fixed=Fixed
 CaseResult.Status.Regression=Regression
+
+JUnitResultsStep.IgnoreEnclosingDepthLessThanZero=Only values of 0 or greater can be used for ignoreEnclosingDepth.

--- a/src/main/resources/hudson/tasks/junit/pipeline/JUnitResultsStep/config.jelly
+++ b/src/main/resources/hudson/tasks/junit/pipeline/JUnitResultsStep/config.jelly
@@ -27,4 +27,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
     xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <st:include page="config.jelly" class="hudson.tasks.junit.JUnitResultArchiver" />
+    <f:entry title="${%Ignore enclosing stage/branch depth}" field="ignoreEnclosingDepth">
+        <f:number default="0" min="0" step="1"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/tasks/junit/pipeline/JUnitResultsStep/help-ignoreEnclosingDepth.html
+++ b/src/main/resources/hudson/tasks/junit/pipeline/JUnitResultsStep/help-ignoreEnclosingDepth.html
@@ -1,0 +1,36 @@
+<div>
+    Optionally, specify the number of enclosing stages or branches, starting from the innermost stage or branch, to
+    ignore. Defaults to 0, meaning all are included.
+
+    Example:
+    <code>
+        stage('outer stage') {
+          stage('inner stage') {
+            parallel(branchA: {
+                       node {
+                         sh './run_first_set_of_tests.sh`
+                         junit testResults: '**/target/surefire-reports/TEST-*.xml'
+                       }
+                     },
+                     branchB: {
+                       node {
+                         sh './run_second_set_of_tests.sh`
+                         junit testResults: '**/target/surefire-reports/TEST-*.xml', ignoreEnclosingDepth: 1
+                       }
+                     },
+                     branchC: {
+                       node {
+                         sh './run_third_set_of_tests.sh`
+                         junit testResults: '**/target/surefire-reports/TEST-*.xml', ignoreEnclosingDepth: 2
+                       }
+                     })
+          }
+        }
+    </code>
+    Tests in <code>branchA</code>, with no <code>ignoreEnclosingDepth</code> specified, will be listed like
+    <code>outer stage / inner stage / branchA / testName</code>.
+    Tests in <code>branchB</code>, with <code>ignoreEnclosingDepth</code> specified as 1, will be listed like
+    <code>outer stage / inner stage / testName</code>, ignoring their innermost enclosing stage or branch.
+    Tests in <code>branchC</code>, with <code>ignoreEnclosingDepth</code> specified as 2, will be listed like
+    <code>outer stage / testName</code>, ignoring their two innermost enclosing stages or branches.
+</div>


### PR DESCRIPTION
[JENKINS-48372](https://issues.jenkins-ci.org/browse/JENKINS-48372)

If `ignoreEnclosingDepth` is specified, that many enclosing nodes,
starting from the innermost, are ignored when recording test
results. This allows, for example, not recording parallel branches for
use with parallel-test-executor.

cc @reviewbybees 