### PR TITLE
[JENKINS-43995] Set FlowNode status when unstable.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.60.1'], platforms: ['linux']) // Tests need to be refactored to run on Windows
+buildPlugin(platforms: ['linux']) // Tests need to be refactored to run on Windows

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.0</version>
+        <version>3.1</version>
         <relativePath />
     </parent>
     <artifactId>junit</artifactId>
@@ -13,10 +13,10 @@
     <description>Allows JUnit-format test results to be published.</description>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/JUnit+Plugin</url>
     <properties>
-        <jenkins.version>2.7.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.60.3</jenkins.version>
+        <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
-        <workflow-cps.version>2.37</workflow-cps.version>
+        <workflow-cps.version>2.43-20171207.203526-1</workflow-cps.version> <!-- TODO: Switch to release -->
         <workflow-support.version>2.14</workflow-support.version>
     </properties>
     <licenses>
@@ -52,12 +52,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.12</version>
+            <version>2.13</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.22</version>
+            <version>2.25-20171207.185127-2</version> <!-- TODO: Switch to release -->
             <exclusions>
                 <exclusion>
                     <groupId>org.jenkins-ci.plugins</groupId>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.30</version>
+            <version>1.36</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
@@ -12,6 +12,8 @@ import hudson.tasks.test.PipelineTestDetails;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+
+import org.jenkinsci.plugins.workflow.actions.FlowNodeStatusAction;
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
@@ -51,7 +53,8 @@ public class JUnitResultsStepExecution extends SynchronousNonBlockingStepExecuti
 
             if (testResultAction != null) {
                 // TODO: Once JENKINS-43995 lands, update this to set the step status instead of the entire build.
-                if (testResultAction.getResult().getFailCount() > 0) {
+                if (testResultAction.getResult().getResultByNode(nodeId).getFailCount() > 0) {
+                    node.addOrReplaceAction(new FlowNodeStatusAction(Result.UNSTABLE));
                     run.setResult(Result.UNSTABLE);
                 }
                 return new TestResultSummary(testResultAction.getResult().getResultByNode(nodeId));


### PR DESCRIPTION
[JENKINS-43995](https://issues.jenkins-ci.org/browse/JENKINS-43995)

Downstream of https://github.com/jenkinsci/workflow-cps-plugin/pull/192 and https://github.com/jenkinsci/workflow-api-plugin/pull/63

Also tweaked tests to always check against fail count (and verify block status).