### PR TITLE
Disambiguate a case where multiple test suites have the same name

### DIFF
--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -532,9 +532,14 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     @Override
     public CaseResult getPreviousResult() {
         if (parent == null) return null;
-        SuiteResult pr = parent.getPreviousResult();
-        if(pr==null)    return null;
-        return pr.getCase(getTransformedFullDisplayName());
+
+        TestResult previousResult = parent.getParent().getPreviousResult();
+        if (previousResult == null) return null;
+        if (previousResult instanceof hudson.tasks.junit.TestResult) {
+            hudson.tasks.junit.TestResult pr = (hudson.tasks.junit.TestResult) previousResult;
+            return pr.getCase(parent.getName(), getTransformedFullDisplayName());
+        }
+        return null;
     }
 
     /**

--- a/src/test/java/hudson/tasks/junit/pipeline/JUnitResultsStepTest.java
+++ b/src/test/java/hudson/tasks/junit/pipeline/JUnitResultsStepTest.java
@@ -10,11 +10,13 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.junit.CaseResult;
 import hudson.tasks.junit.Messages;
+import hudson.tasks.junit.SuiteResult;
 import hudson.tasks.junit.TestDataPublisher;
 import hudson.tasks.junit.TestResult;
 import hudson.tasks.junit.TestResultAction;
 import hudson.tasks.junit.TestResultTest;
 import hudson.tasks.test.PipelineBlockWithTests;
+import java.net.URL;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -122,9 +124,7 @@ public class JUnitResultsStepTest {
                 "    assert results.totalCount == 6\n" +
                 "  }\n" +
                 "}\n", true));
-        FilePath ws = rule.jenkins.getWorkspaceFor(j);
-        FilePath testFile = ws.child("test-result.xml");
-        testFile.copyFrom(TestResultTest.class.getResource("junit-report-1463.xml"));
+        copyToWorkspace(j, TestResultTest.class.getResource("junit-report-1463.xml"), "test-result.xml");
 
         WorkflowRun r = rule.buildAndAssertSuccess(j);
         TestResultAction action = r.getAction(TestResultAction.class);
@@ -151,11 +151,8 @@ public class JUnitResultsStepTest {
                 "    assert second.totalCount == 1\n" +
                 "  }\n" +
                 "}\n", true));
-        FilePath ws = rule.jenkins.getWorkspaceFor(j);
-        FilePath testFile = ws.child("first-result.xml");
-        testFile.copyFrom(TestResultTest.class.getResource("junit-report-1463.xml"));
-        FilePath secondTestFile = ws.child("second-result.xml");
-        secondTestFile.copyFrom(TestResultTest.class.getResource("junit-report-2874.xml"));
+        copyToWorkspace(j, TestResultTest.class.getResource("junit-report-1463.xml"), "first-result.xml");
+        copyToWorkspace(j, TestResultTest.class.getResource("junit-report-2874.xml"), "second-result.xml");
 
         WorkflowRun r = rule.buildAndAssertSuccess(j);
         TestResultAction action = r.getAction(TestResultAction.class);
@@ -190,13 +187,9 @@ public class JUnitResultsStepTest {
                 "    assert second.totalCount == 1\n" +
                 "  }\n" +
                 "}\n", true));
-        FilePath ws = rule.jenkins.getWorkspaceFor(j);
-        FilePath testFile = ws.child("first-result.xml");
-        testFile.copyFrom(TestResultTest.class.getResource("junit-report-1463.xml"));
-        FilePath secondTestFile = ws.child("second-result.xml");
-        secondTestFile.copyFrom(TestResultTest.class.getResource("junit-report-2874.xml"));
-        FilePath thirdTestFile = ws.child("third-result.xml");
-        thirdTestFile.copyFrom(TestResultTest.class.getResource("junit-report-nested-testsuites.xml"));
+        copyToWorkspace(j, TestResultTest.class.getResource("junit-report-1463.xml"), "first-result.xml");
+        copyToWorkspace(j, TestResultTest.class.getResource("junit-report-2874.xml"), "second-result.xml");
+        copyToWorkspace(j, TestResultTest.class.getResource("junit-report-nested-testsuites.xml"), "third-result.xml");
 
         WorkflowRun r = rule.assertBuildStatus(Result.UNSTABLE,
                 rule.waitForCompletion(j.scheduleBuild2(0).waitForStart()));
@@ -229,13 +222,9 @@ public class JUnitResultsStepTest {
     @Test
     public void parallelInStage() throws Exception {
         WorkflowJob j = rule.jenkins.createProject(WorkflowJob.class, "parallelInStage");
-        FilePath ws = rule.jenkins.getWorkspaceFor(j);
-        FilePath testFile = ws.child("first-result.xml");
-        testFile.copyFrom(TestResultTest.class.getResource("junit-report-1463.xml"));
-        FilePath secondTestFile = ws.child("second-result.xml");
-        secondTestFile.copyFrom(TestResultTest.class.getResource("junit-report-2874.xml"));
-        FilePath thirdTestFile = ws.child("third-result.xml");
-        thirdTestFile.copyFrom(TestResultTest.class.getResource("junit-report-nested-testsuites.xml"));
+        copyToWorkspace(j, TestResultTest.class.getResource("junit-report-1463.xml"), "first-result.xml");
+        copyToWorkspace(j, TestResultTest.class.getResource("junit-report-2874.xml"), "second-result.xml");
+        copyToWorkspace(j, TestResultTest.class.getResource("junit-report-nested-testsuites.xml"), "third-result.xml");
 
         j.setDefinition(new CpsFlowDefinition("stage('first') {\n" +
                 "  node {\n" +
@@ -262,13 +251,9 @@ public class JUnitResultsStepTest {
     @Test
     public void stageInParallel() throws Exception {
         WorkflowJob j = rule.jenkins.createProject(WorkflowJob.class, "stageInParallel");
-        FilePath ws = rule.jenkins.getWorkspaceFor(j);
-        FilePath testFile = ws.child("first-result.xml");
-        testFile.copyFrom(TestResultTest.class.getResource("junit-report-1463.xml"));
-        FilePath secondTestFile = ws.child("second-result.xml");
-        secondTestFile.copyFrom(TestResultTest.class.getResource("junit-report-2874.xml"));
-        FilePath thirdTestFile = ws.child("third-result.xml");
-        thirdTestFile.copyFrom(TestResultTest.class.getResource("junit-report-nested-testsuites.xml"));
+        copyToWorkspace(j, TestResultTest.class.getResource("junit-report-1463.xml"), "first-result.xml");
+        copyToWorkspace(j, TestResultTest.class.getResource("junit-report-2874.xml"), "second-result.xml");
+        copyToWorkspace(j, TestResultTest.class.getResource("junit-report-nested-testsuites.xml"), "third-result.xml");
 
         j.setDefinition(new CpsFlowDefinition("stage('outer') {\n" +
                 "  node {\n" +
@@ -368,9 +353,7 @@ public class JUnitResultsStepTest {
                 "    assert currentBuild.result == 'UNSTABLE'\n" +
                 "  }\n" +
                 "}\n", true));
-        FilePath ws = rule.jenkins.getWorkspaceFor(j);
-        FilePath testFile = ws.child("test-result.xml");
-        testFile.copyFrom(JUnitResultsStepTest.class.getResource("junit-report-testTrends-first-2.xml"));
+        copyToWorkspace(j, JUnitResultsStepTest.class.getResource("junit-report-testTrends-first-2.xml"), "test-result.xml");
 
         rule.assertBuildStatus(Result.UNSTABLE, rule.waitForCompletion(j.scheduleBuild2(0).waitForStart()));
     }
@@ -385,12 +368,55 @@ public class JUnitResultsStepTest {
                 "    assert currentBuild.result == null\n" +
                 "  }\n" +
                 "}\n", true));
-        FilePath ws = rule.jenkins.getWorkspaceFor(j);
-        FilePath testFile = ws.child("test-result.xml");
-        testFile.copyFrom(JUnitResultsStepTest.class.getResource("junit-report-testTrends-first-2.xml"));
+        copyToWorkspace(j, JUnitResultsStepTest.class.getResource("junit-report-testTrends-first-2.xml"), "test-result.xml");
         WorkflowRun r = rule.waitForCompletion(j.scheduleBuild2(0).waitForStart());
         rule.assertBuildStatus(Result.SUCCESS, r);
         assertStageResults(r, 1, 8, 3, "first");
+    }
+
+    @Test
+    public void ageResetSameTestSuiteName() throws Exception {
+        WorkflowJob j = rule.jenkins.createProject(WorkflowJob.class, "currentBuildResultUnstable");
+        j.setDefinition(new CpsFlowDefinition("stage('stage 1') {\n" +
+                "  node {\n" +
+                "    junit(testResults: '*-1.xml')\n" +
+                "  }\n" +
+                "}\n" +
+                "stage('stage 2') {\n" +
+                "  node {\n" +
+                "    junit(testResults: '*-2.xml')\n" +
+                "  }\n" +
+                "}\n", true));
+        copyToWorkspace(j, JUnitResultsStepTest.class.getResource("ageReset-1.xml"), "ageReset-1.xml");
+        copyToWorkspace(j, JUnitResultsStepTest.class.getResource("ageReset-2.xml"), "ageReset-2.xml");
+        WorkflowRun r = rule.waitForCompletion(j.scheduleBuild2(0).waitForStart());
+        rule.assertBuildStatus(Result.UNSTABLE, r);
+        CaseResult caseResult = findCaseResult(r, "aClass.methodName");
+        assertNotNull(caseResult);
+        assertEquals(1, caseResult.getAge());
+
+        // Run a second build, age should increase
+        r = rule.waitForCompletion(j.scheduleBuild2(0).waitForStart());
+        rule.assertBuildStatus(Result.UNSTABLE, r);
+        caseResult = findCaseResult(r, "aClass.methodName");
+        assertNotNull(caseResult);
+        assertEquals(2, caseResult.getAge());
+    }
+
+    private CaseResult findCaseResult(Run r, String name) {
+        for (SuiteResult suite : r.getAction(TestResultAction.class).getResult().getSuites()) {
+            CaseResult caseResult = suite.getCase(name);
+            if (caseResult != null) {
+                return caseResult;
+            }
+        }
+        return null;
+    }
+
+    private void copyToWorkspace(WorkflowJob j, URL source, String destination) throws IOException, InterruptedException {
+        FilePath ws = rule.jenkins.getWorkspaceFor(j);
+        FilePath testFile = ws.child(destination);
+        testFile.copyFrom(source);
     }
 
 

--- a/src/test/java/hudson/tasks/junit/pipeline/JUnitResultsStepTest.java
+++ b/src/test/java/hudson/tasks/junit/pipeline/JUnitResultsStepTest.java
@@ -376,7 +376,7 @@ public class JUnitResultsStepTest {
 
     @Test
     public void ageResetSameTestSuiteName() throws Exception {
-        WorkflowJob j = rule.jenkins.createProject(WorkflowJob.class, "currentBuildResultUnstable");
+        WorkflowJob j = rule.jenkins.createProject(WorkflowJob.class, "p");
         j.setDefinition(new CpsFlowDefinition("stage('stage 1') {\n" +
                 "  node {\n" +
                 "    junit(testResults: '*-1.xml')\n" +
@@ -391,6 +391,7 @@ public class JUnitResultsStepTest {
         copyToWorkspace(j, JUnitResultsStepTest.class.getResource("ageReset-2.xml"), "ageReset-2.xml");
         WorkflowRun r = rule.waitForCompletion(j.scheduleBuild2(0).waitForStart());
         rule.assertBuildStatus(Result.UNSTABLE, r);
+        assertEquals(2, r.getAction(TestResultAction.class).getResult().getSuites().size());
         CaseResult caseResult = findCaseResult(r, "aClass.methodName");
         assertNotNull(caseResult);
         assertEquals(1, caseResult.getAge());

--- a/src/test/resources/hudson/tasks/junit/pipeline/ageReset-1.xml
+++ b/src/test/resources/hudson/tasks/junit/pipeline/ageReset-1.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <testsuites disabled="0" errors="0" failures="1" tests="1" time="2">
-<testsuite disabled="0" errors="0" failures="1" name="Test Suite" skipped="0" tests="1" time="2">
-  <testcase classname="aClass" name="methodName" time="2.0000">
-    <failure message="I failed" type="failure">stacktrace</failure>
-  </testcase>
-</testsuite>
+  <testsuite disabled="0" errors="0" failures="1" name="Test Suite" skipped="0" tests="1" time="2">
+    <testcase classname="aClass" name="methodName" time="2.0000">
+      <failure message="I failed" type="failure">stacktrace</failure>
+    </testcase>
+  </testsuite>
 </testsuites>

--- a/src/test/resources/hudson/tasks/junit/pipeline/ageReset-1.xml
+++ b/src/test/resources/hudson/tasks/junit/pipeline/ageReset-1.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<testsuites disabled="0" errors="0" failures="1" tests="1" time="2">
+<testsuite disabled="0" errors="0" failures="1" name="Test Suite" skipped="0" tests="1" time="2">
+  <testcase classname="aClass" name="methodName" time="2.0000">
+    <failure message="I failed" type="failure">stacktrace</failure>
+  </testcase>
+</testsuite>
+</testsuites>

--- a/src/test/resources/hudson/tasks/junit/pipeline/ageReset-2.xml
+++ b/src/test/resources/hudson/tasks/junit/pipeline/ageReset-2.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?>
+<testsuites disabled="0" errors="0" failures="0" tests="1" time="0.0">
+  <testsuite disabled="0" errors="0" failures="0" name="Test Suite" skipped="0" tests="1" time="0">
+    <testcase classname="a" name="b"/>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
This causes test case resolution to be ambiguous if resolved from the
wrong test suite.

The consequence is for a failing test case that its age could reset
unexpectedly.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
