### PR TITLE
[JENKINS-30413] Fix test age calculation when same test name exists in different package

### DIFF
--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -20,7 +20,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
- */ 
+ */
 package hudson.tasks.junit;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;

--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -207,9 +207,9 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
      * @param errorStackTrace Error stack trace.
      */
     public CaseResult(SuiteResult parent, String testName, String errorStackTrace) {
-    	this(parent, testName, errorStackTrace, "");
+        this(parent, testName, errorStackTrace, "");
     }
-    
+
     public CaseResult(SuiteResult parent, String testName, String errorStackTrace, String errorDetails) {
         this.className = parent == null ? "unnamed" : parent.getName();
         this.testName = testName;
@@ -222,9 +222,9 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         this.skipped = false;
         this.skippedMessage = null;
     }
-    
+
     public ClassResult getParent() {
-    	return classResult;
+        return classResult;
     }
 
     private static String getError(Element testCase) {
@@ -366,17 +366,17 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         if(idx<0)       return "(root)";
         else            return className.substring(0,idx);
     }
-    
+
     @Override
     public String getFullName() {
-    	return className+'.'+getName();
+        return className+'.'+getName();
     }
-    
+
     /**
      * @since 1.515
      */
     public String getFullDisplayName() {
-    	return getNameWithEnclosingBlocks(TestNameTransformer.getTransformedName(getFullName()));
+        return getNameWithEnclosingBlocks(TestNameTransformer.getTransformedName(getFullName()));
     }
 
     @Override
@@ -421,7 +421,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     }
 
     public Run<?,?> getFailedSinceRun() {
-    	return getRun().getParent().getBuildByNumber(getFailedSince());
+        return getRun().getParent().getBuildByNumber(getFailedSince());
     }
 
     /**
@@ -484,7 +484,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         if(pr==null)    return null;
         return pr.getCase(getTransformedTestName());
     }
-    
+
     /**
      * Case results have no children
      * @return null
@@ -567,7 +567,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     public boolean isSkipped() {
         return skipped;
     }
-    
+
     /**
      * @return true if the test was not skipped and did not pass, false otherwise.
      * @since 1.520
@@ -690,7 +690,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     /*package*/ void setClass(ClassResult classResult) {
         this.classResult = classResult;
     }
-    
+
     void replaceParent(SuiteResult parent) {
         this.parent = parent;
     }

--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -376,7 +376,10 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
      * @since 1.515
      */
     public String getFullDisplayName() {
-        return getNameWithEnclosingBlocks(TestNameTransformer.getTransformedName(getFullName()));
+        return getNameWithEnclosingBlocks(getTransformedFullDisplayName());
+    }
+    public String getTransformedFullDisplayName() {
+        return TestNameTransformer.getTransformedName(getFullName());
     }
 
     @Override
@@ -482,7 +485,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         if (parent == null) return null;
         SuiteResult pr = parent.getPreviousResult();
         if(pr==null)    return null;
-        return pr.getCase(getTransformedTestName());
+        return pr.getCase(getTransformedFullDisplayName());
     }
 
     /**

--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -20,7 +20,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
- */
+ */ 
 package hudson.tasks.junit;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;

--- a/src/main/java/hudson/tasks/junit/SuiteResult.java
+++ b/src/main/java/hudson/tasks/junit/SuiteResult.java
@@ -387,13 +387,13 @@ public final class SuiteResult implements Serializable {
     /**
      * The absolute path to the original test report. OS-dependent.
      *
-     * @return the sabsolute path to the original test report.
+     * @return the absolute path to the original test report.
      */
     public String getFile() {
-		return file;
-	}
+        return file;
+    }
 
