### PR TITLE
Fix chart with deleted builds

### DIFF
--- a/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
+++ b/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
@@ -222,7 +222,7 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
             loadedBuilds = null;
         }
         while(true) {
-            b = loadedBuilds == null || loadedBuilds.contains(b.number - /* assuming there are no gaps */1) ? b.getPreviousBuild() : null;
+            b = loadedBuilds == null || Collections.min(loadedBuilds) < b.number ? b.getPreviousBuild() : null;
             if(b==null)
                 return null;
             U r = b.getAction(type);

--- a/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
+++ b/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
@@ -222,7 +222,7 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
             loadedBuilds = null;
         }
         while(true) {
-            b = loadedBuilds == null || Collections.min(loadedBuilds) < b.number ? b.getPreviousBuild() : null;
+            b = loadedBuilds == null ? b.getPreviousBuild() : (LazyBuildMixIn.LazyLoadingJob<?,?>)b.getParent()).getLazyBuildMixIn().getNearestOldBuild(b.number - 1);
             if(b==null)
                 return null;
             U r = b.getAction(type);


### PR DESCRIPTION
When builds are deleted, there *are* gaps in build numbers, and chart doesn't show anything before deleted build. This causes [JENKINS-52711](https://issues.jenkins-ci.org/browse/JENKINS-52711).
I haven't tested this fix, as I am stuck at the moment with out-of-date Jenkins version, but I think it should work.