### PR TITLE
Java 11 readiness: build both on JDK8 and JDK11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.60.1'])
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -13,11 +13,11 @@
     <description>Allows JUnit-format test results to be published.</description>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/JUnit+Plugin</url>
     <properties>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.121.1</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <workflow-cps.version>2.37</workflow-cps.version>
-        <workflow-support.version>2.14</workflow-support.version>
+        <workflow-support.version>3.2</workflow-support.version>
     </properties>
     <licenses>
         <license>
@@ -47,27 +47,26 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.7</version>
+            <version>1.17</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.12</version>
+            <version>2.19</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.22</version>
+            <version>2.33</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.30</version>
+            <version>1.57</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.8.5</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.9</version>
+        <version>3.42</version>
         <relativePath />
     </parent>
     <artifactId>junit</artifactId>
@@ -13,8 +13,8 @@
     <description>Allows JUnit-format test results to be published.</description>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/JUnit+Plugin</url>
     <properties>
-        <jenkins.version>2.7.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.60.3</jenkins.version>
+        <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <workflow-cps.version>2.37</workflow-cps.version>
         <workflow-support.version>2.14</workflow-support.version>

--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -459,7 +459,7 @@ public final class TestResult extends MetaTabulatedResult {
     }
     
     /**
-     * Returns <tt>true</tt> if this doesn't have any any test results.
+     * Returns <code>true</code> if this doesn't have any any test results.
      *
      * @return whether this doesn't contain any test results.
      * @since 1.511

--- a/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
+++ b/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
@@ -202,7 +202,7 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
      *
      * <p>
      * If such a concept doesn't make sense for a particular subtype,
-     * return <tt>this</tt>.
+     * return <code>this</code>.
      */
     public abstract Object getResult();
 

--- a/src/main/java/hudson/tasks/test/package.html
+++ b/src/main/java/hudson/tasks/test/package.html
@@ -24,6 +24,6 @@ THE SOFTWARE.
 
 <html><head/><body>
 Defines contracts that need to be implemented by a test reporting
-action (such as the built-in JUnit one). This contract allows <tt>Project</tt>
+action (such as the built-in JUnit one). This contract allows <code>Project</code>
 to display a test result trend history.
 </body></html>


### PR DESCRIPTION
Making sure this plugin is constantly checked both building with JDK8 and JDK11.

This goes with the Jenkins Java 11 General Availability announcement made back in March, and we're making a pass to check plugins are looking good on a JDK11.

([to understand the Jenkinsfile content](https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines#Java11DeveloperGuidelines-MakesureyourpluginistestedinContinuousIntegrationonJava8andJava11atthesametime))

@jenkinsci/java11-support 