### PR TITLE
Allow setting custom checks name

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The JUnit publisher is configured at the job level by adding a Publish JUnit tes
   For example, if you are using this feature for a GitHub organization project, the warnings will be published to
   GitHub through the Checks API. If this operation slows down your build, or you don't want to publish the warnings to
   SCM platforms, you can use this option to deactivate this feature.
+* **Checks name:** If provided, and publishing checks enabled, the plugin will use this name when publishing
+  results to corresponding SCM hosting platforms. If not, a default of "Test" will be used.
 
 ### Test result checks (for GitHub projects)
 
@@ -49,4 +51,10 @@ In the *Details* view of each check ([example](https://github.com/timja-org/juni
 In order to disable the checks feature, set the property `skipPublishingChecks` to `true`:
 ```groovy
 junit skipPublishingChecks: true, testResults: 'test-results.xml'
+```
+
+In order to provide a custom check name, set the property `checksName`:
+
+```groovy
+junit checksName: 'Integration Tests', testResults: 'test-results.xml'
 ```

--- a/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
+++ b/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
@@ -93,6 +93,7 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
      */
     private boolean allowEmptyResults;
     private boolean skipPublishingChecks;
+    private String checksName;
 
     @DataBoundConstructor
     public JUnitResultArchiver(String testResults) {
@@ -185,6 +186,7 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
                 action.mergeResult(result, listener);
             }
             action.setHealthScaleFactor(task.getHealthScaleFactor()); // overwrites previous value if appending
+            action.setChecksName(task.getChecksName());
             if (result.isEmpty()) {
                 if (build.getResult() == Result.FAILURE) {
                     // most likely a build failed before it gets to the test phase.
@@ -260,6 +262,7 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
                 summary = new TestResultSummary(result);
             }
             action.setHealthScaleFactor(task.getHealthScaleFactor()); // overwrites previous value if appending
+            action.setChecksName(task.getChecksName());
             if (summary.getTotalCount() == 0 && /* maybe a secondary effect */ build.getResult() != Result.FAILURE) {
                 assert task.isAllowEmptyResults();
                 listener.getLogger().println(Messages.JUnitResultArchiver_ResultIsEmpty());
@@ -374,6 +377,16 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
     @DataBoundSetter
     public void setSkipPublishingChecks(boolean skipPublishingChecks) {
         this.skipPublishingChecks = skipPublishingChecks;
+    }
+
+    @Override
+    public String getChecksName() {
+        return checksName;
+    }
+
+    @DataBoundSetter
+    public void setChecksName(String checksName) {
+        this.checksName = checksName;
     }
 
     @DataBoundSetter public final void setAllowEmptyResults(boolean allowEmptyResults) {

--- a/src/main/java/hudson/tasks/junit/JUnitTask.java
+++ b/src/main/java/hudson/tasks/junit/JUnitTask.java
@@ -14,4 +14,6 @@ public interface JUnitTask {
     boolean isAllowEmptyResults();
     
     boolean isSkipPublishingChecks();
+
+    String getChecksName();
 }

--- a/src/main/java/hudson/tasks/junit/TestResultAction.java
+++ b/src/main/java/hudson/tasks/junit/TestResultAction.java
@@ -288,6 +288,10 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
     }
 
     public String getChecksName() {
+        if (Util.fixEmpty(checksName) == null) {
+            return "Tests";
+        }
+        
         return checksName;
     }
 

--- a/src/main/java/hudson/tasks/junit/TestResultAction.java
+++ b/src/main/java/hudson/tasks/junit/TestResultAction.java
@@ -75,6 +75,7 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
     private @Nullable Integer totalCount;
     private Double healthScaleFactor;
     private List<Data> testData = new ArrayList<>();
+    private String checksName;
 
     @Deprecated
     public TestResultAction(AbstractBuild owner, TestResult result, BuildListener listener) {
@@ -284,6 +285,14 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
         synchronized (testData) {
             this.testData.add(data);
         }
+    }
+
+    public String getChecksName() {
+        return checksName;
+    }
+
+    public void setChecksName(String checksName) {
+        this.checksName = checksName;
     }
 
     /**

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStep.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStep.java
@@ -53,6 +53,7 @@ public class JUnitResultsStep extends Step implements JUnitTask {
      */
     private boolean allowEmptyResults;
     private boolean skipPublishingChecks;
+    private String checksName;
 
     @DataBoundConstructor
     public JUnitResultsStep(String testResults) {
@@ -129,6 +130,16 @@ public class JUnitResultsStep extends Step implements JUnitTask {
     @DataBoundSetter
     public void setSkipPublishingChecks(boolean skipPublishingChecks) {
         this.skipPublishingChecks = skipPublishingChecks;
+    }
+
+    @Override
+    public String getChecksName() {
+        return checksName;
+    }
+
+    @DataBoundSetter
+    public void setChecksName(String checksName) {
+        this.checksName = checksName;
     }
 
     @DataBoundSetter public final void setAllowEmptyResults(boolean allowEmptyResults) {

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStep.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStep.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.Util;
 import hudson.model.Descriptor;
 import hudson.model.Saveable;
 import hudson.model.TaskListener;
@@ -134,6 +135,10 @@ public class JUnitResultsStep extends Step implements JUnitTask {
 
     @Override
     public String getChecksName() {
+        if (Util.fixEmpty(checksName) == null) {
+            return "Tests";
+        }
+        
         return checksName;
     }
 

--- a/src/main/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisher.java
@@ -47,7 +47,7 @@ public class JUnitChecksPublisher {
                 .build();
 
         return new ChecksDetails.ChecksDetailsBuilder()
-                .withName("Tests")
+                .withName(action.getChecksName() != null ? action.getChecksName() : "Tests")
                 .withStatus(ChecksStatus.COMPLETED)
                 .withConclusion(summary.getFailCount() > 0 ? ChecksConclusion.FAILURE : ChecksConclusion.SUCCESS)
                 .withDetailsURL(testsURL)

--- a/src/main/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisher.java
@@ -47,7 +47,7 @@ public class JUnitChecksPublisher {
                 .build();
 
         return new ChecksDetails.ChecksDetailsBuilder()
-                .withName(action.getChecksName() != null ? action.getChecksName() : "Tests")
+                .withName(action.getChecksName())
                 .withStatus(ChecksStatus.COMPLETED)
                 .withConclusion(summary.getFailCount() > 0 ? ChecksConclusion.FAILURE : ChecksConclusion.SUCCESS)
                 .withDetailsURL(testsURL)

--- a/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
+++ b/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
@@ -51,6 +51,6 @@ THE SOFTWARE.
         <f:checkbox title="${%If unchecked, then issues will be published to SCM provider platforms}" />
     </f:entry>
     <f:entry title="${%Checks name}" field="checksName">
-        <f:textbox />
+        <f:textbox default="Tests" />
     </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
+++ b/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
@@ -50,4 +50,7 @@ THE SOFTWARE.
              field="skipPublishingChecks">
         <f:checkbox title="${%If unchecked, then issues will be published to SCM provider platforms}" />
     </f:entry>
+    <f:entry title="${%Checks name}" field="checksName">
+        <f:textbox />
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/help-checksName.html
+++ b/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/help-checksName.html
@@ -1,0 +1,4 @@
+<div>
+    If provided, and publishing checks enabled, the plugin will use this name when publishing results to corresponding
+    SCM hosting platforms. If not, a default of "Test" will be used.
+</div>

--- a/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/help-checksName.html
+++ b/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/help-checksName.html
@@ -1,4 +1,4 @@
 <div>
     If provided, and publishing checks enabled, the plugin will use this name when publishing results to corresponding
-    SCM hosting platforms. If not, a default of "Test" will be used.
+    SCM hosting platforms. If not, a default of "Tests" will be used.
 </div>

--- a/src/main/resources/hudson/tasks/junit/pipeline/JUnitResultsStep/help-checksName.html
+++ b/src/main/resources/hudson/tasks/junit/pipeline/JUnitResultsStep/help-checksName.html
@@ -1,0 +1,4 @@
+<div>
+    If provided, and publishing checks enabled, the plugin will use this name when publishing results to corresponding
+    SCM hosting platforms. If not, a default of "Test" will be used.
+</div>

--- a/src/main/resources/hudson/tasks/junit/pipeline/JUnitResultsStep/help-checksName.html
+++ b/src/main/resources/hudson/tasks/junit/pipeline/JUnitResultsStep/help-checksName.html
@@ -1,4 +1,4 @@
 <div>
     If provided, and publishing checks enabled, the plugin will use this name when publishing results to corresponding
-    SCM hosting platforms. If not, a default of "Test" will be used.
+    SCM hosting platforms. If not, a default of "Tests" will be used.
 </div>

--- a/src/test/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisherTest.java
+++ b/src/test/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisherTest.java
@@ -8,8 +8,6 @@ import hudson.tasks.junit.TestResultTest;
 import io.jenkins.plugins.checks.api.ChecksConclusion;
 import io.jenkins.plugins.checks.api.ChecksDetails;
 import io.jenkins.plugins.checks.api.ChecksOutput;
-import java.nio.charset.StandardCharsets;
-import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;

--- a/src/test/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisherTest.java
+++ b/src/test/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisherTest.java
@@ -33,7 +33,7 @@ public class JUnitChecksPublisherTest {
         WorkflowJob j = rule.jenkins.createProject(WorkflowJob.class, "singleStep");
         j.setDefinition(new CpsFlowDefinition("stage('first') {\n" +
                 "  node {\n" +
-                "    def results = junit(testResults: '*.xml')\n" + // node id 7
+                "    def results = junit(testResults: '*.xml')\n" +
                 "    assert results.totalCount == 6\n" +
                 "  }\n" +
                 "}\n", true));
@@ -64,7 +64,7 @@ public class JUnitChecksPublisherTest {
         WorkflowJob j = rule.jenkins.createProject(WorkflowJob.class, "singleStep");
         j.setDefinition(new CpsFlowDefinition("stage('first') {\n" +
                 "  node {\n" +
-                "    def results = junit(testResults: '*.xml')\n" + // node id 7
+                "    def results = junit(testResults: '*.xml')\n" +
                 "    assert results.totalCount == 6\n" +
                 "  }\n" +
                 "}\n", true));
@@ -93,7 +93,7 @@ public class JUnitChecksPublisherTest {
         WorkflowJob j = rule.jenkins.createProject(WorkflowJob.class, "singleStep");
         j.setDefinition(new CpsFlowDefinition("stage('first') {\n" +
                 "  node {\n" +
-                "    def results = junit(testResults: '*.xml')\n" + // node id 7
+                "    def results = junit(testResults: '*.xml')\n" +
                 "    assert results.totalCount == 6\n" +
                 "  }\n" +
                 "}\n", true));
@@ -122,7 +122,7 @@ public class JUnitChecksPublisherTest {
         WorkflowJob j = rule.jenkins.createProject(WorkflowJob.class, "singleStep");
         j.setDefinition(new CpsFlowDefinition("stage('first') {\n" +
               "  node {\n" +
-              "    def results = junit(testResults: '*.xml', checksName: 'Custom Checks Name')\n" + // node id 7
+              "    def results = junit(testResults: '*.xml', checksName: 'Custom Checks Name')\n" +
               "    assert results.totalCount == 6\n" +
               "  }\n" +
               "}\n", true));

--- a/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
+++ b/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
@@ -157,7 +157,7 @@ public class TestResultStorageJunitTest {
                     childNames.add(((Element) item).getTagName());
                 }
             }
-            assertEquals(buildXml, ImmutableSet.of("healthScaleFactor", "testData", "descriptions"), childNames);
+            assertEquals(buildXml, ImmutableSet.of("checksName", "healthScaleFactor", "testData", "descriptions"), childNames);
         }
         Impl.queriesPermitted = true;
         {


### PR DESCRIPTION
Adds the ability to set a custom name for the Checks API for each junit invocation.

I could see a number of ways to skin this cat, so I've picked this one on a fairly arbitrary basis.

This is also my first contribution to a jenkins plugin so please forgive anything I've missed!