### PR TITLE
Improve jenkins-table layout

### DIFF
--- a/src/main/resources/hudson/tasks/junit/CaseResult/list.jelly
+++ b/src/main/resources/hudson/tasks/junit/CaseResult/list.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
-  <table class="jenkins-table pane sortable" id="testresult">
+  <table class="jenkins-table sortable" id="testresult">
     <thead>
       <tr>
         <th class="pane-header" style="width:10em">${%Build}</th>

--- a/src/main/resources/hudson/tasks/junit/ClassResult/body.jelly
+++ b/src/main/resources/hudson/tasks/junit/ClassResult/body.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
   <j:if test="${it.totalCount!=0}">
     <h2>${%All Tests}</h2>
-    <table class="jenkins-table pane sortable" id="testresult">
+    <table class="jenkins-table sortable" id="testresult">
       <thead>
         <tr>
           <th class="pane-header">${%Test name}</th>

--- a/src/main/resources/hudson/tasks/junit/ClassResult/list.jelly
+++ b/src/main/resources/hudson/tasks/junit/ClassResult/list.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
-    <table class="jenkins-table pane sortable" id="testresult">
+    <table class="jenkins-table sortable" id="testresult">
       <thead>
         <tr>
           <th class="pane-header">${%Build}</th>

--- a/src/main/resources/hudson/tasks/junit/History/index.jelly
+++ b/src/main/resources/hudson/tasks/junit/History/index.jelly
@@ -75,7 +75,7 @@ THE SOFTWARE.
       <j:set var="historySummary" value="${it.retrieveHistorySummary(start)}"/>
 
       <br/>
-      <table class="jenkins-table pane sortable" id="testresult">
+      <table class="jenkins-table sortable" id="testresult">
         <thead>
           <tr>
             <th class="pane-header">${%Build}</th>

--- a/src/main/resources/hudson/tasks/test/AggregatedTestResultPublisher/TestResultAction/index.jelly
+++ b/src/main/resources/hudson/tasks/test/AggregatedTestResultPublisher/TestResultAction/index.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
         <j:otherwise>
           <test:bar/>
           <h2>${%Drill Down}</h2>
-          <table class="jenkins-table pane sortable">
+          <table class="jenkins-table sortable">
             <thead>
               <tr>
                 <th class="pane-header">${%Test}</th>

--- a/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
+++ b/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson/test">
   <j:if test="${it.failCount!=0}">
     <h2>${%All Failed Tests}</h2>
-    <table class="jenkins-table pane sortable">
+    <table class="jenkins-table sortable">
       <thead>
         <tr>
           <th class="pane-header">${%Test Name}</th>
@@ -51,7 +51,7 @@ THE SOFTWARE.
 
   <j:if test="${it.totalCount!=0}">
     <h2>${%All Tests}</h2>
-    <table class="jenkins-table pane sortable" id="testresult">
+    <table class="jenkins-table sortable" id="testresult">
       <thead>
         <tr>
           <th class="pane-header">${it.childTitle}</th>

--- a/src/main/resources/hudson/tasks/test/MetaTabulatedResult/list.jelly
+++ b/src/main/resources/hudson/tasks/test/MetaTabulatedResult/list.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
-    <table class="jenkins-table pane sortable" id="testresult">
+    <table class="jenkins-table sortable" id="testresult">
       <thead>
           <tr>
             <th class="pane-header">${%Build}</th>

--- a/src/main/resources/lib/hudson/test/aggregated-failed-tests.jelly
+++ b/src/main/resources/lib/hudson/test/aggregated-failed-tests.jelly
@@ -44,7 +44,7 @@ THE SOFTWARE.
           <a href="../${report.child.project.shortUrl}testReport">${report.child.project.name}</a>
         </h3>
 
-        <table class="jenkins-table pane sortable">
+        <table class="jenkins-table sortable">
           <thead>
             <tr>
               <th class="pane-header">Test Name</th>

--- a/src/test/resources/hudson/tasks/test/TrivialTestResult/body.jelly
+++ b/src/test/resources/hudson/tasks/test/TrivialTestResult/body.jelly
@@ -65,7 +65,7 @@ THE SOFTWARE.
 
   <j:if test="${it.totalCount!=0}">
     <h2>${%All Tests}</h2>
-    <table class="jenkins-table pane sortable" id="testresult">
+    <table class="jenkins-table sortable" id="testresult">
         <thead>
             <tr>
                 <th class="pane-header">${it.childTitle}</th>


### PR DESCRIPTION
Addressing the comment from https://github.com/jenkinsci/junit-plugin/pull/347#issuecomment-1115122097
The test table does currently render like
![](https://user-images.githubusercontent.com/503338/166291330-e0de1ff4-3de6-4a9a-9a7c-9685d43dbf46.png)
The change proposed gets a rid of the wrong pane argument and renders tables fine again:
![](https://i.imgur.com/Wu1t3kM.png)