### PR TITLE
[JENKINS-57882] Fix age of failed tests if previous build was skipped

### DIFF
--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -446,9 +446,9 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     private void recomputeFailedSinceIfNeeded() {
         if (failedSince==0 && getFailCount()==1) {
             CaseResult prev = getPreviousResult();
-            if(prev!=null && !prev.isPassed())
+            if (prev != null && prev.isFailed()) {
                 this.failedSince = prev.getFailedSince();
-            else if (getRun() != null) {
+            } else if (getRun() != null) {
                 this.failedSince = getRun().getNumber();
             } else {
                 LOGGER.warning("trouble calculating getFailedSince. We've got prev, but no owner.");

--- a/src/test/java/hudson/tasks/junit/TestResultLinksTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultLinksTest.java
@@ -137,4 +137,30 @@ public class TestResultLinksTest {
         };
         testResult.freeze(new TestResultAction(build, testResult, null));
      }
+
+    @Test
+    public void testFailedSinceAfterSkip() throws IOException, URISyntaxException {
+        TestResult testResult = new TestResult();
+        File dataFile = TestResultTest.getDataFile("SKIPPED_MESSAGE/skippedTestResult.xml");
+        testResult.parse(dataFile, null);
+        FreeStyleBuild build = new FreeStyleBuild(project) {
+            @Override
+            public FreeStyleBuild getPreviousBuild() {
+                return null;
+            }
+        };
+        build.addAction(new TestResultAction(build, testResult, null));
+        TestResult testResult2 = new TestResult();
+        File dataFile2 = TestResultTest.getDataFile("SKIPPED_MESSAGE/afterSkippedResult.xml");
+        testResult2.parse(dataFile2, null);
+        FreeStyleBuild build2 = new FreeStyleBuild(project) {
+            @Override
+            public FreeStyleBuild getPreviousBuild() {
+                return build;
+            }
+        };
+
+        testResult2.freeze(new TestResultAction(build2, testResult, null));
+        assertEquals(2, testResult2.getFailedTests().get(0).getFailedSince());
+    }
 }

--- a/src/test/resources/hudson/tasks/junit/SKIPPED_MESSAGE/afterSkippedResult.xml
+++ b/src/test/resources/hudson/tasks/junit/SKIPPED_MESSAGE/afterSkippedResult.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?><testsuite failures="0" name="cucumber.runtime.formatter.JUnitFormatter" skipped="1" tests="1" time="0.172697">
+    <testcase classname="Test Sample" name="Test Example" time="0.172697">
+        <error message="RuntimeException; nested exception is: &#10;&#9;java.lang.IllegalArgumentException: id to load is required for loading"
+               type="java.rmi.ServerException">java.rmi.ServerException: RuntimeException
+        </error>
+
+    </testcase>
+</testsuite>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

See https://issues.jenkins.io/browse/JENKINS-57882

When fixing https://issues.jenkins.io/browse/JENKINS-31660 I made sure `failedSince` is computed by only checking one build instead of loading the whole history. If the previous build is skipped, it doesn't have `failedSince` set and current build is considered to be failing since build 0.

With this change `failedSince` should be reset to current build number after a skipped run.

