### PR TITLE
Remove unneeded API in pluggable storage

### DIFF
--- a/src/main/java/hudson/tasks/junit/ClassResult.java
+++ b/src/main/java/hudson/tasks/junit/ClassResult.java
@@ -132,15 +132,7 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
 
     @Override
     public Object getDynamic(String name, StaplerRequest req, StaplerResponse rsp) {
-        JunitTestResultStorage storage = JunitTestResultStorage.find();
-        CaseResult c;
-        if (!(storage instanceof FileJunitTestResultStorage)) {
-            Run<?, ?> run = Stapler.getCurrentRequest().findAncestorObject(Run.class);
-            TestResultImpl pluggableStorage = storage.load(run.getParent().getFullName(), run.getNumber());
-            c = pluggableStorage.getCaseResult(name);
-        } else {
-            c = getCaseResult(name);
-        }
+        CaseResult c = getCaseResult(name);
     	if (c != null) {
             return c;
     	} else {

--- a/src/main/java/io/jenkins/plugins/junit/storage/TestResultImpl.java
+++ b/src/main/java/io/jenkins/plugins/junit/storage/TestResultImpl.java
@@ -105,16 +105,7 @@ public interface TestResultImpl {
      */
     @CheckForNull
     TestResult getPreviousResult();
-
-    // These methods don't take into account context of packages
-    // so could easily lookup the wrong test
-    // they are used in the classic view for test results
-    ClassResult getClassResult(String name);
-    CaseResult getCaseResult(String name);
-
     SuiteResult getSuite(String name);
-
-    // end dodgy methods with no context
 
     float getTotalTestDuration();
 }

--- a/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
+++ b/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
@@ -485,50 +485,7 @@ public class TestResultStorageJunitTest {
                     });
 
                 }
-
-                @Override
-                public ClassResult getClassResult(String name) {
-                    return query(connection -> {
-                        try (PreparedStatement statement = connection.prepareStatement("SELECT suite, package, testname, classname, errordetails, skipped, duration, stdout, stderr, stacktrace FROM " + Impl.CASE_RESULTS_TABLE + " WHERE job = ? AND build = ? AND classname = ?")) {
-                            statement.setString(1, job);
-                            statement.setInt(2, build);
-                            statement.setString(3, name);
-                            try (ResultSet result = statement.executeQuery()) {
-
-                                ClassResult classResult = null;
-                                TestResult parent = new TestResult(this);
-                                while (result.next()) {
-                                    String testName = result.getString("testname");
-                                    String packageName = result.getString("package");
-                                    String errorDetails = result.getString("errordetails");
-                                    String suite = result.getString("suite");
-                                    String className = result.getString("classname");
-                                    String skipped = result.getString("skipped");
-                                    String stdout = result.getString("stdout");
-                                    String stderr = result.getString("stderr");
-                                    String stacktrace = result.getString("stacktrace");
-                                    float duration = result.getFloat("duration");
-                                    
-                                    if (classResult == null) {
-                                        classResult = new ClassResult(new PackageResult(new TestResult(this), packageName), className);
-                                    }
-
-                                    SuiteResult suiteResult = new SuiteResult(suite, null, null, null);
-                                    suiteResult.setParent(parent);
-                                    CaseResult caseResult = new CaseResult(suiteResult, className, testName, errorDetails, skipped, duration, stdout, stderr, stacktrace);
-                                    classResult.add(caseResult);
-                                    caseResult.setClass(classResult);
-                                }
-                                if (classResult != null) {
-                                    classResult.tally();
-                                }
-                                return classResult;
-                            }
-                        }
-                    });
-
-                }
-
+                
                 @Override
                 public Run<?, ?> getFailedSinceRun(CaseResult caseResult) {
                     return query(connection -> {
@@ -644,48 +601,6 @@ public class TestResultStorageJunitTest {
                     return retrieveCaseResult(column + " IS NOT NULL");
                 }
                 
-                @Override
-                public CaseResult getCaseResult(String testName) {
-                    return query(connection -> {
-                        try (PreparedStatement statement = connection.prepareStatement("SELECT suite, testname, package, classname, errordetails, skipped, duration, stdout, stderr, stacktrace FROM " + Impl.CASE_RESULTS_TABLE + " WHERE job = ? AND build = ? AND testname = ?")) {
-                            statement.setString(1, job);
-                            statement.setInt(2, build);
-                            statement.setString(3, testName);
-                            try (ResultSet result = statement.executeQuery()) {
-
-                                CaseResult caseResult = null;
-                                
-                                if (result.next()) {
-                                    String resultTestName = result.getString("testname");
-                                    String errorDetails = result.getString("errordetails");
-                                    String packageName = result.getString("package");
-                                    String suite = result.getString("suite");
-                                    String className = result.getString("classname");
-                                    String skipped = result.getString("skipped");
-                                    String stdout = result.getString("stdout");
-                                    String stderr = result.getString("stderr");
-                                    String stacktrace = result.getString("stacktrace");
-                                    float duration = result.getFloat("duration");
-
-                                    SuiteResult suiteResult = new SuiteResult(suite, null, null, null);
-                                    suiteResult.setParent(new TestResult(this));
-                                    caseResult = new CaseResult(suiteResult, className, resultTestName, errorDetails, skipped, duration, stdout, stderr, stacktrace);
-                                    PackageResult packageResult = new PackageResult(new TestResult(this), packageName);
-                                    ClassResult classResult = new ClassResult(packageResult, className);
-                                    classResult.add(caseResult);
-                                    packageResult.add(caseResult);
-                                    packageResult.tally();
-                                    caseResult.tally();
-                                    caseResult.setClass(classResult);
-                                }
-                                return caseResult;
-                            }
-                        }
-                    });
-
-
-                }
-
                 @Override
                 public SuiteResult getSuite(String name) {
                     return query(connection -> {


### PR DESCRIPTION
Cases are populated when the class result is retrieved from the DB