### PR TITLE
[JENKINS-34217] add option to disable historical statistics gathering…

### DIFF
--- a/src/main/java/hudson/tasks/junit/History.java
+++ b/src/main/java/hudson/tasks/junit/History.java
@@ -24,6 +24,7 @@
 package hudson.tasks.junit;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Job;
 import hudson.model.Run;
 import jenkins.model.Jenkins;
 import hudson.tasks.test.TestObject;
@@ -69,10 +70,9 @@ public class History {
 	}
 	
     public boolean historyAvailable() {
-       if (testObject.getRun().getParent().getBuilds().size() > 1)
-           return true;
-        else
-           return false; 
+        Job<?,?> job  = testObject.getRun().getParent();
+        JobTestResultDisplayProperty settings = job.getProperty(JobTestResultDisplayProperty.class);
+        return (settings == null || !settings.getDisableHistoricalResults()) && job.getBuilds().size() > 1;
     }
 	
     public List<TestResult> getList(int start, int end) {

--- a/src/main/java/hudson/tasks/junit/JobTestResultDisplayProperty.java
+++ b/src/main/java/hudson/tasks/junit/JobTestResultDisplayProperty.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 SAP SE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.tasks.junit;
+
+import hudson.Extension;
+import hudson.model.Job;
+import hudson.model.JobProperty;
+import hudson.model.JobPropertyDescriptor;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.StaplerRequest;
+
+/**
+ *
+ */
+public class JobTestResultDisplayProperty extends JobProperty<Job<?, ?>> {
+	private final boolean disableHistoricalResults;
+
+	public JobTestResultDisplayProperty(Boolean disableHistoricalResults) {
+		if ( disableHistoricalResults != null ) {
+			this.disableHistoricalResults = disableHistoricalResults;
+		}
+		else {
+			this.disableHistoricalResults = false;
+		}
+	}
+
+	public boolean getDisableHistoricalResults() {
+		return disableHistoricalResults;
+	}
+
+	@Extension
+	public static class DescriptorImpl extends JobPropertyDescriptor {
+
+		@Override
+		public String getDisplayName() {
+			return "";
+		}
+
+		@Override
+		public JobTestResultDisplayProperty newInstance(StaplerRequest req, JSONObject formData) {
+			if (formData.isNullObject()) return null;
+			return new JobTestResultDisplayProperty(formData.getBoolean("junitsettings-disableHistoricalResults"));
+		}
+	}
+}

--- a/src/main/java/hudson/tasks/junit/TestResultAction.java
+++ b/src/main/java/hudson/tasks/junit/TestResultAction.java
@@ -199,6 +199,17 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
     }
 
 
+    @Override
+    public boolean shouldCalculatePreviousResults() {
+        JobTestResultDisplayProperty settings = run.getParent().getProperty(JobTestResultDisplayProperty.class);
+        if ( settings != null ) {
+            return !settings.getDisableHistoricalResults();
+        }
+        else {
+            return super.shouldCalculatePreviousResults();
+        }
+    }
+
     /**
      * Loads a {@link TestResult} from disk.
      */

--- a/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
+++ b/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
@@ -188,6 +188,15 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
     }
 
     /**
+     * Allows a particular job to disable scanning previous result history.
+     * 
+     * @return if calculation of previous results should be done
+     */
+    public boolean shouldCalculatePreviousResults() {
+        return true;
+    }
+
+    /**
      * Exposes this object to the remote API.
      */
     public Api getApi() {

--- a/src/main/java/hudson/tasks/test/TestResult.java
+++ b/src/main/java/hudson/tasks/test/TestResult.java
@@ -137,6 +137,11 @@ public abstract class TestResult extends TestObject {
         if (b == null) {
             return null;
         }
+
+        // abort if the job is configured to not do this
+        AbstractTestResultAction tra = b.getAction(getParentAction().getClass());
+        if ( tra != null && !tra.shouldCalculatePreviousResults()) return null;
+
         while(true) {
             b = b.getPreviousBuild();
             if(b==null)

--- a/src/main/java/hudson/tasks/test/TestResultProjectAction.java
+++ b/src/main/java/hudson/tasks/test/TestResultProjectAction.java
@@ -107,7 +107,7 @@ public class TestResultProjectAction implements Action {
      */
     public void doTrend( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
         AbstractTestResultAction a = getLastTestResultAction();
-        if(a!=null)
+        if(a!=null && a.shouldCalculatePreviousResults())
             a.doGraph(req,rsp);
         else
             rsp.setStatus(HttpServletResponse.SC_NOT_FOUND);

--- a/src/main/resources/hudson/tasks/junit/JobTestResultDisplayProperty/config.jelly
+++ b/src/main/resources/hudson/tasks/junit/JobTestResultDisplayProperty/config.jelly
@@ -1,0 +1,33 @@
+<!--
+The MIT License
+
+Copyright 2016 SAP AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+	<f:optionalBlock name="junitsettings-disableHistoricalResults"
+	                 title="${%Disable JUnit historical test results statistics}"
+	                 checked="${instance.disableHistoricalResults}"
+	                 inline="true"
+	                 help="/descriptor/hudson.tasks.junit.JobTestResultDisplayProperty/help/disableHistoricalResults"
+	/>
+</j:jelly>

--- a/src/main/resources/hudson/tasks/junit/JobTestResultDisplayProperty/help-disableHistoricalResults.html
+++ b/src/main/resources/hudson/tasks/junit/JobTestResultDisplayProperty/help-disableHistoricalResults.html
@@ -1,0 +1,28 @@
+<!--
+The MIT License
+
+Copyright 2016 SAP AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<div>
+If enabled, historical test results will not be computed and maintained for this job.
+<br>
+The test results graph will not be displayed, and the number of builds for which a test has been failing will not be computed.
+</div>

--- a/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
   <j:set var="tr" value="${action.lastTestResultAction}" />
-  <j:if test="${tr.previousResult!=null}">
+  <j:if test="${tr.previousResult!=null and tr.shouldCalculatePreviousResults()}">
     <!-- at least two data points are required for a trend report -->
     <div align="right">
       <j:set var="mode" value="${h.getCookie(request,'TestResultAction_failureOnly').value}" />


### PR DESCRIPTION
… for test results

This change adds a new job configuration property that, when enabled, disables
the display of the test trend chart and prevents the plugin from even calculating
how long a test has been failing for, thus saving the work of digging up historical
records.
Note that this commit is squashing the 3 commits initially devloped by Jim Carrothers.
It also fixes h.t.j.JobTestResultDisplayProperty$DescriptorImpl.getDisplayName() return value.