### PR TITLE
bump bom to 1500.ve4d05cd32975

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.303.x</artifactId>
-                <version>1117.v62a_f6a_01de98</version>
+                <version>1500.ve4d05cd32975</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -174,11 +174,11 @@
             <groupId>io.jenkins.configuration-as-code</groupId>
             <artifactId>test-harness</artifactId>
             <scope>test</scope>
-            <!-- TODO bump version in jcasc -->
+            <!-- TODO bump parent pom or cherry-pick https://github.com/jenkinsci/junit-plugin/pull/362 -->
             <exclusions>
                 <exclusion>
-                    <groupId>commons-validator</groupId>
-                    <artifactId>commons-validator</artifactId>
+                    <groupId>org.jenkins-ci.main</groupId>
+                    <artifactId>jenkins-test-harness</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Need to bump 1.54 to a newer version of bom to avoid cycle dependency between jackson api and jersey api.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
