### PR TITLE
Use waitForMessage in tests to reduce flakes

### DIFF
--- a/src/test/java/hudson/tasks/junit/pipeline/JUnitResultsStepTest.java
+++ b/src/test/java/hudson/tasks/junit/pipeline/JUnitResultsStepTest.java
@@ -92,7 +92,7 @@ public class JUnitResultsStepTest {
 
         WorkflowRun r = j.scheduleBuild2(0).waitForStart();
         rule.assertBuildStatus(Result.FAILURE, rule.waitForCompletion(r));
-        rule.assertLogContains("ERROR: " + Messages.JUnitResultArchiver_NoTestReportFound(), r);
+        rule.waitForMessage("ERROR: " + Messages.JUnitResultArchiver_NoTestReportFound(), r);
         FlowExecution execution = r.getExecution();
         DepthFirstScanner scanner = new DepthFirstScanner();
         FlowNode f = scanner.findFirstMatch(execution, new Predicate<FlowNode>() {
@@ -126,7 +126,7 @@ public class JUnitResultsStepTest {
 
         WorkflowRun r = rule.buildAndAssertSuccess(j);
         assertNull(r.getAction(TestResultAction.class));
-        rule.assertLogContains("None of the test reports contained any result", r);
+        rule.waitForMessage("None of the test reports contained any result", r);
     }
 
     @Test


### PR DESCRIPTION
Hi we're experiencing flakey tests trying to integrate the next bom line,

example:
```
Expected: a string containing "broken condition"
     but: was "Started
Running in Durability level: MAX_SURVIVABILITY
[Pipeline] Start of Pipeline
[Pipeline] waitUntil
[Pipeline] {
[Pipeline] semaphore
[Pipeline] }
Will try again after 0.25 sec
[Pipeline] {
[Pipeline] semaphore
[Pipeline] }
[Pipeline] // waitUntil
[Pipeline] End of Pipeline
```

@jglick suggested replacing assertLogContains with waitForMessage
https://github.com/jenkinsci/bom/pull/110#issuecomment-594782396
