### PR TITLE
JENKINS-48583: Improve logic that handles suite aggregation

### DIFF
--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -260,6 +260,23 @@ public class TestResultTest {
         assertEquals("Wrong number of test cases", 3, testResult.getTotalCount());
     }
     
+    /**
+     * Despite problem stated for {@link TestResultTest#testDuplicatedTestSuiteIsNotCounted()} above,
+     * sometimes test cases are split over multiple files with identical timestamps.
+     */
+    @Issue("JENKINS-48583")
+    @Test
+    public void testNonDuplicatedTestSuiteIsCounted() throws IOException, URISyntaxException {
+        TestResult testResult = new TestResult();
+        testResult.parse(getDataFile("JENKINS-12457/TestSuite_b.xml"), null);
+        testResult.parse(getDataFile("JENKINS-12457/TestSuite_b_duplicate.xml"), null);
+        testResult.parse(getDataFile("JENKINS-12457/TestSuite_b_nonduplicate.xml"), null);
+        testResult.tally();
+        
+        assertEquals("Wrong number of testsuites", 1, testResult.getSuites().size());
+        assertEquals("Wrong number of test cases", 2, testResult.getTotalCount());
+    }
+
     private static final XStream XSTREAM = new XStream2();
 
     static {

--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -246,6 +246,20 @@ public class TestResultTest {
         assertEquals("Wrong duration for test class", 93.0, class2.getDuration(), 0.1);
     }
 
+    @Issue("JENKINS-48583")
+    @Test
+    public void testIgnoresDuplicateSuitesInMergedOutput() throws IOException, URISyntaxException {
+        TestResult testResult = new TestResult();
+        testResult.parse(getDataFile("JENKINS-48583/TEST-com.sample.test.TestMessage.xml"), null);
+        testResult.parse(getDataFile("JENKINS-48583/TEST-com.sample.test.TestMessage2.xml"), null);
+        testResult.parse(getDataFile("JENKINS-48583/TESTS-TestSuites.xml"), null);
+        testResult.parse(getDataFile("JENKINS-48583/TEST-com.sample.test.TestMessage.xml"), null);
+        testResult.tally();
+        
+        assertEquals("Wrong number of testsuites", 2, testResult.getSuites().size());
+        assertEquals("Wrong number of test cases", 3, testResult.getTotalCount());
+    }
+    
     private static final XStream XSTREAM = new XStream2();
 
     static {

--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -32,12 +32,10 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
 import org.junit.Test;
-import org.jvnet.hudson.test.Bug;
 
 import com.thoughtworks.xstream.XStream;
 import org.jvnet.hudson.test.Issue;
@@ -136,7 +134,8 @@ public class TestResultTest {
         assertEquals("Wrong number of test cases", 3, testResult.getTotalCount());
     }
     
-    @Bug(12457)
+    @Issue("JENKINS-12457")
+    @Test
     public void testTestSuiteDistributedOverMultipleFilesIsCountedAsOne() throws IOException, URISyntaxException {
         TestResult testResult = new TestResult();
         testResult.parse(getDataFile("JENKINS-12457/TestSuite_a1.xml"), null);
@@ -154,6 +153,7 @@ public class TestResultTest {
      * A common problem is that people parse TEST-*.xml as well as TESTS-TestSuite.xml.
      * See http://jenkins.361315.n4.nabble.com/Problem-with-duplicate-build-execution-td371616.html for discussion.
      */
+    @Test
     public void testDuplicatedTestSuiteIsNotCounted() throws IOException, URISyntaxException {
         TestResult testResult = new TestResult();
         testResult.parse(getDataFile("JENKINS-12457/TestSuite_b.xml"), null);
@@ -190,7 +190,7 @@ public class TestResultTest {
     @Test
     public void testMergeWithTime() throws Exception {
         TestResult testResult = new TestResult();
-        testResult.parse(getDataFile("junit-report-time-aggregation.xml"));
+        testResult.parse(getDataFile("junit-report-time-aggregation.xml"), null);
         testResult.tally();
 
         assertEquals(1, testResult.getSuites().size());
@@ -203,7 +203,7 @@ public class TestResultTest {
     @Test
     public void testMergeWithoutTime() throws Exception {
         TestResult testResult = new TestResult();
-        testResult.parse(getDataFile("junit-report-time-aggregation2.xml"));
+        testResult.parse(getDataFile("junit-report-time-aggregation2.xml"), null);
         testResult.tally();
 
         assertEquals(1, testResult.getSuites().size());
@@ -216,7 +216,7 @@ public class TestResultTest {
     @Test
     public void testSuiteWithMultipleClasses() throws IOException, URISyntaxException {
         TestResult testResult = new TestResult();
-        testResult.parse(getDataFile("JENKINS-42438/junit-report-1.xml"));
+        testResult.parse(getDataFile("JENKINS-42438/junit-report-1.xml"), null);
         testResult.tally();
 
         assertEquals("Wrong number of testsuites", 1, testResult.getSuites().size());

--- a/src/test/resources/hudson/tasks/junit/JENKINS-12457/TestSuite_b_nonduplicate.xml
+++ b/src/test/resources/hudson/tasks/junit/JENKINS-12457/TestSuite_b_nonduplicate.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="TestSuite_b" tests="1" errors="0" failures="0" skip="0" timestamp="2012-01-01T00:00:00">
+  <testcase classname="TestFoo" name="bar2" time="1" />
+</testsuite>

--- a/src/test/resources/hudson/tasks/junit/JENKINS-48583/TEST-com.sample.test.TestMessage.xml
+++ b/src/test/resources/hudson/tasks/junit/JENKINS-48583/TEST-com.sample.test.TestMessage.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuite errors="0" failures="0" hostname="myhost" name="com.sample.test.TestMessage" skipped="0" tests="1" time="0.063" timestamp="2015-01-13T07:23:07">
+  <properties>
+  </properties>
+  <testcase classname="com.sample.test.TestMessage" name="test_welcome_message" time="0.002" />
+  <system-out><![CDATA[]]></system-out>
+  <system-err><![CDATA[]]></system-err>
+</testsuite>

--- a/src/test/resources/hudson/tasks/junit/JENKINS-48583/TEST-com.sample.test.TestMessage2.xml
+++ b/src/test/resources/hudson/tasks/junit/JENKINS-48583/TEST-com.sample.test.TestMessage2.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuite errors="0" failures="0" hostname="myhost" name="com.sample.test.TestMessage2" skipped="0" tests="2" time="0.06" timestamp="2015-01-13T07:23:08">
+  <properties>
+  </properties>
+  <testcase classname="com.sample.test.TestMessage2" name="test_welcome_message_2" time="0.001" />
+  <testcase classname="com.sample.test.TestMessage2" name="test_welcome_message_3" time="0.003" />
+  <system-out><![CDATA[]]></system-out>
+  <system-err><![CDATA[]]></system-err>
+</testsuite>

--- a/src/test/resources/hudson/tasks/junit/JENKINS-48583/TESTS-TestSuites.xml
+++ b/src/test/resources/hudson/tasks/junit/JENKINS-48583/TESTS-TestSuites.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+  <testsuite errors="0" failures="0" hostname="myhost" id="0" name="TestMessage" package="com.sample.test" skipped="0" tests="1" time="0.063" timestamp="2015-01-13T07:23:07">
+      <properties>
+      </properties>
+      <testcase classname="com.sample.test.TestMessage" name="test_welcome_message" time="0.002" />
+      <system-out><![CDATA[]]></system-out>
+      <system-err><![CDATA[]]></system-err>
+  </testsuite>
+  <testsuite errors="0" failures="0" hostname="myhost" id="1" name="TestMessage2" package="com.sample.test" skipped="0" tests="2" time="0.06" timestamp="2015-01-13T07:23:08">
+      <properties>
+      </properties>
+      <testcase classname="com.sample.test.TestMessage2" name="test_welcome_message_2" time="0.001" />
+      <testcase classname="com.sample.test.TestMessage2" name="test_welcome_message_3" time="0.003" />
+      <system-out><![CDATA[]]></system-out>
+      <system-err><![CDATA[]]></system-err>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
Original intended use case was for complete duplicate suite definitions due to aggregation of multiple suites into a single file by ant's JUnitReport task. I added a test to ensure that scenario is still supported (who still uses ant? :D ).

Modern tools run tests in parallel, and a single suite may have test cases written across several files. The updated logic will only ignore a suite if it has an identical name, timestamp, duration, and number of test cases as the existing. If both suites being compared only have a single test case, then the full name of test case will also be compared.

Also, any ignored test suites are now logged as a warning. Many productive hours have been lost investigating this issue, so hopefully that will minimize future hours lost if another use case is discovered.