-	public hudson.tasks.junit.TestResult getParent() {
+    public hudson.tasks.junit.TestResult getParent() {
         return parent;
     }
 
@@ -435,13 +435,13 @@ public final class SuiteResult implements Serializable {
         return casesByName().get(name);
     }
 
-	public Set<String> getClassNames() {
-		Set<String> result = new HashSet<String>();
-		for (CaseResult c : cases) {
-			result.add(c.getClassName());
-		}
-		return result;
-	}
+    public Set<String> getClassNames() {
+        Set<String> result = new HashSet<String>();
+        for (CaseResult c : cases) {
+            result.add(c.getClassName());
+        }
+        return result;
+    }
 
     /** KLUGE. We have to call this to prevent freeze()
      * from calling c.freeze() on all its children,

--- a/src/main/java/hudson/tasks/junit/SuiteResult.java
+++ b/src/main/java/hudson/tasks/junit/SuiteResult.java
@@ -131,7 +131,7 @@ public final class SuiteResult implements Serializable {
         if (casesByName == null) {
             casesByName = new HashMap<>();
             for (CaseResult c : cases) {
-                casesByName.put(c.getTransformedTestName(), c);
+                casesByName.put(c.getTransformedFullDisplayName(), c);
             }
         }
         return casesByName;
@@ -294,7 +294,7 @@ public final class SuiteResult implements Serializable {
 
     /*package*/ void addCase(CaseResult cr) {
         cases.add(cr);
-        casesByName().put(cr.getTransformedTestName(), cr);
+        casesByName().put(cr.getTransformedFullDisplayName(), cr);
 
         //if suite time was not specified use sum of the cases' times
         if( !hasTimeAttr() ){
@@ -421,18 +421,15 @@ public final class SuiteResult implements Serializable {
     }
 
     /**
-     * Returns the {@link CaseResult} whose {@link CaseResult#getDisplayName()}
+     * Returns the {@link CaseResult} whose {@link CaseResult#getFullDisplayName()}
      * is the same as the given string.
-     * <p>
-     * Note that test name needs not be unique.
-     * </p>
      *
-     * @param name The case name.
+     * @param caseResultFullDisplayName The case FullDisplayName.
      *
      * @return the {@link CaseResult} with the provided name.
      */
-    public CaseResult getCase(String name) {
-        return casesByName().get(name);
+    public CaseResult getCase(String caseResultFullDisplayName) {
+        return casesByName().get(caseResultFullDisplayName);
     }
 
     public Set<String> getClassNames() {

--- a/src/test/java/hudson/tasks/junit/SuiteResultTest.java
+++ b/src/test/java/hudson/tasks/junit/SuiteResultTest.java
@@ -149,7 +149,7 @@ public class SuiteResultTest {
             assertEquals(source.getStderr(), result.getStderr());
             assertEquals(source.getStdout(), result.getStdout());
             assertEquals(source.getCases().size(), result.getCases().size());
-            assertNotNull(result.getCase("testGetBundle"));
+            assertNotNull(result.getCase("test.foo.bar.BundleResolverIntegrationTest.testGetBundle"));
         } finally {
             dest.delete();
 }

--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -231,14 +231,14 @@ public class TestResultTest {
 
         assertEquals("Wrong number of test classes", 2, suite.getClassNames().size());
 
-        CaseResult case1 = suite.getCase("testDrawingSurfaceBitmapIsScreenSize");
+        CaseResult case1 = suite.getCase("org.catrobat.paintroid.test.integration.BitmapIntegrationTest.testDrawingSurfaceBitmapIsScreenSize");
         assertNotNull(case1);
         ClassResult class1 = case1.getParent();
         assertNotNull(class1);
         assertEquals("org.catrobat.paintroid.test.integration.BitmapIntegrationTest", class1.getFullName());
         assertEquals("Wrong duration for test class", 5.0, class1.getDuration(),0.1);
 
-        CaseResult case2 = suite.getCase("testColorPickerDialogSwitchTabsInLandscape");
+        CaseResult case2 = suite.getCase("org.catrobat.paintroid.test.integration.LandscapeTest.testColorPickerDialogSwitchTabsInLandscape");
         assertNotNull(case2);
         ClassResult class2 = case2.getParent();
         assertNotNull(class2);

--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -100,7 +100,7 @@ public class TestResultTest {
 
         SuiteResult failedSuite = result.getSuite("broken");
         assertNotNull(failedSuite);
-        CaseResult failedCase = failedSuite.getCase("becomeUglier");
+        CaseResult failedCase = failedSuite.getCase("breakable.misc.UglyTest.becomeUglier");
         assertNotNull(failedCase);
         assertFalse(failedCase.isSkipped());
         assertFalse(failedCase.isPassed());

--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -255,3 +255,4 @@ public class TestResultTest {
         XSTREAM.registerConverter(new HeapSpaceStringConverter(),100);
     }
 }
+

--- a/src/test/resources/hudson/tasks/junit/JENKINS-30413.xml
+++ b/src/test/resources/hudson/tasks/junit/JENKINS-30413.xml
@@ -1,0 +1,9 @@
+<!-- https://issues.jenkins-ci.org/browse/JENKINS-30413 -->
+<testsuites>
+    <testsuite name="MyTestSuitename" >
+        <testcase classname="test.classname1" name="DuplicateTestName">
+            <failure message="FAILED"/>
+        </testcase>
+        <testcase classname="test.classname2" name="DuplicateTestName"/>
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
[JENKINS-30413](https://issues.jenkins-ci.org/browse/JENKINS-30413)

So far TestCases were identified by their name only and this was causing troubles when different test suites contain identically named TestCases.
This PR solves this by storing TestCases names with unique pattern: <Test.Suite.Name>.TestCaseName>