### PR TITLE
Compatibility with XStream 1.4.18

### DIFF
--- a/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
+++ b/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
@@ -880,6 +880,10 @@ public class TestResultStorageJunitTest {
             private static final XStream XSTREAM = new XStream();
             private final String databaseXml;
 
+            static {
+                XSTREAM.allowTypes(new Class[] {LocalH2Database.class});
+            }
+
             RemoteConnectionSupplier() {
                 databaseXml = XSTREAM.toXML(GlobalDatabaseConfiguration.get().getDatabase());
             }


### PR DESCRIPTION
I observed this stack trace in a recent BOM run:

```
com.thoughtworks.xstream.security.ForbiddenClassException: org.jenkinsci.plugins.database.h2.LocalH2Database
 at com.thoughtworks.xstream.security.NoTypePermission.allows(NoTypePermission.java:26)
 at com.thoughtworks.xstream.mapper.SecurityMapper.realClass(SecurityMapper.java:74)
 at com.thoughtworks.xstream.mapper.MapperWrapper.realClass(MapperWrapper.java:125)
 at com.thoughtworks.xstream.mapper.CachingMapper.realClass(CachingMapper.java:47)
 at com.thoughtworks.xstream.core.util.HierarchicalStreams.readClassType(HierarchicalStreams.java:29)
 at com.thoughtworks.xstream.core.TreeUnmarshaller.start(TreeUnmarshaller.java:133)
 at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.unmarshal(AbstractTreeMarshallingStrategy.java:32)
 at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1391)
 at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1376)
 at com.thoughtworks.xstream.XStream.fromXML(XStream.java:1261)
 at com.thoughtworks.xstream.XStream.fromXML(XStream.java:1252)
 at io.jenkins.plugins.junit.storage.TestResultStorageJunitTest$Impl$RemoteConnectionSupplier.database(TestResultStorageJunitTest.java:888)
 at io.jenkins.plugins.junit.storage.TestResultStorageJunitTest$Impl$ConnectionSupplier.connection(TestResultStorageJunitTest.java:840)
 at io.jenkins.plugins.junit.storage.TestResultStorageJunitTest$Impl$RemotePublisherImpl.publish(TestResultStorageJunitTest.java:779)
 at hudson.tasks.junit.JUnitParser$StorageParseResultCallable.handle(JUnitParser.java:188)
 at hudson.tasks.junit.JUnitParser$StorageParseResultCallable.handle(JUnitParser.java:175)
 at hudson.tasks.junit.JUnitParser$ParseResultCallable.invoke(JUnitParser.java:155)
 at hudson.FilePath$FileCallableWrapper.call(FilePath.java:3326)
 at hudson.remoting.UserRequest.perform(UserRequest.java:211)
 at hudson.remoting.UserRequest.perform(UserRequest.java:54)
 at hudson.remoting.Request$2.run(Request.java:376)
 at hudson.remoting.InterceptingExecutorService.lambda$wrap$0(InterceptingExecutorService.java:78)
 at java.util.concurrent.FutureTask.run(FutureTask.java:266)
 at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
 at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
 at java.lang.Thread.run(Thread.java:748)
```

This is due to the recent XStream upgrade in jenkinsci/jenkins#5685. I was able to reproduce this problem running the JUnit tests against Jenkins 2.309. This patch fixes the problem without breaking the tests against the current baseline either.