### PR TITLE
[JENKINS-61787] Do not attempt to look up TestNameTransformer’s from an agent JVM

### DIFF
--- a/src/main/java/hudson/tasks/junit/TestNameTransformer.java
+++ b/src/main/java/hudson/tasks/junit/TestNameTransformer.java
@@ -2,7 +2,7 @@ package hudson.tasks.junit;
 
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
-import jenkins.model.Jenkins;
+import jenkins.util.JenkinsJVM;
 
 /**
  * Allow extensions to transform the class/package/method name for JUnit test
@@ -29,6 +29,10 @@ public abstract class TestNameTransformer implements ExtensionPoint {
     public abstract String transformName(String name);
     
     public static String getTransformedName(String name) {
+        if (!JenkinsJVM.isJenkinsJVM()) {
+            // TODO JENKINS-61787 should this be serialized and passed along in the callable?
+            return name;
+        }
         String transformedName = name;
         for (TestNameTransformer transformer : all()) {
             transformedName = transformer.transformName(transformedName);

--- a/src/test/java/hudson/tasks/junit/TestNameTransformerTest.java
+++ b/src/test/java/hudson/tasks/junit/TestNameTransformerTest.java
@@ -1,20 +1,19 @@
 package hudson.tasks.junit;
 
+import jenkins.security.MasterToSlaveCallable;
 import static org.junit.Assert.*;
-
-import hudson.Extension;
-
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
 
 public class TestNameTransformerTest {
 
     private static final String UNIQUE_NAME_FOR_TEST = "unique-name-to-test-name-transformer";
     @Rule public JenkinsRule j = new JenkinsRule();
 
-    @Extension
+    @TestExtension
     public static class TestTransformer extends TestNameTransformer {
         @Override
         public String transformName(String name) {
@@ -26,8 +25,20 @@ public class TestNameTransformerTest {
     }
 
     @Test
-    public void testNameIsTransformed() {
+    public void testNameIsTransformed() throws Exception {
         assertEquals(UNIQUE_NAME_FOR_TEST + "-transformed", TestNameTransformer.getTransformedName(UNIQUE_NAME_FOR_TEST));
+    }
+
+    @Issue("JENKINS-61787")
+    @Test
+    public void testNameIsNotTransformedRemotely() throws Exception {
+        assertEquals(UNIQUE_NAME_FOR_TEST, j.createOnlineSlave().getChannel().call(new Remote()));
+    }
+    private static final class Remote extends MasterToSlaveCallable<String, RuntimeException> {
+        @Override
+        public String call() throws RuntimeException {
+            return TestNameTransformer.getTransformedName(UNIQUE_NAME_FOR_TEST);
+        }
     }
 
 }


### PR DESCRIPTION
Attempt at a hotfix for [JENKINS-61787](https://issues.jenkins-ci.org/browse/JENKINS-61787). I am guessing Scala test name transformation was already broken when using an agent; let us not make the whole `junit` step crash when you are not even using that plugin!