### PR TITLE
Upgrade trends and detail views to Bootstrap 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>echarts-api</artifactId>
-            <version>5.1.0-3-rc454.dbbdd5633ce2</version>
+            <version>5.1.0-3-rc464.d7d9d5650d0a</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>bootstrap5-api</artifactId>
-            <version>5.0.1-1</version>
+            <version>5.0.1-2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>echarts-api</artifactId>
-            <version>5.1.0-3-rc443.de651a379c4a</version>
+            <version>5.1.0-3-rc454.dbbdd5633ce2</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,12 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>junit</artifactId>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -201,7 +207,7 @@
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>font-awesome-api</artifactId>
-                <version>5.15.3-2</version>
+                <version>5.15.3-3</version>
             </dependency>
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
@@ -211,7 +217,7 @@
             <dependency>
                 <groupId>io.jenkins.plugins</groupId>
                 <artifactId>plugin-util-api</artifactId>
-                <version>2.2.0</version>
+                <version>2.3.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,11 @@
                 <artifactId>plugin-util-api</artifactId>
                 <version>2.3.0</version>
             </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>jackson2-api</artifactId>
+                <version>2.12.3</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>echarts-api</artifactId>
-            <version>5.1.2-6-rc504.fd62772631c3</version>
+            <version>5.1.2-6</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>echarts-api</artifactId>
-            <version>5.1.0-3-rc464.d7d9d5650d0a</version>
+            <version>5.1.2-1</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -16,14 +16,14 @@
         <revision>1.50</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.249.1</jenkins.version>
+        <jenkins.version>2.263.1</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
     </properties>
     <licenses>
         <license>
             <name>MIT</name>
-            <url>http://opensource.org/licenses/MIT</url>
+            <url>https://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
     <scm>
@@ -48,17 +48,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>echarts-api</artifactId>
-            <version>5.1.2-2</version>
-        </dependency>
-        <dependency>
-            <groupId>io.jenkins.plugins</groupId>
-            <artifactId>checks-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.jenkins.plugins</groupId>
-            <artifactId>checks-api</artifactId>
-            <scope>test</scope>
-            <classifier>tests</classifier>
+            <version>5.1.2-6-rc504.fd62772631c3</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
@@ -70,14 +60,18 @@
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
-            <artifactId>github-checks</artifactId>
-            <version>1.0.9</version>
-            <scope>test</scope>
+            <artifactId>bootstrap5-api</artifactId>
+            <version>5.1.0-1</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
-            <artifactId>bootstrap5-api</artifactId>
-            <version>5.0.1-2</version>
+            <artifactId>font-awesome-api</artifactId>
+            <version>5.15.3-4</version> <!-- TODO merged but not released in bom -->
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jquery3-api</artifactId>
+            <version>3.6.0-2</version> <!-- TODO merged but not released in bom -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -91,6 +85,28 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jackson2-api</artifactId>
+        </dependency>
+        <!-- Checks API -->
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>checks-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>checks-api</artifactId>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>github-checks</artifactId>
+            <version>1.0.9</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- End Checks API -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -158,14 +174,8 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>database</artifactId>
-            <version>1.7</version>
+            <version>114.v0e004e100040</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion> <!-- TODO move to bom in Jenkins core -->
-                    <groupId>antlr</groupId>
-                    <artifactId>antlr</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -190,39 +200,15 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>jackson2-api</artifactId>
-        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.222.x</artifactId>
-                <version>26</version>
+                <artifactId>bom-2.263.x</artifactId>
+                <version>919.v3c802a29576e</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>io.jenkins.plugins</groupId>
-                <artifactId>font-awesome-api</artifactId>
-                <version>5.15.3-3</version>
-            </dependency>
-            <dependency>
-                <groupId>io.jenkins.plugins</groupId>
-                <artifactId>jquery3-api</artifactId>
-                <version>3.6.0-1</version>
-            </dependency>
-            <dependency>
-                <groupId>io.jenkins.plugins</groupId>
-                <artifactId>plugin-util-api</artifactId>
-                <version>2.3.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>jackson2-api</artifactId>
-                <version>2.12.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>echarts-api</artifactId>
-            <version>5.1.0-3-rc442.19377bcf1d00</version>
+            <version>5.1.0-3-rc443.de651a379c4a</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>echarts-api</artifactId>
-            <version>5.1.2-1</version>
+            <version>5.1.2-2</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <revision>1.50</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.222.4</jenkins.version>
+        <jenkins.version>2.249.1</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
     </properties>
@@ -48,6 +48,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>echarts-api</artifactId>
+            <version>5.1.0-3-rc442.19377bcf1d00</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
@@ -75,7 +76,8 @@
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
-            <artifactId>bootstrap4-api</artifactId>
+            <artifactId>bootstrap5-api</artifactId>
+            <version>5.0.1-1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -195,6 +197,21 @@
                 <version>26</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>font-awesome-api</artifactId>
