### PR TITLE
Use full name to identify test result

### DIFF
--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -270,7 +270,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     }
 
     public String getTransformedTestName() {
-        return TestNameTransformer.getTransformedName(testName);
+        return TestNameTransformer.getTransformedName(getFullName());
     }
 
     public String getDisplayName() {

--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -270,6 +270,10 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     }
 
     public String getTransformedTestName() {
+        return TestNameTransformer.getTransformedName(testName);
+    }
+
+    public String getTransformedFullName() {
         return TestNameTransformer.getTransformedName(getFullName());
     }
 
@@ -376,7 +380,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
      * @since 1.515
      */
     public String getFullDisplayName() {
-    	return getNameWithEnclosingBlocks(TestNameTransformer.getTransformedName(getFullName()));
+    	return getNameWithEnclosingBlocks(getTransformedFullName());
     }
 
     @Override
@@ -482,7 +486,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         if (parent == null) return null;
         SuiteResult pr = parent.getPreviousResult();
         if(pr==null)    return null;
-        return pr.getCase(getTransformedTestName());
+        return pr.getCase(getTransformedFullName());
     }
     
     /**

--- a/src/main/java/hudson/tasks/junit/SuiteResult.java
+++ b/src/main/java/hudson/tasks/junit/SuiteResult.java
@@ -131,7 +131,7 @@ public final class SuiteResult implements Serializable {
         if (casesByName == null) {
             casesByName = new HashMap<>();
             for (CaseResult c : cases) {
-                casesByName.put(c.getTransformedTestName(), c);
+                casesByName.put(c.getTransformedFullName(), c);
             }
         }
         return casesByName;
@@ -294,7 +294,7 @@ public final class SuiteResult implements Serializable {
 
     /*package*/ void addCase(CaseResult cr) {
         cases.add(cr);
-        casesByName().put(cr.getTransformedTestName(), cr);
+        casesByName().put(cr.getTransformedFullName(), cr);
 
         //if suite time was not specified use sum of the cases' times
         if( !hasTimeAttr() ){


### PR DESCRIPTION
JENKINS-56755: The method name is not enough to find a previous test result since a method name can occur in multiple classes. Use the full name instead.