### PR TITLE
Add support for https testng DTD namespace

### DIFF
--- a/src/main/java/hudson/tasks/junit/XMLEntityResolver.java
+++ b/src/main/java/hudson/tasks/junit/XMLEntityResolver.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Jorg Heymans
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,6 +23,7 @@
  */
 package hudson.tasks.junit;
 
+import org.apache.commons.lang.StringUtils;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -46,7 +47,8 @@ import java.util.logging.Logger;
  */
 public class XMLEntityResolver implements EntityResolver {
 
-    private static final String TESTNG_NAMESPACE = "http://testng.org/";
+    private static final String TESTNG_HTTP_NAMESPACE = "http://testng.org/";
+    private static final String TESTNG_HTTPS_NAMESPACE = "https://testng.org/";
 
     /**
      * Intercepts the lookup of publicId, systemId
@@ -57,9 +59,9 @@ public class XMLEntityResolver implements EntityResolver {
                 LOGGER.fine("Will try to resolve systemId [" + systemId + "]");
             }
             // TestNG system-ids
-            if (systemId.startsWith(TESTNG_NAMESPACE)) {
+            if (systemId.startsWith(TESTNG_HTTP_NAMESPACE) || systemId.startsWith(TESTNG_HTTPS_NAMESPACE)) {
                 LOGGER.fine("It's a TestNG document, will try to lookup DTD in classpath");
-                String dtdFileName = systemId.substring(TESTNG_NAMESPACE.length());
+                String dtdFileName = StringUtils.substringAfterLast(systemId, "/");
 
                 URL url = getClass().getClassLoader().getResource(dtdFileName);
                 if (url != null)


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
TestNG outputs the following DTD line:
`<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">`

When using `XMLEntityResolver` on testng with https DTD, you end up with a NPE:

```
org.dom4j.DocumentException: null Nested exception: null
	at org.dom4j.io.SAXReader.read(SAXReader.java:484)
	at org.dom4j.io.SAXReader.read(SAXReader.java:343)
	at hudson.tasks.junit.SuiteResult.parse(SuiteResult.java:178)
	at hudson.tasks.junit.TestResult.parse(TestResult.java:348)
	at hudson.tasks.junit.TestResult.parsePossiblyEmpty(TestResult.java:281)
	at hudson.tasks.junit.TestResult.parse(TestResult.java:206)
	at hudson.tasks.junit.TestResult.parse(TestResult.java:178)
	at hudson.tasks.junit.TestResult.<init>(TestResult.java:143)
	at hudson.tasks.junit.JUnitParser$ParseResultCallable.invoke(JUnitParser.java:146)
	at hudson.tasks.junit.JUnitParser$ParseResultCallable.invoke(JUnitParser.java:118)
	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:3050)
	at hudson.remoting.UserRequest.perform(UserRequest.java:212)
	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
	at hudson.remoting.Request$2.run(Request.java:369)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

The solution was to add support for `https` prefix in the DTD namespace.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
