### PR TITLE
Workaournd to "[JENKINS-6048] Matrix builds fail when Axes values contain invalid characters for Windows directory names"

### DIFF
--- a/src/test/java/hudson/tasks/junit/JUnitResultArchiverTest.java
+++ b/src/test/java/hudson/tasks/junit/JUnitResultArchiverTest.java
@@ -333,6 +333,7 @@ public class JUnitResultArchiverTest {
 
         MatrixProject p = j.jenkins.createProject(MatrixProject.class, "test-" + j.jenkins.getItems().size());
         p.setAxes(new AxisList(new TextAxis("a", "<|#)")));
+        p.setChildCustomWorkspace("axis_sub_folder");
         p.setScm(new SingleFileSCM("report.xml", getClass().getResource("junit-report-20090516.xml")));
         p.getPublishersList().add(new JUnitResultArchiver("report.xml"));
 


### PR DESCRIPTION
By default, for Matrix jobs, jenkins creates a workspace based on axis name and axis value.
In this test axis name is 'a', which is fine, but axis value is '<|#)' which cannot be used as folder name.
Overriding folder name to prevent this issue.