### PR TITLE
Fixing build link in history table when viewing a Test method's history

### DIFF
--- a/src/main/resources/hudson/tasks/junit/CaseResult/list.jelly
+++ b/src/main/resources/hudson/tasks/junit/CaseResult/list.jelly
@@ -41,7 +41,7 @@ THE SOFTWARE.
         <j:if test="${test != null}">
           <tr>
             <td class="pane">
-              <a href="${app.rootUrl}${p.url}" class="model-link inside">${b.fullDisplayName}</a>
+              <a href="${app.rootUrl}${b.url}" class="model-link inside">${b.fullDisplayName}</a>
               <j:forEach var="badge" items="${test.testActions}">
                 <st:include it="${badge}" page="badge.jelly" optional="true"/>
               </j:forEach>


### PR DESCRIPTION
Fixes #200 - fixing url creation when showing the single test case