### PR TITLE
[JENKINS-31660] avoid reading unnecessary test results from disk

### DIFF
--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -402,6 +402,11 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     public int getFailedSince() {
         // If we haven't calculated failedSince yet, and we should,
         // do it now.
+        recomputeFailedSinceIfNeeded();
+        return failedSince;
+    }
+
+    private void recomputeFailedSinceIfNeeded() {
         if (failedSince==0 && getFailCount()==1) {
             CaseResult prev = getPreviousResult();
             if(prev!=null && !prev.isPassed())
@@ -413,9 +418,8 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
                 // failedSince will be 0, which isn't correct. 
             }
         }
-        return failedSince;
     }
-    
+
     public Run<?,?> getFailedSinceRun() {
     	return getRun().getParent().getBuildByNumber(getFailedSince());
     }
@@ -637,13 +641,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     public void freeze(SuiteResult parent) {
         this.parent = parent;
         // some old test data doesn't have failedSince value set, so for those compute them.
-        if(!isPassed() && failedSince==0) {
-            CaseResult prev = getPreviousResult();
-            if(prev!=null && !prev.isPassed())
-                this.failedSince = prev.failedSince;
-            else
-                this.failedSince = getRun().getNumber();
-        }
+        recomputeFailedSinceIfNeeded();
     }
 
     public int compareTo(CaseResult that) {

--- a/src/test/java/hudson/tasks/junit/TestResultLinksTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultLinksTest.java
@@ -30,8 +30,12 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.concurrent.TimeUnit;
 
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.TouchBuilder;
@@ -117,4 +121,20 @@ public class TestResultLinksTest {
         boolean pathStartsWithRootUrl = !pathIsEmptyOrNull && relativePath2.startsWith(rule.jenkins.getRootUrl());
         assertTrue("relative path is empty OR begins with the app root", pathIsEmptyOrNull || pathStartsWithRootUrl ); 
     }
+    
+    @Issue("JENKINS-31660")
+    @Test
+    public void testPreviousBuildNotLoaded() throws IOException, URISyntaxException {
+        TestResult testResult = new TestResult();
+        File dataFile = TestResultTest.getDataFile("SKIPPED_MESSAGE/skippedTestResult.xml");
+        testResult.parse(dataFile, null);
+        FreeStyleBuild build = new FreeStyleBuild(project) {
+            @Override
+            public FreeStyleBuild getPreviousBuild() {
+                fail("When no tests fail, we don't need tp load previous builds (expensive)");
+                return null;
+            }
+        };
+        testResult.freeze(new TestResultAction(build, testResult, null));
+     }
 }

--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -50,7 +50,7 @@ import static org.junit.Assert.*;
  * @author dty
  */
 public class TestResultTest {
-    private File getDataFile(String name) throws URISyntaxException {
+    protected static File getDataFile(String name) throws URISyntaxException {
         return new File(TestResultTest.class.getResource(name).toURI());
     }
 


### PR DESCRIPTION
See [JENKINS-31660](https://issues.jenkins-ci.org/browse/JENKINS-31660)

In case the a test was skipped, we don't need to know if it had previous failures, which allows us to avoid loading a lot of data from the disk and avoid StackOverflowError (in case the test was always skipped, we avoid loading all the previous builds).

There are two methods that recompute the failedSince field, one of them handled skipped builds correctly, the other one did not. With this PR they will both use the same logic.