### PR TITLE
Publish only results included in current invocation to checks api - fixes #198

### DIFF
--- a/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
+++ b/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
@@ -186,7 +186,6 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
                 action.mergeResult(result, listener);
             }
             action.setHealthScaleFactor(task.getHealthScaleFactor()); // overwrites previous value if appending
-            action.setChecksName(task.getChecksName());
             if (result.isEmpty()) {
                 if (build.getResult() == Result.FAILURE) {
                     // most likely a build failed before it gets to the test phase.
@@ -262,7 +261,6 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
                 summary = new TestResultSummary(result);
             }
             action.setHealthScaleFactor(task.getHealthScaleFactor()); // overwrites previous value if appending
-            action.setChecksName(task.getChecksName());
             if (summary.getTotalCount() == 0 && /* maybe a secondary effect */ build.getResult() != Result.FAILURE) {
                 assert task.isAllowEmptyResults();
                 listener.getLogger().println(Messages.JUnitResultArchiver_ResultIsEmpty());
@@ -284,7 +282,7 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
             }
 
             if (!task.isSkipPublishingChecks()) {
-                new JUnitChecksPublisher(action, summary).publishChecks(listener);
+                new JUnitChecksPublisher(build, task.getChecksName(), result, summary).publishChecks(listener);
             }
 
             return summary;

--- a/src/main/java/hudson/tasks/junit/TestResultAction.java
+++ b/src/main/java/hudson/tasks/junit/TestResultAction.java
@@ -75,7 +75,6 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
     private @Nullable Integer totalCount;
     private Double healthScaleFactor;
     private List<Data> testData = new ArrayList<>();
-    private String checksName;
 
     @Deprecated
     public TestResultAction(AbstractBuild owner, TestResult result, BuildListener listener) {
@@ -285,18 +284,6 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
         synchronized (testData) {
             this.testData.add(data);
         }
-    }
-
-    public String getChecksName() {
-        if (Util.fixEmpty(checksName) == null) {
-            return "Tests";
-        }
-        
-        return checksName;
-    }
-
-    public void setChecksName(String checksName) {
-        this.checksName = checksName;
     }
 
     /**

--- a/src/test/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisherTest.java
+++ b/src/test/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisherTest.java
@@ -44,7 +44,7 @@ public class JUnitChecksPublisherTest {
         assertNotNull(action);
 
         TestResultSummary summary = new TestResultSummary(0, 0, 6, 6);
-        JUnitChecksPublisher publisher = new JUnitChecksPublisher(action, summary);
+        JUnitChecksPublisher publisher = new JUnitChecksPublisher(r, null, action.getResult(), summary);
         ChecksDetails checksDetails = publisher.extractChecksDetails();
 
         assertThat(checksDetails.getConclusion(), is(ChecksConclusion.SUCCESS));
@@ -75,10 +75,11 @@ public class JUnitChecksPublisherTest {
         assertNotNull(action);
 
         TestResultSummary summary = new TestResultSummary(1, 0, 1, 2);
-        JUnitChecksPublisher publisher = new JUnitChecksPublisher(action, summary);
+        JUnitChecksPublisher publisher = new JUnitChecksPublisher(r, "", action.getResult(), summary);
         ChecksDetails checksDetails = publisher.extractChecksDetails();
 
         assertThat(checksDetails.getConclusion(), is(ChecksConclusion.FAILURE));
+        assertThat(checksDetails.getName().get(), is("Tests"));
 
         ChecksOutput output = checksDetails.getOutput().get();
 
@@ -104,10 +105,11 @@ public class JUnitChecksPublisherTest {
         assertNotNull(action);
 
         TestResultSummary summary = new TestResultSummary(3, 0, 5, 8);
-        JUnitChecksPublisher publisher = new JUnitChecksPublisher(action, summary);
+        JUnitChecksPublisher publisher = new JUnitChecksPublisher(r, "Tests", action.getResult(), summary);
         ChecksDetails checksDetails = publisher.extractChecksDetails();
 
         assertThat(checksDetails.getConclusion(), is(ChecksConclusion.FAILURE));
+        assertThat(checksDetails.getName().get(), is("Tests"));
 
         ChecksOutput output = checksDetails.getOutput().get();
 
@@ -133,7 +135,7 @@ public class JUnitChecksPublisherTest {
         assertNotNull(action);
 
         TestResultSummary summary = new TestResultSummary(0, 0, 6, 6);
-        JUnitChecksPublisher publisher = new JUnitChecksPublisher(action, summary);
+        JUnitChecksPublisher publisher = new JUnitChecksPublisher(r, "Custom Checks Name", action.getResult(), summary);
         ChecksDetails checksDetails = publisher.extractChecksDetails();
 
         assertThat(checksDetails.getConclusion(), is(ChecksConclusion.SUCCESS));

--- a/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
+++ b/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
@@ -157,7 +157,7 @@ public class TestResultStorageJunitTest {
                     childNames.add(((Element) item).getTagName());
                 }
             }
-            assertEquals(buildXml, ImmutableSet.of("checksName", "healthScaleFactor", "testData", "descriptions"), childNames);
+            assertEquals(buildXml, ImmutableSet.of("healthScaleFactor", "testData", "descriptions"), childNames);
         }
         Impl.queriesPermitted = true;
         {


### PR DESCRIPTION
This, I believe, should fix the problem described in #198. However, I'm at a bit of a loss as to how best to test it, short of mocking a checks publisher and inspecting calls to that.

fixes #198