### PR TITLE
Fix chart with deleted builds

### DIFF
--- a/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
+++ b/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
@@ -222,7 +222,7 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
             loadedBuilds = null;
         }
         while(true) {
-            b = loadedBuilds == null || loadedBuilds.contains(b.number - /* assuming there are no gaps */1) ? b.getPreviousBuild() : null;
+            b = loadedBuilds == null ? b.getPreviousBuild() : ((LazyBuildMixIn.LazyLoadingJob<?,?>)b.getParent()).getLazyBuildMixIn().getNearestOldBuild(b.number - 1);
             if(b==null)
                 return null;
             U r = b.getAction(type);


### PR DESCRIPTION
[JENKINS-25340] [JENKINS-52711]
When there are deleted builds, test results chart only shows results for until the deleted build, older builds are not displayed. This PR tries to address this.