### PR TITLE
Bump plugin BOM from 1210.vcd41f6657f03 to 1280.vd669827e38cd

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,8 +185,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
-            <!-- TODO https://github.com/jenkinsci/bom/pull/1011 -->
-            <version>2.13.2.20220328-273.v11d70a_b_a_1a_52</version>
         </dependency>
     </dependencies>
     <dependencyManagement>
@@ -194,7 +192,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.303.x</artifactId>
-                <version>1210.vcd41f6657f03</version>
+                <version>1280.vd669827e38cd</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Undoes #375. Now that the plugin BOM has been updated to cross the Jackson/Jersey flag day in https://github.com/jenkinsci/bom/pull/1011, we no longer need to declare an explicit version.