### PR TITLE
Ability to pull the skippedMessage from the skipped xml element text when there is no message attribute available.

### DIFF
--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -261,6 +261,9 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
 
         if (skippedElement != null) {
             message = skippedElement.attributeValue("message");
+            if(message == null) {
+                message = skippedElement.getText();
+            }
         }
 
         return message;

--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -116,7 +116,6 @@ public class TestResultTest {
         testResult.parse(getDataFile("SKIPPED_MESSAGE/skippedTestResult.xml"), null);
         List<SuiteResult> suiteResults = new ArrayList<>(testResult.getSuites());
         CaseResult caseResult = suiteResults.get(0).getCases().get(0);
-        assertNotNull(caseResult.getSkippedMessage());
         assertEquals("Given skip This Test........................................................pending\n", caseResult.getSkippedMessage());
     }
 

--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -31,6 +31,8 @@ import hudson.util.XStream2;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -104,7 +106,20 @@ public class TestResultTest {
         assertFalse(failedCase.isPassed());
         assertEquals(5, failedCase.getFailedSince());
     }
-    
+
+    /**
+     * When  skipped test case result does not contain message attribute then the skipped xml element text is retrieved
+     */
+    @Test
+    public void testSkippedMessageIsAddedWhenTheMessageAttributeIsNull() throws IOException, URISyntaxException {
+        TestResult testResult = new TestResult();
+        testResult.parse(getDataFile("SKIPPED_MESSAGE/skippedTestResult.xml"), null);
+        List<SuiteResult> suiteResults = new ArrayList<>(testResult.getSuites());
+        CaseResult caseResult = suiteResults.get(0).getCases().get(0);
+        assertNotNull(caseResult.getSkippedMessage());
+        assertEquals("Given skip This Test........................................................pending\n", caseResult.getSkippedMessage());
+    }
+
     /**
      * When test methods are parametrized, they can occur multiple times in the testresults XMLs.
      * Test that these are counted correctly.

--- a/src/test/resources/hudson/tasks/junit/SKIPPED_MESSAGE/skippedTestResult.xml
+++ b/src/test/resources/hudson/tasks/junit/SKIPPED_MESSAGE/skippedTestResult.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?><testsuite failures="0" name="cucumber.runtime.formatter.JUnitFormatter" skipped="1" tests="1" time="0.172697">
+<testcase classname="Test Sample" name="Test Example" time="0.172697">
+<skipped><![CDATA[Given skip This Test........................................................pending
+]]></skipped>
+</testcase>
+</testsuite>


### PR DESCRIPTION
Example Data:
```
<?xml version="1.0" encoding="UTF-8"?><testsuite failures="0" name="cucumber.runtime.formatter.JUnitFormatter" skipped="1" tests="1" time="0.172697">
<testcase classname="Test Sample" name="Test Example" time="0.172697">
<skipped><![CDATA[Given skip This Test........................................................pending
]]></skipped>
</testcase>
</testsuite>
```