### PR TITLE
Add ability to ignore current stage name when computing test names 

### DIFF
--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStep.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStep.java
@@ -53,6 +53,7 @@ public class JUnitResultsStep extends Step implements JUnitTask {
      */
     private boolean allowEmptyResults;
     private boolean skipPublishingChecks;
+    private boolean ignoreCurrentStage;
 
     @DataBoundConstructor
     public JUnitResultsStep(String testResults) {
@@ -129,6 +130,15 @@ public class JUnitResultsStep extends Step implements JUnitTask {
     @DataBoundSetter
     public void setSkipPublishingChecks(boolean skipPublishingChecks) {
         this.skipPublishingChecks = skipPublishingChecks;
+    }
+
+    public boolean isIgnoreCurrentStage() {
+        return ignoreCurrentStage;
+    }
+
+    @DataBoundSetter
+    public void setIgnoreCurrentStage(boolean ignoreCurrentStage) {
+        this.ignoreCurrentStage = ignoreCurrentStage;
     }
 
     @DataBoundSetter public final void setAllowEmptyResults(boolean allowEmptyResults) {

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
@@ -44,6 +44,12 @@ public class JUnitResultsStepExecution extends SynchronousNonBlockingStepExecuti
 
         List<FlowNode> enclosingBlocks = getEnclosingStagesAndParallels(node);
 
+        if (step.isIgnoreCurrentStage()) {
+            FlowNode newParent = enclosingBlocks.get(0);
+            enclosingBlocks.remove(newParent);
+            nodeId = newParent.getId();
+        }
+
         PipelineTestDetails pipelineTestDetails = new PipelineTestDetails();
         pipelineTestDetails.setNodeId(nodeId);
         pipelineTestDetails.setEnclosingBlocks(getEnclosingBlockIds(enclosingBlocks));


### PR DESCRIPTION
Opening this PR as a way to demonstrate the problem I'm trying to fix:

I currently have a pipeline that looks something like this:
```
-- unit tests -- / -- integration chunking -- \ -- chunk 1 -- / -- integration test reporting --
                                              |               |
                                              \ -- chunk 2 -- /
                                              |               |
                                              \ -- chunk 3 -- /
```

That is, we run some fast unit tests, and then split up our slow integration tests to be run in chunks on multiple agents, in parallel. This chunking is optimised for evenly sized bins, so which tests are in which chunks will change on each run. At the end of each chunk we stash the junit xml file, and in a final stage once all chunks have run we unstash them all and invoke junit.

The reason we have to do it this convoluted way is that if we were to invoke junit in the chunks, we would end up with the chunk name in the test report, which would make tracking test stability over time effectively impossible.

While this workaround is serving us reasonably well, it is quite annoying when a single test fails and you have to do the legwork to find out which of the chunks the test failed in, so you can download the relevant artifacts and do some sniffing.

This PR, which I do not claim to be the right solution to this problem, merely _a_ solution, helps us with this by adding an option to ignore the innermost stage name when calculating enclosing blocks, effectively re-scoping the junit invocation to the stage containing the parallel invocations.

Could I please have some thoughts on whether this is a completely ridiculous idea and I should continue to just use our workable workaround, whether there's a way of doing this without code change, or any other ideas for how to skin this particular cat.