### PR TITLE
Updated to new parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.0</version>
+        <version>3.9</version>
         <relativePath />
     </parent>
     <artifactId>junit</artifactId>

--- a/src/main/java/hudson/tasks/test/AggregatedTestResultPublisher.java
+++ b/src/main/java/hudson/tasks/test/AggregatedTestResultPublisher.java
@@ -354,7 +354,7 @@ public class AggregatedTestResultPublisher extends Recorder {
                 name = name.trim();
                 if (Helper.getActiveInstance().getItem(name,project) == null) {
                     final AbstractProject<?,?> nearest = AbstractProject.findNearest(name);
-                    return FormValidation.error(hudson.tasks.Messages.BuildTrigger_NoSuchProject(name, nearest != null ? nearest.getName() : null));
+                    return FormValidation.error(Messages.BuildTrigger_NoSuchProject(name, nearest != null ? nearest.getName() : null));
                 }
             }
             

--- a/src/main/resources/hudson/tasks/test/Messages.properties
+++ b/src/main/resources/hudson/tasks/test/Messages.properties
@@ -37,3 +37,4 @@ Run.Summary.TestsStartedToFail={0} {0,choice,0#tests|1#test|1<tests}  started to
 Run.Summary.MoreTestsFailing={0} more {0,choice,0#tests are|1#test is|1<tests are} failing (total {1})
 Run.Summary.LessTestsFailing={0} less {0,choice,0#tests are|1#test is|1<tests are} failing (total {1})
 Run.Summary.TestsStillFailing={0} {0,choice,0#tests are|1#test is|1<tests are} still failing
+BuildTrigger.NoSuchProject=No such project \u2018{0}\u2019. Did you mean \u2018{1}\u2019?


### PR DESCRIPTION
`Messages` is `@Restricted(NoExternalUse.class)`. We were just failing to enforce that before.