### PR TITLE
Use Run instead of AbstractBuild in AggregatedTestResultAction

### DIFF
--- a/src/main/java/hudson/tasks/test/AggregatedTestResultAction.java
+++ b/src/main/java/hudson/tasks/test/AggregatedTestResultAction.java
@@ -86,7 +86,7 @@ public abstract class AggregatedTestResultAction extends AbstractTestResultActio
         failCount += child.getFailCount();
         skipCount += child.getSkipCount();
         totalCount += child.getTotalCount();
-        this.children.add(new Child(getChildName(child),child.owner.number));
+        this.children.add(new Child(getChildName(child),child.run.number));
     }
 
     public int getFailCount() {


### PR DESCRIPTION
We're experimenting with aggregating test results from pipelines.
If the child is not an AbstractBuild then child.owner is null while child.run is filled, this fixes that case.