### PR TITLE
JENKINS-62775: Increase spacing between "Older" and "Newer" buttons

### DIFF
--- a/src/main/resources/hudson/tasks/junit/History/index.jelly
+++ b/src/main/resources/hudson/tasks/junit/History/index.jelly
@@ -67,11 +67,11 @@ THE SOFTWARE.
       <st:include from="${it.testObject}" it="${it.testObject}" page="list.jelly" optional="true"/>
       	<div>
 	      <j:if test="${it.testObject.run.parent.builds.size() > end}">
-	      		<a href="${app.rootUrl}${it.testObject.run.url}testReport${it.testObject.url}/history?start=${end+1}">${%Older}</a>
+	      		<a href="${app.rootUrl}${it.testObject.run.url}testReport${it.testObject.url}/history?start=${end+1}" style="margin:1px">${%Older}</a>
 	      </j:if>
 
 	      <j:if test="${start > 0}">
-	      		<a href="${app.rootUrl}${it.testObject.run.url}testReport${it.testObject.url}/history${(start-25)>0?'?start='+(start-25):''}">${%Newer}</a>
+	      		<a href="${app.rootUrl}${it.testObject.run.url}testReport${it.testObject.url}/history${(start-25)>0?'?start='+(start-25):''}" style="margin:1px">${%Newer}</a>
 	      </j:if>	       
       	</div>
     </l:main-panel>


### PR DESCRIPTION
The "Older" and "Newer" links are currently displayed in a concatenated manner, i.e. "OlderNewer". This PR adds a tiny amount of spacing to distinguish the two buttons more clearly.