### PR TITLE
[JENKINS-39203] Mark JUnit steps with failing tests with WarningAction

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.0-beta-7</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.60.1'])
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.9</version>
+        <version>3.42</version>
         <relativePath />
     </parent>
     <artifactId>junit</artifactId>
@@ -13,11 +13,11 @@
     <description>Allows JUnit-format test results to be published.</description>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/JUnit+Plugin</url>
     <properties>
-        <jenkins.version>2.7.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.138.4</jenkins.version>
+        <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
-        <workflow-cps.version>2.37</workflow-cps.version>
-        <workflow-support.version>2.14</workflow-support.version>
+        <workflow-cps.version>2.66</workflow-cps.version>
+        <workflow-support.version>3.2</workflow-support.version>
     </properties>
     <licenses>
         <license>
@@ -47,22 +47,22 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.7</version>
+            <version>1.17</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.12</version>
+            <version>2.19</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.22</version>
+            <version>2.34-20190418.192123-1</version> <!-- TODO: https://github.com/jenkinsci/workflow-api-plugin/pull/91 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.30</version>
+            <version>1.56</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.11.1</version>
+            <version>2.32</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.6</version>
+            <version>2.15</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.13</version>
+            <version>2.28</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.34-20190418.192123-1</version> <!-- TODO: https://github.com/jenkinsci/workflow-api-plugin/pull/91 -->
+            <version>2.34-rc893.b179faa50943</version> <!-- TODO: https://github.com/jenkinsci/workflow-api-plugin/pull/91 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.34-rc901.34c79c66fab6</version> <!-- TODO: https://github.com/jenkinsci/workflow-api-plugin/pull/91 -->
+            <version>2.34</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,14 @@
         <relativePath />
     </parent>
     <artifactId>junit</artifactId>
-    <version>1.28-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>JUnit Plugin</name>
     <description>Allows JUnit-format test results to be published.</description>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/JUnit+Plugin</url>
     <properties>
+        <revision>1.28</revision>
+        <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
@@ -29,7 +31,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
+      <tag>${scmTag}</tag>
     </scm>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.42</version>
+        <version>3.43</version>
         <relativePath />
     </parent>
     <artifactId>junit</artifactId>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.34-rc893.b179faa50943</version> <!-- TODO: https://github.com/jenkinsci/workflow-api-plugin/pull/91 -->
+            <version>2.34-rc901.34c79c66fab6</version> <!-- TODO: https://github.com/jenkinsci/workflow-api-plugin/pull/91 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
@@ -6,13 +6,13 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.junit.JUnitResultArchiver;
+import hudson.tasks.junit.TestResult;
 import hudson.tasks.junit.TestResultAction;
 import hudson.tasks.junit.TestResultSummary;
 import hudson.tasks.test.PipelineTestDetails;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
-
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
 import org.jenkinsci.plugins.workflow.actions.WarningAction;
