### PR TITLE
JENKINS-63339 Fix aggregated report trend

### DIFF
--- a/src/main/java/hudson/tasks/test/TestResultTrendSeriesBuilder.java
+++ b/src/main/java/hudson/tasks/test/TestResultTrendSeriesBuilder.java
@@ -14,10 +14,13 @@ public class TestResultTrendSeriesBuilder extends SeriesBuilder<AbstractTestResu
     @Override
     protected Map<String, Integer> computeSeries(AbstractTestResultAction testResultAction) {
         Map<String, Integer> series = new HashMap<>();
-        series.put(TOTALS_KEY, testResultAction.getTotalCount());
-        series.put(PASSED_KEY, testResultAction.getPassedTests().size());
-        series.put(FAILED_KEY, testResultAction.getFailCount());
-        series.put(SKIPPED_KEY, testResultAction.getSkipCount());
+        int totalCount = testResultAction.getTotalCount();
+        int failCount = testResultAction.getFailCount();
+        int skipCount = testResultAction.getSkipCount();
+        series.put(TOTALS_KEY, totalCount);
+        series.put(PASSED_KEY, totalCount - failCount - skipCount);
+        series.put(FAILED_KEY, failCount);
+        series.put(SKIPPED_KEY, skipCount);
         return series;
     }
 }


### PR DESCRIPTION
Aggregated reports don't record the passed tests.

Picked up in JENKINS-63339 as the maven-plugin uses this base class.

Seems safer to just revert to the previous logic than to try patching in tracking of the passed tests.