### PR TITLE
Mark types in hudson.tasks.junit.storage package as beta

### DIFF
--- a/src/main/java/hudson/tasks/junit/storage/TestResultImpl.java
+++ b/src/main/java/hudson/tasks/junit/storage/TestResultImpl.java
@@ -32,10 +32,13 @@ import hudson.tasks.junit.PackageResult;
 import hudson.tasks.junit.TestResult;
 import hudson.tasks.junit.TrendTestResultSummary;
 import java.util.List;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
 
 /**
  * Pluggable implementation of {@link TestResult}.
  */
+@Restricted(Beta.class)
 public interface TestResultImpl {
     int getFailCount();
     int getSkipCount();

--- a/src/main/java/hudson/tasks/junit/storage/TestResultStorage.java
+++ b/src/main/java/hudson/tasks/junit/storage/TestResultStorage.java
@@ -33,10 +33,13 @@ import hudson.tasks.junit.TestResult;
 import java.io.IOException;
 import javax.annotation.CheckForNull;
 import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
 
 /**
  * Allows test results to be saved and loaded from an external storage service.
  */
+@Restricted(Beta.class)
 public interface TestResultStorage extends ExtensionPoint {
 
     /**


### PR DESCRIPTION
Not all the hard problems in #142 have been worked on (I suppose), so we should not advertise these interfaces to rando plugin developers without a warning.