+                <version>5.15.3-2</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>jquery3-api</artifactId>
+                <version>3.6.0-1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>plugin-util-api</artifactId>
+                <version>2.2.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/hudson/tasks/junit/History.java
+++ b/src/main/java/hudson/tasks/junit/History.java
@@ -69,12 +69,6 @@ public class History {
         return testObject.getRun().getParent().getBuilds().size() > 1;
     }
 
-    @Deprecated
-    @SuppressWarnings("unused") // Called by jelly view
-    public String getTestResultTrend() {
-        return getTestResultTrend(EMPTY_CONFIGURATION);
-    }
-
     @JavaScriptMethod
     @SuppressWarnings("unused") // Called by jelly view
     public String getTestResultTrend(final String configuration) {
@@ -91,12 +85,6 @@ public class History {
         }
 
         return new TestResultTrendChart().createFromTestObject(createBuildHistory(testObject), chartModelConfiguration);
-    }
-
-    @Deprecated
-    @SuppressWarnings("unused") // Called by jelly view
-    public String getTestDurationTrend() {
-        return getTestDurationTrend(EMPTY_CONFIGURATION);
     }
 
     @JavaScriptMethod

--- a/src/main/java/hudson/tasks/test/TestResultDurationChart.java
+++ b/src/main/java/hudson/tasks/test/TestResultDurationChart.java
@@ -1,25 +1,23 @@
 package hudson.tasks.test;
 
+import java.util.List;
+
 import edu.hm.hafner.echarts.ChartModelConfiguration;
 import edu.hm.hafner.echarts.LineSeries;
 import edu.hm.hafner.echarts.LinesChartModel;
 import edu.hm.hafner.echarts.LinesDataSet;
 import edu.hm.hafner.echarts.Palette;
-import hudson.tasks.junit.TestDurationResultSummary;
-import hudson.tasks.junit.TrendTestResultSummary;
-import java.util.List;
 
