### PR TITLE
[JENKINS-43692] Allow to not mark build as unstable on test failure

### DIFF
--- a/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
+++ b/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
@@ -98,6 +98,10 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
     private boolean allowEmptyResults;
     private boolean skipPublishingChecks;
     private String checksName;
+    /**
+     * If true, the run won't be marked as unstable if there are failing tests. Only the stage will be marked as unstable.
+     */
+    private boolean skipMarkingBuildUnstable;
 
     private static final String DEFAULT_CHECKS_NAME = "Tests";
 
@@ -163,7 +167,7 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
     @Override
     public void perform(Run build, FilePath workspace, Launcher launcher,
             TaskListener listener) throws InterruptedException, IOException {
-        if (parseAndSummarize(this, null, build, workspace, launcher, listener).getFailCount() > 0) {
+        if (parseAndSummarize(this, null, build, workspace, launcher, listener).getFailCount() > 0 && !skipMarkingBuildUnstable) {
             build.setResult(Result.UNSTABLE);
         }
     }
@@ -409,6 +413,14 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
         this.allowEmptyResults = allowEmptyResults;
     }
 
+    public boolean isSkipMarkingBuildUnstable() {
+        return skipMarkingBuildUnstable;
+    }
+
+    @DataBoundSetter
+    public void setSkipMarkingBuildUnstable(boolean skipMarkingBuildUnstable) {
+        this.skipMarkingBuildUnstable = skipMarkingBuildUnstable;
+    }
 
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStep.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStep.java
@@ -55,6 +55,10 @@ public class JUnitResultsStep extends Step implements JUnitTask {
     private boolean allowEmptyResults;
     private boolean skipPublishingChecks;
     private String checksName;
+    /**
+     * If true, the run won't be marked as unstable if there are failing tests. Only the stage will be marked as unstable.
+     */
+    private boolean skipMarkingBuildUnstable;
 
     @DataBoundConstructor
     public JUnitResultsStep(String testResults) {
@@ -145,6 +149,15 @@ public class JUnitResultsStep extends Step implements JUnitTask {
 
     @DataBoundSetter public final void setAllowEmptyResults(boolean allowEmptyResults) {
         this.allowEmptyResults = allowEmptyResults;
+    }
+
+    public boolean isSkipMarkingBuildUnstable() {
+        return skipMarkingBuildUnstable;
+    }
+
+    @DataBoundSetter
+    public void setSkipMarkingBuildUnstable(boolean skipMarkingBuildUnstable) {
+        this.skipMarkingBuildUnstable = skipMarkingBuildUnstable;
     }
 
     @Override

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
@@ -66,7 +66,9 @@ public class JUnitResultsStepExecution extends SynchronousNonBlockingStepExecuti
                 int testFailures = summary.getFailCount();
                 if (testFailures > 0) {
                     node.addOrReplaceAction(new WarningAction(Result.UNSTABLE).withMessage(testFailures + " tests failed"));
-                    run.setResult(Result.UNSTABLE);
+                    if (!step.isSkipMarkingBuildUnstable()) {
+                        run.setResult(Result.UNSTABLE);
+                    }
                 }
             }
             return summary;

--- a/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
+++ b/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
@@ -53,4 +53,7 @@ THE SOFTWARE.
     <f:entry title="${%Checks name}" field="checksName">
         <f:textbox />
     </f:entry>
+    <f:entry title="${%Skip marking build as unstable on test failure}" field="skipMarkingBuildUnstable">
+            <f:checkbox default="false" title="${%If checked, the test failures will still be reported but won't mark the build as unstable}"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/help-skipMarkingBuildUnstable.html
+++ b/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/help-skipMarkingBuildUnstable.html
@@ -1,0 +1,4 @@
+<div>
+    If this option is unchecked, then the plugin will mark the build as unstable when it finds at least 1 test failure.
+    If this option is checked, then the build will still be successful even if there are test failures reported.
+</div>

--- a/src/main/resources/hudson/tasks/junit/pipeline/JUnitResultsStep/help-skipMarkingBuildUnstable.html
+++ b/src/main/resources/hudson/tasks/junit/pipeline/JUnitResultsStep/help-skipMarkingBuildUnstable.html
@@ -1,0 +1,5 @@
+<div>
+    If this option is unchecked, then the plugin will mark the build as unstable when it finds at least 1 test failure.
+    If this option is checked, then the build will still be successful even if there are test failures reported.
+    In any case, the corresponding pipeline node (and stage) will be marked as unstable in case of test failure.
+</div>


### PR DESCRIPTION
When using the pipeline step with `skipMarkingBuildUnstable: true`, the corresponding node will still be
marked as unstable.

Fixes https://github.com/jenkinsci/junit-plugin/issues/278

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
