### PR TITLE
[JENKINS-53365] do not exclude transitive plugin deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,12 +58,6 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
             <version>2.22</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>scm-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
[JENKINS-53365](https://issues.jenkins-ci.org/browse/JENKINS-53365)
excluding a transitive plugin dependency is a recipe for disaster for
consumers of the plugin.

It will cause anyone who is depending on this plugin to have to declare
a dependency on the excluded plugin in order for the InjectedTest or
hpi:run to work.

Given that the optionality was removed earlier I am just removing the
exclusion, however I do not fully understand why the optionality on the
workflow-api could not have been retained.

@abayer @jglick @agentgonzo 