-import static hudson.tasks.test.TestDurationTrendSeriesBuilder.SECONDS;
-import static hudson.tasks.test.TestResultTrendSeriesBuilder.FAILED_KEY;
-import static hudson.tasks.test.TestResultTrendSeriesBuilder.PASSED_KEY;
-import static hudson.tasks.test.TestResultTrendSeriesBuilder.SKIPPED_KEY;
+import hudson.tasks.junit.TestDurationResultSummary;
+
+import static hudson.tasks.test.TestDurationTrendSeriesBuilder.*;
 
 public class TestResultDurationChart {
-    
-    public LinesChartModel create(List<TestDurationResultSummary> results) {
+
+    public LinesChartModel create(final List<TestDurationResultSummary> results) {
         LinesDataSet dataset = new LinesDataSet();
         results.forEach(result -> dataset.add(result.getDisplayName(), result.toMap(), result.getBuildNumber()));
-        
+
         return getLinesChartModel(dataset);
     }
 
@@ -31,16 +29,13 @@ public class TestResultDurationChart {
         return getLinesChartModel(dataSet);
     }
 
-    private LinesChartModel getLinesChartModel(LinesDataSet dataSet) {
-        LinesChartModel model = new LinesChartModel();
-        model.setDomainAxisLabels(dataSet.getDomainAxisLabels());
-        model.setBuildNumbers(dataSet.getBuildNumbers());
-
+    private LinesChartModel getLinesChartModel(final LinesDataSet dataSet) {
+        LinesChartModel model = new LinesChartModel(dataSet);
         LineSeries duration = new LineSeries(SECONDS, Palette.GREEN.getNormal(),
                 LineSeries.StackedMode.STACKED, LineSeries.FilledMode.FILLED);
         duration.addAll(dataSet.getSeries(SECONDS));
         model.addSeries(duration);
-        
+
         return model;
     }
 }

--- a/src/main/java/hudson/tasks/test/TestResultProjectAction.java
+++ b/src/main/java/hudson/tasks/test/TestResultProjectAction.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,29 +23,32 @@
  */
 package hudson.tasks.test;
 
+import java.io.IOException;
+import java.util.List;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
 import edu.hm.hafner.echarts.ChartModelConfiguration;
 import edu.hm.hafner.echarts.JacksonFacade;
 import edu.hm.hafner.echarts.LinesChartModel;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+
+import org.kohsuke.stapler.Ancestor;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.bind.JavaScriptMethod;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.tasks.junit.JUnitResultArchiver;
-import io.jenkins.plugins.junit.storage.FileJunitTestResultStorage;
-import io.jenkins.plugins.junit.storage.TestResultImpl;
-import io.jenkins.plugins.junit.storage.JunitTestResultStorage;
-import io.jenkins.plugins.echarts.AsyncTrendChart;
-import org.kohsuke.stapler.Ancestor;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.List;
-import org.kohsuke.stapler.bind.JavaScriptMethod;
+import io.jenkins.plugins.echarts.AsyncConfigurableTrendChart;
+import io.jenkins.plugins.echarts.AsyncTrendChart;
+import io.jenkins.plugins.junit.storage.FileJunitTestResultStorage;
+import io.jenkins.plugins.junit.storage.JunitTestResultStorage;
+import io.jenkins.plugins.junit.storage.TestResultImpl;
 
 /**
  * Project action object from test reporter, such as {@link JUnitResultArchiver},
@@ -56,7 +59,7 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
  *
  * @author Kohsuke Kawaguchi
  */
-public class TestResultProjectAction implements Action, AsyncTrendChart {
+public class TestResultProjectAction implements Action, AsyncTrendChart, AsyncConfigurableTrendChart {
     /**
      * Project that owns this action.
      * @since 1.2-beta-1
@@ -69,13 +72,13 @@ public class TestResultProjectAction implements Action, AsyncTrendChart {
     /**
      * @since 1.2-beta-1
      */
-    public TestResultProjectAction(Job<?,?> job) {
+    public TestResultProjectAction(final Job<?,?> job) {
         this.job = job;
         project = job instanceof AbstractProject ? (AbstractProject) job : null;
     }
 
     @Deprecated
-    public TestResultProjectAction(AbstractProject<?,?> project) {
+    public TestResultProjectAction(final AbstractProject<?,?> project) {
         this((Job) project);
     }
 
@@ -111,7 +114,12 @@ public class TestResultProjectAction implements Action, AsyncTrendChart {
         return null;
     }
 
+    @Deprecated
     protected LinesChartModel createChartModel() {
+        return createChartModel(new ChartModelConfiguration());
+    }
+
+    private LinesChartModel createChartModel(final ChartModelConfiguration configuration) {
         Run<?, ?> lastCompletedBuild = job.getLastCompletedBuild();
 
         JunitTestResultStorage storage = JunitTestResultStorage.find();
@@ -124,11 +132,11 @@ public class TestResultProjectAction implements Action, AsyncTrendChart {
         if (buildHistory == null) {
             return new LinesChartModel();
         }
-        return new TestResultTrendChart().create(buildHistory, new ChartModelConfiguration());
+        return new TestResultTrendChart().create(buildHistory, configuration);
     }
 
     @CheckForNull
-    private TestResultActionIterable createBuildHistory(Run<?, ?> lastCompletedBuild) {
+    private TestResultActionIterable createBuildHistory(final Run<?, ?> lastCompletedBuild) {
         // some plugins that depend on junit seem to attach the action even though there's no run
         // e.g. xUnit and cucumber
         if (lastCompletedBuild == null) {
@@ -150,11 +158,11 @@ public class TestResultProjectAction implements Action, AsyncTrendChart {
 
     /**
      * Display the test result trend.
-     * 
+     *
      * @deprecated Replaced by echarts in TODO
      */
     @Deprecated
-    public void doTrend( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
+    public void doTrend( final StaplerRequest req, final StaplerResponse rsp ) throws IOException, ServletException {
         AbstractTestResultAction a = getLastTestResultAction();
         if(a!=null)
             a.doGraph(req,rsp);
@@ -168,7 +176,7 @@ public class TestResultProjectAction implements Action, AsyncTrendChart {
      * @deprecated Replaced by echarts in TODO
      */
     @Deprecated
-    public void doTrendMap( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
+    public void doTrendMap( final StaplerRequest req, final StaplerResponse rsp ) throws IOException, ServletException {
         AbstractTestResultAction a = getLastTestResultAction();
         if(a!=null)
             a.doGraphMap(req,rsp);
@@ -179,7 +187,7 @@ public class TestResultProjectAction implements Action, AsyncTrendChart {
     /**
      * Changes the test result report display mode.
      */
-    public void doFlipTrend( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
+    public void doFlipTrend( final StaplerRequest req, final StaplerResponse rsp ) throws IOException, ServletException {
         boolean failureOnly = false;
 
         // check the current preference value
@@ -197,7 +205,7 @@ public class TestResultProjectAction implements Action, AsyncTrendChart {
         // set the updated value
         Cookie cookie = new Cookie(FAILURE_ONLY_COOKIE,String.valueOf(failureOnly));
         List<Ancestor> anc = req.getAncestors();
-        Ancestor a = (Ancestor) anc.get(anc.size()-2);
+        Ancestor a = anc.get(anc.size()-2);
         cookie.setPath(a.getUrl()); // just for this project
         cookie.setMaxAge(60*60*24*365); // 1 year
         rsp.addCookie(cookie);
@@ -208,10 +216,15 @@ public class TestResultProjectAction implements Action, AsyncTrendChart {
 
     private static final String FAILURE_ONLY_COOKIE = "TestResultAction_failureOnly";
 
-    @JavaScriptMethod
-    @Override
+    @Override @Deprecated
     public String getBuildTrendModel() {
         return new JacksonFacade().toJson(createChartModel());
+    }
+
+    @JavaScriptMethod
+    @Override
+    public String getConfigurableBuildTrendModel(final String configuration) {
+        return new JacksonFacade().toJson(createChartModel(ChartModelConfiguration.fromJson(configuration)));
     }
 
     @Override

--- a/src/main/java/hudson/tasks/test/TestResultTrendChart.java
+++ b/src/main/java/hudson/tasks/test/TestResultTrendChart.java
@@ -1,24 +1,24 @@
 package hudson.tasks.test;
 
+import java.util.List;
+
 import edu.hm.hafner.echarts.ChartModelConfiguration;
 import edu.hm.hafner.echarts.LineSeries;
 import edu.hm.hafner.echarts.LinesChartModel;
 import edu.hm.hafner.echarts.LinesDataSet;
 import edu.hm.hafner.echarts.Palette;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.tasks.junit.TrendTestResultSummary;
-import java.util.List;
 
-import static hudson.tasks.test.TestResultTrendSeriesBuilder.FAILED_KEY;
-import static hudson.tasks.test.TestResultTrendSeriesBuilder.PASSED_KEY;
-import static hudson.tasks.test.TestResultTrendSeriesBuilder.SKIPPED_KEY;
+import hudson.tasks.junit.TrendTestResultSummary;
+
+import static hudson.tasks.test.TestResultTrendSeriesBuilder.*;
 
 public class TestResultTrendChart {
-    
-    public LinesChartModel create(List<TrendTestResultSummary> results) {
+
+    public LinesChartModel create(final List<TrendTestResultSummary> results) {
         LinesDataSet dataset = new LinesDataSet();
         results.forEach(result -> dataset.add(result.getDisplayName(), result.toMap(), result.getBuildNumber()));
-        
+
         return getLinesChartModel(dataset);
     }
 
@@ -29,7 +29,7 @@ public class TestResultTrendChart {
 
         return getLinesChartModel(dataSet);
     }
-    
+
     public LinesChartModel createFromTestObject(final Iterable results,
                                   final ChartModelConfiguration configuration) {
         TestObjectTrendSeriesBuilder builder = new TestObjectTrendSeriesBuilder();
@@ -38,11 +38,8 @@ public class TestResultTrendChart {
         return getLinesChartModel(dataSet);
     }
 
-    private LinesChartModel getLinesChartModel(LinesDataSet dataSet) {
-        LinesChartModel model = new LinesChartModel();
-        model.setDomainAxisLabels(dataSet.getDomainAxisLabels());
-        model.setBuildNumbers(dataSet.getBuildNumbers());
-
+    private LinesChartModel getLinesChartModel(final LinesDataSet dataSet) {
+        LinesChartModel model = new LinesChartModel(dataSet);
         LineSeries failed = new LineSeries("Failed", Palette.RED.getNormal(),
                 LineSeries.StackedMode.STACKED, LineSeries.FilledMode.FILLED);
         failed.addAll(dataSet.getSeries(FAILED_KEY));

--- a/src/main/resources/hudson/tasks/junit/History/index.jelly
+++ b/src/main/resources/hudson/tasks/junit/History/index.jelly
@@ -24,20 +24,22 @@ THE SOFTWARE.
 
 <!-- Displays the chart that show how long builds are taking -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:bs="/bootstrap">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:bs="/bootstrap5">
   <bs:layout title="${%title(it.testObject.displayName)}">
     <j:set var="start" value="${it.asInt(request.getParameter('start'),0)}"/>
     <j:set var="end" value="${it.asInt(request.getParameter('end'),start+24)}"/>
     <j:set var="rangeParameters" value="start=${start}&amp;end=${end+1}"/>
-    <link rel="stylesheet" href="${resURL}/plugin/junit/history/history.css"/>
+
     <st:adjunct includes="io.jenkins.plugins.echarts"/>
+    <st:adjunct includes="io.jenkins.plugins.bootstrap5"/>
+    <st:adjunct includes="io.jenkins.plugins.echarts-trend-configuration-dialog"/>
 
     <st:include from="${it.testObject}" it="${it.testObject}" page="sidepanel.jelly"/>
     <l:main-panel>
       <j:choose>
         <j:when test="${it.historyAvailable()}">
           <bs:card title="${%History}" fontAwesomeIcon="chart-line">
-            <div id="trend-carousel" class="carousel slide" data-interval="false">
+            <div id="trend-carousel" class="carousel slide carousel-dark" data-bs-interval="false">
               <div class="carousel-inner">
                 <div class="carousel-item">
                   <div id="test-duration-trend-chart" class="graph-cursor-pointer card-chart"/>
@@ -46,14 +48,14 @@ THE SOFTWARE.
                   <div id="test-result-trend-chart" class="graph-cursor-pointer card-chart"/>
                 </div>
               </div>
-              <a class="carousel-control-prev" data-target="#trend-carousel" role="button" data-slide="prev">
+              <button class="carousel-control-prev" type="button" data-bs-target="#trend-carousel" data-bs-slide="prev">
                 <span class="carousel-control-prev-icon" aria-hidden="true"/>
-                <span class="sr-only">Previous</span>
-              </a>
-              <a class="carousel-control-next" data-target="#trend-carousel" role="button" data-slide="next">
+                <span class="visually-hidden">Previous</span>
+              </button>
+              <button class="carousel-control-next" type="button" data-bs-target="#trend-carousel" data-bs-slide="next">
                 <span class="carousel-control-next-icon" aria-hidden="true"/>
-                <span class="sr-only">Next</span>
-              </a>
+                <span class="visually-hidden">Next</span>
+              </button>
             </div>
           </bs:card>
 

--- a/src/main/resources/hudson/tasks/junit/History/index.jelly
+++ b/src/main/resources/hudson/tasks/junit/History/index.jelly
@@ -28,9 +28,11 @@ THE SOFTWARE.
   <bs:layout title="${%title(it.testObject.displayName)}">
     <j:set var="start" value="${it.asInt(request.getParameter('start'),0)}"/>
     <j:set var="end" value="${it.asInt(request.getParameter('end'),start+24)}"/>
-    <link rel="stylesheet" href="${resURL}/plugin/junit/history/history.css"/>
     <st:adjunct includes="io.jenkins.plugins.echarts"/>
     <st:adjunct includes="io.jenkins.plugins.bootstrap5"/>
+    <st:adjunct includes="io.jenkins.plugins.echarts-trend-default-setup"/>
+    <link rel="stylesheet" href="${resURL}/plugin/junit/history/history.css"/>
+
     <st:once>
       <c:chart-setup id="test-history"/>
       <script>var view =
@@ -47,10 +49,10 @@ THE SOFTWARE.
             <div id="trend-carousel" class="carousel slide carousel-dark" data-bs-interval="false">
               <div class="carousel-inner">
                 <div class="carousel-item">
-                  <div id="test-duration-trend-chart" class="graph-cursor-pointer card-chart"/>
+                  <div id="test-duration-trend-chart" class="graph-cursor-pointer card-chart-carousel"/>
                 </div>
                 <div class="carousel-item active">
-                  <div id="test-result-trend-chart" class="graph-cursor-pointer card-chart"/>
+                  <div id="test-result-trend-chart" class="graph-cursor-pointer card-chart-carousel"/>
                 </div>
               </div>
               <button class="carousel-control-prev" type="button" data-bs-target="#trend-carousel" data-bs-slide="prev">

--- a/src/main/resources/hudson/tasks/junit/History/index.jelly
+++ b/src/main/resources/hudson/tasks/junit/History/index.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <!-- Displays the chart that show how long builds are taking -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:bs="/bootstrap5">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:bs="/bootstrap5" xmlns:c="/charts">
   <bs:layout title="${%title(it.testObject.displayName)}">
     <j:set var="start" value="${it.asInt(request.getParameter('start'),0)}"/>
     <j:set var="end" value="${it.asInt(request.getParameter('end'),start+24)}"/>
@@ -32,7 +32,6 @@ THE SOFTWARE.
 
     <st:adjunct includes="io.jenkins.plugins.echarts"/>
     <st:adjunct includes="io.jenkins.plugins.bootstrap5"/>
-    <st:adjunct includes="io.jenkins.plugins.echarts-trend-default-setup"/>
 
     <st:include from="${it.testObject}" it="${it.testObject}" page="sidepanel.jelly"/>
     <l:main-panel>
@@ -80,8 +79,11 @@ THE SOFTWARE.
          
       </div>
     </l:main-panel>
-    <script>var view =
-      <st:bind value="${it}"/>
+
+    <c:chart-setup id="test-history"/>
+
+    <script>
+      var view =<st:bind value="${it}"/>
     </script>
     <script type="text/javascript" src="${resURL}/plugin/junit/history/history.js"/>
   </bs:layout>

--- a/src/main/resources/hudson/tasks/junit/History/index.jelly
+++ b/src/main/resources/hudson/tasks/junit/History/index.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
 
     <st:adjunct includes="io.jenkins.plugins.echarts"/>
     <st:adjunct includes="io.jenkins.plugins.bootstrap5"/>
-    <st:adjunct includes="io.jenkins.plugins.echarts-trend-configuration-dialog"/>
+    <st:adjunct includes="io.jenkins.plugins.echarts-trend-default-setup"/>
 
     <st:include from="${it.testObject}" it="${it.testObject}" page="sidepanel.jelly"/>
     <l:main-panel>

--- a/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local" xmlns:c="/charts">
-  <c:trend-chart it="${from}" title="${%Test Result Trend}" enableLinks="true"/>
+<j:jelly xmlns:j="jelly:core"
+         xmlns:c="/charts">
+  <c:trend-chart it="${from}" title="${%Test Result Trend}" enableLinks="true" configurationId="default"/>
 </j:jelly>

--- a/src/main/webapp/history/history.css
+++ b/src/main/webapp/history/history.css
@@ -1,8 +1,0 @@
-.card-chart {
-    width: 90%;
-    min-height: 256px;
-    min-width: 256px;
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
-}

--- a/src/main/webapp/history/history.css
+++ b/src/main/webapp/history/history.css
@@ -1,0 +1,8 @@
+.card-chart-carousel {
+    width: 100%;
+    min-height: 256px;
+    min-width: 256px;
+    display: block;
+    padding-left: 20px;
+    padding-right: 20px;
+}

--- a/src/main/webapp/history/history.js
+++ b/src/main/webapp/history/history.js
@@ -1,6 +1,6 @@
 /* global jQuery3, bootstrap5, view, echartsJenkinsApi */
 (function ($) {
-    const trendConfigurationDialogId = 'trend-configuration-default';
+    const trendConfigurationDialogId = 'chart-configuration-test-history';
 
     $('#' + trendConfigurationDialogId).on('hidden.bs.modal', function () {
         redrawTrendCharts();
@@ -24,7 +24,7 @@
      * redraws the trend charts.
      */
     function redrawTrendCharts() {
-        const configuration = JSON.stringify(echartsJenkinsApi.readConfiguration(trendDefaultStorageId));
+        const configuration = JSON.stringify(echartsJenkinsApi.readFromLocalStorage('jenkins-echarts-chart-configuration-test-history'));
 
         /**
          * Creates a build trend chart that shows the number of issues per tool.

--- a/src/main/webapp/history/history.js
+++ b/src/main/webapp/history/history.js
@@ -1,6 +1,8 @@
 /* global jQuery3, bootstrap5, view, echartsJenkinsApi */
 (function ($) {
-    $('#defaultTrendConfiguration').on('hidden.bs.modal', function () {
+    const trendConfigurationDialogId = 'trend-configuration-default';
+
+    $('#' + trendConfigurationDialogId).on('hidden.bs.modal', function () {
         redrawTrendCharts();
     });
 
@@ -22,15 +24,14 @@
      * redraws the trend charts.
      */
     function redrawTrendCharts() {
-        const configuration = echartsJenkinsApi.readConfiguration('jenkins-echarts-test-history');
-        const trendConfigurationDialogId = 'defaultTrendConfiguration';
+        const configuration = JSON.stringify(echartsJenkinsApi.readConfiguration(trendDefaultStorageId));
 
         /**
          * Creates a build trend chart that shows the number of issues per tool.
          * Requires that a DOM <div> element exists with the ID '#tools-trend-chart'.
          */
         view.getTestDurationTrend(configuration, function (lineModel) {
-            echartsJenkinsApi.renderConfigurableZoomableTrendChart('test-duration-trend-chart', lineModel.responseJSON, redrawTrendCharts, trendConfigurationDialogId);
+            echartsJenkinsApi.renderConfigurableZoomableTrendChart('test-duration-trend-chart', lineModel.responseJSON, trendConfigurationDialogId);
         });
 
         /**
@@ -38,7 +39,7 @@
          * Requires that a DOM <div> element exists with the ID '#severities-trend-chart'.
          */
         view.getTestResultTrend(configuration, function (lineModel) {
-            echartsJenkinsApi.renderConfigurableZoomableTrendChart('test-result-trend-chart', lineModel.responseJSON, redrawTrendCharts, trendConfigurationDialogId);
+            echartsJenkinsApi.renderConfigurableZoomableTrendChart('test-result-trend-chart', lineModel.responseJSON, trendConfigurationDialogId);
         });
     }
 

--- a/src/main/webapp/history/history.js
+++ b/src/main/webapp/history/history.js
@@ -1,5 +1,9 @@
-/* global jQuery3, view, echartsJenkinsApi */
+/* global jQuery3, bootstrap5, view, echartsJenkinsApi */
 (function ($) {
+    $('#defaultTrendConfiguration').on('hidden.bs.modal', function () {
+        redrawTrendCharts();
+    });
+
     redrawTrendCharts();
     storeAndRestoreCarousel('trend-carousel');
 
@@ -7,7 +11,10 @@
      * Activate tooltips.
      */
     $(function () {
-        $('[data-toggle="tooltip"]').tooltip();
+        $('[data-bs-toggle="tooltip"]').each(function () {
+            const tooltip = new bootstrap5.Tooltip($(this)[0]);
+            tooltip.enable();
+        });
     });
 
     /**
@@ -15,21 +22,23 @@
      * redraws the trend charts.
      */
     function redrawTrendCharts() {
+        const configuration = echartsJenkinsApi.readConfiguration('jenkins-echarts-test-history');
+        const trendConfigurationDialogId = 'defaultTrendConfiguration';
 
         /**
          * Creates a build trend chart that shows the number of issues per tool.
          * Requires that a DOM <div> element exists with the ID '#tools-trend-chart'.
          */
-        view.getTestDurationTrend(function (lineModel) {
-            echartsJenkinsApi.renderZoomableTrendChart('test-duration-trend-chart', lineModel.responseJSON, redrawTrendCharts);
+        view.getTestDurationTrend(configuration, function (lineModel) {
+            echartsJenkinsApi.renderConfigurableZoomableTrendChart('test-duration-trend-chart', lineModel.responseJSON, redrawTrendCharts, trendConfigurationDialogId);
         });
 
         /**
          * Creates a build trend chart that shows the number of issues for a couple of builds.
          * Requires that a DOM <div> element exists with the ID '#severities-trend-chart'.
          */
-        view.getTestResultTrend(function (lineModel) {
-            echartsJenkinsApi.renderZoomableTrendChart('test-result-trend-chart', lineModel.responseJSON, redrawTrendCharts);
+        view.getTestResultTrend(configuration, function (lineModel) {
+            echartsJenkinsApi.renderConfigurableZoomableTrendChart('test-result-trend-chart', lineModel.responseJSON, redrawTrendCharts, trendConfigurationDialogId);
         });
     }
 
@@ -50,7 +59,9 @@
         });
         const activeCarousel = localStorage.getItem(carouselId);
         if (activeCarousel) {
-            carousel.carousel(parseInt(activeCarousel));
+            const carouselControl = new bootstrap5.Carousel(carousel[0]);
+            carouselControl.to(parseInt(activeCarousel));
+            carouselControl.pause();
         }
     }
 })(jQuery3);

--- a/src/test/java/hudson/tasks/junit/JUnitResultArchiverTest.java
+++ b/src/test/java/hudson/tasks/junit/JUnitResultArchiverTest.java
@@ -65,6 +65,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
+import hudson.tasks.test.helper.WebClientFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/src/test/java/hudson/tasks/junit/TestResultPublishingTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultPublishingTest.java
@@ -83,9 +83,7 @@ public class TestResultPublishingTest {
 
         assertTestResults(build);
 
-        WebClient wc = rule.createWebClient();
-        wc.getPage(project); // project page
-        wc.getPage(build); // build page
+        WebClient wc = WebClientFactory.createWebClientWithDisabledJavaScript(rule);
         wc.getPage(build, "testReport");  // test report
         wc.getPage(build, "testReport/hudson.security"); // package
         wc.getPage(build, "testReport/hudson.security/HudsonPrivateSecurityRealmTest/"); // class
@@ -107,7 +105,7 @@ public class TestResultPublishingTest {
 
         testBasic();
     }
-  
+
 
     /**
      * Verify that we can successfully parse and display test results in the
@@ -124,7 +122,7 @@ public class TestResultPublishingTest {
         assertNotNull("We should have a project named " + TEST_PROJECT_WITH_HISTORY, proj);
 
         // Validate that there are test results where I expect them to be:
-        WebClient wc = rule.createWebClient();
+        WebClient wc = WebClientFactory.createWebClientWithDisabledJavaScript(rule);
 
         // On the project page:
         HtmlPage projectPage = wc.getPage(proj);
@@ -138,12 +136,8 @@ public class TestResultPublishingTest {
         //      there should be a test result trend graph
         HtmlElement trendGraphCaption = (HtmlElement) projectPage.getByXPath( "//div[@class='test-trend-caption']").get(0);
         assertThat(trendGraphCaption.getTextContent(), is("Test Result Trend"));
-        HtmlElement testCanvas = ((HtmlElement) trendGraphCaption.getParentNode()).getElementsByTagName("canvas").get(0);
-        assertNotNull("couldn't find test result trend graph", testCanvas);
-
-        // The trend graph should be clickable and take us to a run details page
-        assertTrue("image node should be an HtmlCanvas object", testCanvas instanceof HtmlCanvas);
-        // TODO: Check that we can click on the graph and get to a particular run. How do I do this with HtmlUnit?
+        HtmlElement testCanvas = (HtmlElement) trendGraphCaption.getNextSibling().getFirstChild();
+        assertTrue("couldn't find test result trend graph", testCanvas.getAttribute("class").contains("echarts-trend"));
 
         XmlPage xmlProjectPage = wc.goToXml(proj.getUrl() + "/lastBuild/testReport/api/xml");
         rule.assertXPath(xmlProjectPage, "/testResult");
@@ -227,7 +221,7 @@ public class TestResultPublishingTest {
         assertNotNull("We should have a project named " + TEST_PROJECT_WITH_HISTORY, proj);
 
         // Validate that there are test results where I expect them to be:
-        WebClient wc = rule.createWebClient();
+        WebClient wc = WebClientFactory.createWebClientWithDisabledJavaScript(rule);
         Run theRun = proj.getBuildByNumber(4);
         assertTestResultsAsExpected(wc, theRun, "/testReport",
                         "org.jvnet.hudson.examples.small", "12 ms", "FAILURE",
@@ -250,7 +244,7 @@ public class TestResultPublishingTest {
         assertNotNull("We should have a project named " + TEST_PROJECT_WITH_HISTORY, proj);
 
         // Validate that there are test results where I expect them to be:
-        WebClient wc = rule.createWebClient();
+        WebClient wc = WebClientFactory.createWebClientWithDisabledJavaScript(rule);
 
         HtmlPage historyPage = wc.getPage(proj.getBuildByNumber(7),"/testReport/history/");
         rule.assertGoodStatus(historyPage);
@@ -292,7 +286,7 @@ public class TestResultPublishingTest {
             return true;
         }
     }
-  
+
     void assertStringEmptyOrNull(String msg, String str) {
         if (str==null)
             return;
@@ -301,7 +295,7 @@ public class TestResultPublishingTest {
         fail(msg + "(should be empty or null) : '" + str + "'");
     }
 
-    void assertPaneDiffText(String msg, int expectedValue, Object paneObj) { 
+    void assertPaneDiffText(String msg, int expectedValue, Object paneObj) {
         assertTrue( "paneObj should be an HtmlElement, it was " + paneObj.getClass(), paneObj instanceof HtmlElement );
         String paneText = ((HtmlElement) paneObj).asNormalizedText();
         if (expectedValue==0) {

--- a/src/test/java/hudson/tasks/junit/TestResultPublishingTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultPublishingTest.java
@@ -37,6 +37,8 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.slaves.DumbSlave;
 import hudson.tasks.Builder;
+import hudson.tasks.test.helper.WebClientFactory;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/hudson/tasks/junit/TestResultPublishingTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultPublishingTest.java
@@ -250,7 +250,7 @@ public class TestResultPublishingTest {
 
         HtmlPage historyPage = wc.getPage(proj.getBuildByNumber(7),"/testReport/history/");
         rule.assertGoodStatus(historyPage);
-        HtmlElement historyCard = (HtmlElement) historyPage.getByXPath( "//div[@class='card-body']").get(0);
+        HtmlElement historyCard = (HtmlElement) historyPage.getByXPath( "//div[@class='card-body ']").get(0);
         assertThat(historyCard.getTextContent(), containsString("History"));
         DomElement wholeTable = historyPage.getElementById("testresult");
         assertNotNull("table with id 'testresult' exists", wholeTable);

--- a/src/test/java/hudson/tasks/test/AggregatedTestResultPublisherTest.java
+++ b/src/test/java/hudson/tasks/test/AggregatedTestResultPublisherTest.java
@@ -10,6 +10,7 @@ import hudson.tasks.BuildTrigger;
 import hudson.tasks.Fingerprinter;
 import hudson.tasks.Shell;
 import hudson.tasks.junit.JUnitResultArchiver;
+import hudson.tasks.test.helper.WebClientFactory;
 import hudson.tasks.test.helper.BuildPage;
 import hudson.tasks.test.helper.ProjectPage;
 import org.junit.Before;

--- a/src/test/java/hudson/tasks/test/AggregatedTestResultPublisherTest.java
+++ b/src/test/java/hudson/tasks/test/AggregatedTestResultPublisherTest.java
@@ -48,7 +48,7 @@ public class AggregatedTestResultPublisherTest {
 
     @Before
     public void setup() {
-        wc = j.createWebClient();
+        wc = WebClientFactory.createWebClientWithDisabledJavaScript(j);
     }
 
     @LocalData

--- a/src/test/java/hudson/tasks/test/helper/WebClientFactory.java
+++ b/src/test/java/hudson/tasks/test/helper/WebClientFactory.java
@@ -1,0 +1,22 @@
+package hudson.tasks.test.helper;
+
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
+
+import com.gargoylesoftware.htmlunit.NicelyResynchronizingAjaxController;
+
+/**
+ * Creates a {@link WebClient} with deactivated JS.
+ *
+ * @author Ullrich Hafner
+ */
+public class WebClientFactory {
+    public static WebClient createWebClientWithDisabledJavaScript(final JenkinsRule jenkinsRule) {
+        WebClient webClient = jenkinsRule.createWebClient();
+        webClient.setJavaScriptEnabled(false);
+        webClient.setAjaxController(new NicelyResynchronizingAjaxController());
+        webClient.getCookieManager().setCookiesEnabled(false);
+        webClient.getOptions().setCssEnabled(false);
+        return webClient;
+    }
+}


### PR DESCRIPTION
Bootstrap 5 has been released and requires some changes in markup and JS. Additionally, (due to the migration of ECharts to Bootstrap 5) trend charts are now configurable using a dialog.

Upstream PR: jenkinsci/echarts-api-plugin#124

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