@@ -52,12 +52,13 @@ public class JUnitResultsStepExecution extends SynchronousNonBlockingStepExecuti
             TestResultAction testResultAction = JUnitResultArchiver.parseAndAttach(step, pipelineTestDetails, run, workspace, launcher, listener);
 
             if (testResultAction != null) {
-                int testFailures = testResultAction.getResult().getResultByNode(nodeId).getFailCount();
+                TestResult testResult = testResultAction.getResult().getResultByNode(nodeId);
+                int testFailures = testResult.getFailCount();
                 if (testFailures > 0) {
                     node.addOrReplaceAction(new WarningAction(testFailures + " tests failed"));
                     run.setResult(Result.UNSTABLE);
                 }
-                return new TestResultSummary(testResultAction.getResult().getResultByNode(nodeId));
+                return new TestResultSummary(testResult);
             }
         } catch (Exception e) {
             listener.getLogger().println(e.getMessage());

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
@@ -12,8 +12,10 @@ import hudson.tasks.test.PipelineTestDetails;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
+
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
+import org.jenkinsci.plugins.workflow.actions.WarningAction;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graph.StepNode;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -50,8 +52,9 @@ public class JUnitResultsStepExecution extends SynchronousNonBlockingStepExecuti
             TestResultAction testResultAction = JUnitResultArchiver.parseAndAttach(step, pipelineTestDetails, run, workspace, launcher, listener);
 
             if (testResultAction != null) {
-                // TODO: Once JENKINS-43995 lands, update this to set the step status instead of the entire build.
-                if (testResultAction.getResult().getFailCount() > 0) {
+                int testFailures = testResultAction.getResult().getResultByNode(nodeId).getFailCount();
+                if (testFailures > 0) {
+                    node.addOrReplaceAction(new WarningAction(testFailures + " tests failed"));
                     run.setResult(Result.UNSTABLE);
                 }
                 return new TestResultSummary(testResultAction.getResult().getResultByNode(nodeId));

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
@@ -55,7 +55,7 @@ public class JUnitResultsStepExecution extends SynchronousNonBlockingStepExecuti
                 TestResult testResult = testResultAction.getResult().getResultByNode(nodeId);
                 int testFailures = testResult.getFailCount();
                 if (testFailures > 0) {
-                    node.addOrReplaceAction(new WarningAction(testFailures + " tests failed"));
+                    node.addOrReplaceAction(new WarningAction(Result.UNSTABLE).withMessage(testFailures + " tests failed"));
                     run.setResult(Result.UNSTABLE);
                 }
                 return new TestResultSummary(testResult);

--- a/src/test/java/hudson/tasks/junit/pipeline/JUnitResultsStepTest.java
+++ b/src/test/java/hudson/tasks/junit/pipeline/JUnitResultsStepTest.java
@@ -16,14 +16,18 @@ import hudson.tasks.junit.TestResultAction;
 import hudson.tasks.junit.TestResultTest;
 import hudson.tasks.test.PipelineBlockWithTests;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.actions.LogAction;
 import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
+import org.jenkinsci.plugins.workflow.actions.WarningAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.SnippetizerTester;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -264,10 +268,10 @@ public class JUnitResultsStepTest {
         assertEquals(5, action.getResult().getSuites().size());
         assertEquals(10, action.getTotalCount());
 
-        assertBranchResults(r, 1, 6, "a", "first");
-        assertBranchResults(r, 1, 1, "b", "first");
-        assertBranchResults(r, 3, 3, "c", "first");
-        assertStageResults(r, 5, 10, "first");
+        assertBranchResults(r, 1, 6, 0, "a", "first", null);
+        assertBranchResults(r, 1, 1, 0, "b", "first", null);
+        assertBranchResults(r, 3, 3, 1, "c", "first", null);
+        assertStageResults(r, 5, 10, 1, "first");
     }
 
     @Issue("JENKINS-48196")
@@ -300,11 +304,11 @@ public class JUnitResultsStepTest {
         // assertBranchResults looks to make sure the display names for tests are "(stageName) / (branchName) / (testName)"
         // That should still effectively be the case here, even though there's a stage inside each branch, because the
         // branch and nested stage have the same name.
-        assertBranchResults(r, 1, 6, "a", "outer");
-        assertBranchResults(r, 1, 1, "b", "outer");
+        assertBranchResults(r, 1, 6, 0, "a", "outer", null);
+        assertBranchResults(r, 1, 1, 0, "b", "outer", null);
         // ...except for branch c. That contains a stage named 'd', so its test should have display names like
         // "outer / c / d / (testName)"
-        assertBranchResults(r, 3, 3, -1, "c", "outer", "d");
+        assertBranchResults(r, 3, 3, 1, "c", "outer", "d");
     }
 
     @Test
@@ -411,15 +415,11 @@ public class JUnitResultsStepTest {
         };
     }
 
-    public static void assertBranchResults(WorkflowRun run, int suiteCount, int testCount, String branchName, String stageName) {
-        assertBranchResults(run, suiteCount, testCount, -1, branchName, stageName, null);
-    }
-
     public static void assertBranchResults(WorkflowRun run, int suiteCount, int testCount, int failCount, String branchName, String stageName,
                                            String innerStageName) {
         FlowExecution execution = run.getExecution();
         DepthFirstScanner scanner = new DepthFirstScanner();
-        FlowNode aBranch = scanner.findFirstMatch(execution, branchForName(branchName));
+        BlockStartNode aBranch = (BlockStartNode)scanner.findFirstMatch(execution, branchForName(branchName));
         assertNotNull(aBranch);
         TestResult branchResult = assertBlockResults(run, suiteCount, testCount, failCount, aBranch);
         String namePrefix = stageName + " / " + branchName;
@@ -431,19 +431,15 @@ public class JUnitResultsStepTest {
         }
     }
 
-    public static void assertStageResults(WorkflowRun run, int suiteCount, int testCount, String stageName) {
-        assertStageResults(run, suiteCount, testCount, -1, stageName);
-    }
-
     public static void assertStageResults(WorkflowRun run, int suiteCount, int testCount, int failCount, String stageName) {
         FlowExecution execution = run.getExecution();
         DepthFirstScanner scanner = new DepthFirstScanner();
-        FlowNode aStage = scanner.findFirstMatch(execution, stageForName(stageName));
+        BlockStartNode aStage = (BlockStartNode)scanner.findFirstMatch(execution, stageForName(stageName));
         assertNotNull(aStage);
         assertBlockResults(run, suiteCount, testCount, failCount, aStage);
     }
 
-    private static TestResult assertBlockResults(WorkflowRun run, int suiteCount, int testCount, int failCount, FlowNode blockNode) {
+    private static TestResult assertBlockResults(WorkflowRun run, int suiteCount, int testCount, int failCount, BlockStartNode blockNode) {
         assertNotNull(blockNode);
 
         TestResultAction action = run.getAction(TestResultAction.class);
@@ -454,8 +450,11 @@ public class JUnitResultsStepTest {
 
         assertEquals(suiteCount, aResult.getSuites().size());
         assertEquals(testCount, aResult.getTotalCount());
-        if (failCount > -1) {
-            assertEquals(failCount, aResult.getFailCount());
+        assertEquals(failCount, aResult.getFailCount());
+        if (failCount > 0) {
+            assertThat(findJUnitSteps(blockNode), CoreMatchers.hasItem(hasWarningAction()));
+        } else {
+            assertThat(findJUnitSteps(blockNode), CoreMatchers.not(CoreMatchers.hasItem(hasWarningAction())));
         }
 
         PipelineBlockWithTests aBlock = action.getResult().getPipelineBlockWithTests(blockNode.getId());
@@ -480,6 +479,28 @@ public class JUnitResultsStepTest {
         assertNotNull(result);
         assertEquals(suiteCount, result.getSuites().size());
         assertEquals(testCount, result.getTotalCount());
+    }
+
+    private static List<FlowNode> findJUnitSteps(BlockStartNode blockStart) {
+        return new DepthFirstScanner().filteredNodes(
+                Collections.singletonList(blockStart.getEndNode()),
+                Collections.singletonList(blockStart),
+                node -> node instanceof StepAtomNode &&
+                        ((StepAtomNode) node).getDescriptor() instanceof JUnitResultsStep.DescriptorImpl
+        );
+    }
+
+    private static BaseMatcher<FlowNode> hasWarningAction() {
+        return new BaseMatcher<FlowNode>() {
+            @Override
+            public boolean matches(Object item) {
+                return item instanceof FlowNode && ((FlowNode) item).getPersistentAction(WarningAction.class) != null;
+            }
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("a FlowNode with a WarningAction");
+            }
+        };
     }
 
     public static class MockTestDataPublisher extends TestDataPublisher {


### PR DESCRIPTION
See https://github.com/jenkinsci/workflow-api-plugin/pull/91 and [JENKINS-39203](https://issues.jenkins-ci.org/browse/JENKINS-39203). (I am intentionally not updating the status of that ticket or assigning it to myself until I am ready to merge/release all relevant changes to avoid giving users premature hope of a fix and so that I have clear answers for what will and won't work and when any fixes will be released.) Subsumes and is based on #96.

This PR adds a `WarningAction` to the `StepAtomNode` for `junit` steps with failing tests so that the actual stage containing the `junit` step can be visualized as unstable via https://github.com/jenkinsci/pipeline-graph-analysis-plugin/pull/25.

Desired reviewers: @abayer, @jglick, @car-roll 