### PR TITLE
Add failed tests list to TestResultSummary

### DIFF
--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -469,6 +469,7 @@ public final class TestResult extends MetaTabulatedResult {
         return getTotalCount() == 0;
     }
 
+    @Exported(visibility=999)
     @Override
     public List<CaseResult> getFailedTests() {
         return failedTests;

--- a/src/main/java/hudson/tasks/junit/TestResultSummary.java
+++ b/src/main/java/hudson/tasks/junit/TestResultSummary.java
@@ -12,6 +12,7 @@ public class TestResultSummary implements Serializable {
     private int skipCount;
     private int passCount;
     private int totalCount;
+    private List<CaseResult> failedTests;
 
     public TestResultSummary() {
     }
@@ -21,6 +22,7 @@ public class TestResultSummary implements Serializable {
         this.skipCount = result.getSkipCount();
         this.passCount = result.getPassCount();
         this.totalCount = result.getTotalCount();
+        this.failedTests = result.getFailedTests();
     }
 
     @Whitelisted
@@ -41,6 +43,11 @@ public class TestResultSummary implements Serializable {
     @Whitelisted
     public int getTotalCount() {
         return totalCount;
+    }
+    
+    @Whitelisted
+    public List<CaseResult> getFailedTests() {
+        return failedTests;
     }
 }
 

--- a/src/main/java/hudson/tasks/junit/TestResultSummary.java
+++ b/src/main/java/hudson/tasks/junit/TestResultSummary.java
@@ -3,6 +3,7 @@ package hudson.tasks.junit;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * Summary of test results that can be used in Pipeline scripts.


### PR DESCRIPTION
This feature is need in the pipelines, so for example we are notifying in slaack about out failed tests and by this feature we will be able to have a list directly in slack