### PR TITLE
Backports to 1.54.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.31</version>
+        <version>4.37</version>
         <relativePath />
     </parent>
     <artifactId>junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>echarts-api</artifactId>
-            <version>5.3.2-1</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
@@ -77,7 +76,6 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>bootstrap5-api</artifactId>
-            <version>5.1.3-6</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,11 @@
                 <artifactId>jaxb-runtime</artifactId>
                 <version>2.3.6</version>
             </dependency>
+            <dependency>
+                <groupId>com.sun.activation</groupId>
+                <artifactId>jakarta.activation</artifactId>
+                <version>1.2.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,11 @@
                 <artifactId>byte-buddy</artifactId>
                 <version>1.12.7</version>
             </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>2.3.6</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>echarts-api</artifactId>
+            <version>5.3.2-1</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
@@ -75,7 +76,8 @@
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
-            <artifactId>bootstrap4-api</artifactId>
+            <artifactId>bootstrap5-api</artifactId>
+            <version>5.1.3-6</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/hudson/tasks/test/TestResultDurationChart.java
+++ b/src/main/java/hudson/tasks/test/TestResultDurationChart.java
@@ -11,11 +11,11 @@ import java.util.List;
 import static hudson.tasks.test.TestDurationTrendSeriesBuilder.SECONDS;
 
 public class TestResultDurationChart {
-    
+
     public LinesChartModel create(List<TestDurationResultSummary> results) {
         LinesDataSet dataset = new LinesDataSet();
         results.forEach(result -> dataset.add(result.getDisplayName(), result.toMap(), result.getBuildNumber()));
-        
+
         return getLinesChartModel(dataset);
     }
 
@@ -28,15 +28,13 @@ public class TestResultDurationChart {
     }
 
     private LinesChartModel getLinesChartModel(LinesDataSet dataSet) {
-        LinesChartModel model = new LinesChartModel();
-        model.setDomainAxisLabels(dataSet.getDomainAxisLabels());
-        model.setBuildNumbers(dataSet.getBuildNumbers());
+        LinesChartModel model = new LinesChartModel(dataSet);
 
         LineSeries duration = new LineSeries(SECONDS, Palette.GREEN.getNormal(),
                 LineSeries.StackedMode.STACKED, LineSeries.FilledMode.FILLED);
         duration.addAll(dataSet.getSeries(SECONDS));
         model.addSeries(duration);
-        
+
         return model;
     }
 }

--- a/src/main/java/hudson/tasks/test/TestResultProjectAction.java
+++ b/src/main/java/hudson/tasks/test/TestResultProjectAction.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,29 +23,32 @@
  */
 package hudson.tasks.test;
 
+import java.io.IOException;
+import java.util.List;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
 import edu.hm.hafner.echarts.ChartModelConfiguration;
 import edu.hm.hafner.echarts.JacksonFacade;
 import edu.hm.hafner.echarts.LinesChartModel;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+
+import org.kohsuke.stapler.Ancestor;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.bind.JavaScriptMethod;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.tasks.junit.JUnitResultArchiver;
-import io.jenkins.plugins.junit.storage.FileJunitTestResultStorage;
-import io.jenkins.plugins.junit.storage.TestResultImpl;
-import io.jenkins.plugins.junit.storage.JunitTestResultStorage;
-import io.jenkins.plugins.echarts.AsyncTrendChart;
-import org.kohsuke.stapler.Ancestor;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.List;
-import org.kohsuke.stapler.bind.JavaScriptMethod;
+import io.jenkins.plugins.echarts.AsyncConfigurableTrendChart;
+import io.jenkins.plugins.echarts.AsyncTrendChart;
+import io.jenkins.plugins.junit.storage.FileJunitTestResultStorage;
+import io.jenkins.plugins.junit.storage.JunitTestResultStorage;
+import io.jenkins.plugins.junit.storage.TestResultImpl;
 
 /**
  * Project action object from test reporter, such as {@link JUnitResultArchiver},
@@ -56,7 +59,7 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
  *
  * @author Kohsuke Kawaguchi
  */
-public class TestResultProjectAction implements Action, AsyncTrendChart {
+public class TestResultProjectAction implements Action, AsyncTrendChart, AsyncConfigurableTrendChart {
     /**
      * Project that owns this action.
      * @since 1.2-beta-1
@@ -69,13 +72,13 @@ public class TestResultProjectAction implements Action, AsyncTrendChart {
     /**
      * @since 1.2-beta-1
      */
-    public TestResultProjectAction(Job<?,?> job) {
+    public TestResultProjectAction(final Job<?,?> job) {
         this.job = job;
         project = job instanceof AbstractProject ? (AbstractProject) job : null;
     }
 
     @Deprecated
-    public TestResultProjectAction(AbstractProject<?,?> project) {
+    public TestResultProjectAction(final AbstractProject<?,?> project) {
         this((Job) project);
     }
 
@@ -114,7 +117,12 @@ public class TestResultProjectAction implements Action, AsyncTrendChart {
         return null;
     }
 
+    @Deprecated
     protected LinesChartModel createChartModel() {
+        return createChartModel(new ChartModelConfiguration());
+    }
+
+    private LinesChartModel createChartModel(final ChartModelConfiguration configuration) {
         Run<?, ?> lastCompletedBuild = job.getLastCompletedBuild();
 
         JunitTestResultStorage storage = JunitTestResultStorage.find();
@@ -127,11 +135,11 @@ public class TestResultProjectAction implements Action, AsyncTrendChart {
         if (buildHistory == null) {
             return new LinesChartModel();
         }
-        return new TestResultTrendChart().create(buildHistory, new ChartModelConfiguration());
+        return new TestResultTrendChart().create(buildHistory, configuration);
     }
 
     @CheckForNull
-    private TestResultActionIterable createBuildHistory(Run<?, ?> lastCompletedBuild) {
+    private TestResultActionIterable createBuildHistory(final Run<?, ?> lastCompletedBuild) {
         // some plugins that depend on junit seem to attach the action even though there's no run
         // e.g. xUnit and cucumber
         if (lastCompletedBuild == null) {
@@ -153,11 +161,11 @@ public class TestResultProjectAction implements Action, AsyncTrendChart {
 
     /**
      * Display the test result trend.
-     * 
+     *
      * @deprecated Replaced by echarts in TODO
      */
     @Deprecated
-    public void doTrend( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
+    public void doTrend( final StaplerRequest req, final StaplerResponse rsp ) throws IOException, ServletException {
         AbstractTestResultAction a = getLastTestResultAction();
         if(a!=null)
             a.doGraph(req,rsp);
@@ -171,7 +179,7 @@ public class TestResultProjectAction implements Action, AsyncTrendChart {
      * @deprecated Replaced by echarts in TODO
      */
     @Deprecated
-    public void doTrendMap( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
+    public void doTrendMap( final StaplerRequest req, final StaplerResponse rsp ) throws IOException, ServletException {
         AbstractTestResultAction a = getLastTestResultAction();
         if(a!=null)
             a.doGraphMap(req,rsp);
@@ -182,7 +190,7 @@ public class TestResultProjectAction implements Action, AsyncTrendChart {
     /**
      * Changes the test result report display mode.
      */
-    public void doFlipTrend( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
+    public void doFlipTrend( final StaplerRequest req, final StaplerResponse rsp ) throws IOException, ServletException {
         boolean failureOnly = false;
 
         // check the current preference value
@@ -200,7 +208,7 @@ public class TestResultProjectAction implements Action, AsyncTrendChart {
         // set the updated value
         Cookie cookie = new Cookie(FAILURE_ONLY_COOKIE,String.valueOf(failureOnly));
         List<Ancestor> anc = req.getAncestors();
-        Ancestor a = (Ancestor) anc.get(anc.size()-2);
+        Ancestor a = anc.get(anc.size()-2);
         cookie.setPath(a.getUrl()); // just for this project
         cookie.setMaxAge(60*60*24*365); // 1 year
         rsp.addCookie(cookie);
@@ -211,10 +219,15 @@ public class TestResultProjectAction implements Action, AsyncTrendChart {
 
     private static final String FAILURE_ONLY_COOKIE = "TestResultAction_failureOnly";
 
-    @JavaScriptMethod
-    @Override
+    @Override @Deprecated
     public String getBuildTrendModel() {
         return new JacksonFacade().toJson(createChartModel());
+    }
+
+    @JavaScriptMethod
+    @Override
+    public String getConfigurableBuildTrendModel(final String configuration) {
+        return new JacksonFacade().toJson(createChartModel(ChartModelConfiguration.fromJson(configuration)));
     }
 
     @Override

--- a/src/main/java/hudson/tasks/test/TestResultTrendChart.java
+++ b/src/main/java/hudson/tasks/test/TestResultTrendChart.java
@@ -1,24 +1,24 @@
 package hudson.tasks.test;
 
+import java.util.List;
+
 import edu.hm.hafner.echarts.ChartModelConfiguration;
 import edu.hm.hafner.echarts.LineSeries;
 import edu.hm.hafner.echarts.LinesChartModel;
 import edu.hm.hafner.echarts.LinesDataSet;
 import edu.hm.hafner.echarts.Palette;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.tasks.junit.TrendTestResultSummary;
-import java.util.List;
 
-import static hudson.tasks.test.TestResultTrendSeriesBuilder.FAILED_KEY;
-import static hudson.tasks.test.TestResultTrendSeriesBuilder.PASSED_KEY;
-import static hudson.tasks.test.TestResultTrendSeriesBuilder.SKIPPED_KEY;
+import hudson.tasks.junit.TrendTestResultSummary;
+
+import static hudson.tasks.test.TestResultTrendSeriesBuilder.*;
 
 public class TestResultTrendChart {
-    
-    public LinesChartModel create(List<TrendTestResultSummary> results) {
+
+    public LinesChartModel create(final List<TrendTestResultSummary> results) {
         LinesDataSet dataset = new LinesDataSet();
         results.forEach(result -> dataset.add(result.getDisplayName(), result.toMap(), result.getBuildNumber()));
-        
+
         return getLinesChartModel(dataset);
     }
 
@@ -29,7 +29,7 @@ public class TestResultTrendChart {
 
         return getLinesChartModel(dataSet);
     }
-    
+
     public LinesChartModel createFromTestObject(final Iterable results,
                                   final ChartModelConfiguration configuration) {
         TestObjectTrendSeriesBuilder builder = new TestObjectTrendSeriesBuilder();
@@ -38,11 +38,8 @@ public class TestResultTrendChart {
         return getLinesChartModel(dataSet);
     }
 
-    private LinesChartModel getLinesChartModel(LinesDataSet dataSet) {
-        LinesChartModel model = new LinesChartModel();
-        model.setDomainAxisLabels(dataSet.getDomainAxisLabels());
-        model.setBuildNumbers(dataSet.getBuildNumbers());
-
+    private LinesChartModel getLinesChartModel(final LinesDataSet dataSet) {
+        LinesChartModel model = new LinesChartModel(dataSet);
         LineSeries failed = new LineSeries("Failed", Palette.RED.getNormal(),
                 LineSeries.StackedMode.STACKED, LineSeries.FilledMode.FILLED);
         failed.addAll(dataSet.getSeries(FAILED_KEY));

--- a/src/main/resources/hudson/tasks/junit/History/index.jelly
+++ b/src/main/resources/hudson/tasks/junit/History/index.jelly
@@ -24,13 +24,17 @@ THE SOFTWARE.
 
 <!-- Displays the chart that show how long builds are taking -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:bs="/bootstrap">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:bs="/bootstrap5" xmlns:c="/charts">
   <bs:layout title="${%title(it.testObject.displayName)}">
     <j:set var="start" value="${it.asInt(request.getParameter('start'),0)}"/>
     <j:set var="end" value="${it.asInt(request.getParameter('end'),start+24)}"/>
-    <link rel="stylesheet" href="${resURL}/plugin/junit/history/history.css"/>
     <st:adjunct includes="io.jenkins.plugins.echarts"/>
+    <st:adjunct includes="io.jenkins.plugins.bootstrap5"/>
+    <st:adjunct includes="io.jenkins.plugins.echarts-trend-default-setup"/>
+    <link rel="stylesheet" href="${resURL}/plugin/junit/history/history.css"/>
+
     <st:once>
+      <c:chart-setup id="test-history"/>
       <script>var view =
         <st:bind value="${it}"/>
       </script>
@@ -42,23 +46,23 @@ THE SOFTWARE.
       <j:choose>
         <j:when test="${it.historyAvailable()}">
           <bs:card title="${%History}" fontAwesomeIcon="chart-line">
-            <div id="trend-carousel" class="carousel slide" data-interval="false">
+            <div id="trend-carousel" class="carousel slide carousel-dark" data-bs-interval="false">
               <div class="carousel-inner">
                 <div class="carousel-item">
-                  <div id="test-duration-trend-chart" class="graph-cursor-pointer card-chart"/>
+                  <div id="test-duration-trend-chart" class="graph-cursor-pointer card-chart-carousel"/>
                 </div>
                 <div class="carousel-item active">
-                  <div id="test-result-trend-chart" class="graph-cursor-pointer card-chart"/>
+                  <div id="test-result-trend-chart" class="graph-cursor-pointer card-chart-carousel"/>
                 </div>
               </div>
-              <a class="carousel-control-prev" data-target="#trend-carousel" role="button" data-slide="prev">
+              <button class="carousel-control-prev" type="button" data-bs-target="#trend-carousel" data-bs-slide="prev">
                 <span class="carousel-control-prev-icon" aria-hidden="true"/>
-                <span class="sr-only">Previous</span>
-              </a>
-              <a class="carousel-control-next" data-target="#trend-carousel" role="button" data-slide="next">
+                <span class="visually-hidden">Previous</span>
+              </button>
+              <button class="carousel-control-next" type="button" data-bs-target="#trend-carousel" data-bs-slide="next">
                 <span class="carousel-control-next-icon" aria-hidden="true"/>
-                <span class="sr-only">Next</span>
-              </a>
+                <span class="visually-hidden">Next</span>
+              </button>
             </div>
           </bs:card>
 

--- a/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local" xmlns:c="/charts">
-  <c:trend-chart it="${from}" title="${%Test Result Trend}" enableLinks="true"/>
+<j:jelly xmlns:j="jelly:core"
+         xmlns:c="/charts">
+  <c:trend-chart it="${from}" title="${%Test Result Trend}" enableLinks="true" configurationId="default"/>
 </j:jelly>

--- a/src/main/webapp/history/history.css
+++ b/src/main/webapp/history/history.css
@@ -1,8 +1,8 @@
-.card-chart {
-    width: 90%;
+.card-chart-carousel {
+    width: 100%;
     min-height: 256px;
     min-width: 256px;
     display: block;
-    margin-left: auto;
-    margin-right: auto;
+    padding-left: 20px;
+    padding-right: 20px;
 }

--- a/src/main/webapp/history/history.js
+++ b/src/main/webapp/history/history.js
@@ -1,48 +1,69 @@
-/* global jQuery3, view, echartsJenkinsApi */
-document.addEventListener('DOMContentLoaded', function () {
-    redrawTrendCharts();
-    storeAndRestoreCarousel('trend-carousel');
+/* global jQuery3, bootstrap5, view, echartsJenkinsApi */
+(function ($) {
+    $(document).ready(function ($) {
+        const trendConfigurationDialogId = 'chart-configuration-test-history';
 
-    /**
-     * Redraws the trend charts. Reads the last selected X-Axis type from the browser local storage and
-     * redraws the trend charts.
-     */
-    function redrawTrendCharts() {
+        $('#' + trendConfigurationDialogId).on('hidden.bs.modal', function () {
+            redrawTrendCharts();
+        });
+
+        redrawTrendCharts();
+        storeAndRestoreCarousel('trend-carousel');
 
         /**
-         * Creates a build trend chart that shows the test duration across a number of builds.
-         * Requires that a DOM <div> element exists with the ID '#test-duration-trend-chart'.
+         * Activate tooltips.
          */
-        view.getTestDurationTrend(function (lineModel) {
-            echartsJenkinsApi.renderZoomableTrendChart('test-duration-trend-chart', lineModel.responseJSON, redrawTrendCharts);
+        $(function () {
+            $('[data-bs-toggle="tooltip"]').each(function () {
+                const tooltip = new bootstrap5.Tooltip($(this)[0]);
+                tooltip.enable();
+            });
         });
 
         /**
-         * Creates a build trend chart that shows the test results across a number of builds.
-         * Requires that a DOM <div> element exists with the ID '#test-result-trend-chart'.
+         * Redraws the trend charts. Reads the last selected X-Axis type from the browser local storage and
+         * redraws the trend charts.
          */
-        view.getTestResultTrend(function (lineModel) {
-            echartsJenkinsApi.renderZoomableTrendChart('test-result-trend-chart', lineModel.responseJSON, redrawTrendCharts);
-        });
-    }
+        function redrawTrendCharts() {
+            const configuration = JSON.stringify(echartsJenkinsApi.readFromLocalStorage('jenkins-echarts-chart-configuration-test-history'));
 
-    /**
-     * Store and restore the selected carousel image in browser's local storage.
-     * Additionally, the trend chart is redrawn.
-     *
-     */
-    function storeAndRestoreCarousel (carouselId) {
-        const carousel = jQuery3('#' + carouselId);
-        carousel.on('slid.bs.carousel', function (e) {
-            localStorage.setItem(carouselId, e.to);
-            const chart = jQuery3(e.relatedTarget).find('>:first-child')[0].echart;
-            if (chart) {
-                chart.resize();
-            }
-        });
-        const activeCarousel = localStorage.getItem(carouselId);
-        if (activeCarousel) {
-            carousel.carousel(parseInt(activeCarousel));
+            /**
+             * Creates a build trend chart that shows the test duration across a number of builds.
+             * Requires that a DOM <div> element exists with the ID '#test-duration-trend-chart'.
+             */
+            view.getTestDurationTrend(configuration, function (lineModel) {
+                echartsJenkinsApi.renderConfigurableZoomableTrendChart('test-duration-trend-chart', lineModel.responseJSON, trendConfigurationDialogId);
+            });
+
+            /**
+             * Creates a build trend chart that shows the test results across a number of builds.
+             * Requires that a DOM <div> element exists with the ID '#test-result-trend-chart'.
+             */
+            view.getTestResultTrend(configuration, function (lineModel) {
+                echartsJenkinsApi.renderConfigurableZoomableTrendChart('test-result-trend-chart', lineModel.responseJSON, trendConfigurationDialogId);
+            });
         }
-    }
-})
+
+        /**
+         * Store and restore the selected carousel image in browser's local storage.
+         * Additionally, the trend chart is redrawn.
+         *
+         */
+        function storeAndRestoreCarousel (carouselId) {
+            const carousel = $('#' + carouselId);
+            carousel.on('slid.bs.carousel', function (e) {
+                localStorage.setItem(carouselId, e.to);
+                const chart = $(e.relatedTarget).find('>:first-child')[0].echart;
+                if (chart) {
+                    chart.resize();
+                }
+            });
+            const activeCarousel = localStorage.getItem(carouselId);
+            if (activeCarousel) {
+                const carouselControl = new bootstrap5.Carousel(carousel[0]);
+                carouselControl.to(parseInt(activeCarousel));
+                carouselControl.pause();
+            }
+        }
+    })
+})(jQuery3);

--- a/src/test/java/hudson/tasks/junit/JUnitResultArchiverTest.java
+++ b/src/test/java/hudson/tasks/junit/JUnitResultArchiverTest.java
@@ -382,15 +382,15 @@ public class JUnitResultArchiverTest {
         WebClient wc = j.createWebClient();
         HtmlPage page = wc.getPage(b, "testReport");
 
-        assertThat(page.asText(), not(containsString(EXPECTED)));
+        assertThat(page.asNormalizedText(), not(containsString(EXPECTED)));
 
         ((HtmlAnchor) page.getElementById(ID_PREFIX + "-showlink")).click();
         wc.waitForBackgroundJavaScript(10000L);
-        assertThat(page.asText(), containsString(EXPECTED));
+        assertThat(page.asNormalizedText(), containsString(EXPECTED));
 
         ((HtmlAnchor) page.getElementById(ID_PREFIX + "-hidelink")).click();
         wc.waitForBackgroundJavaScript(10000L);
-        assertThat(page.asText(), not(containsString(EXPECTED)));
+        assertThat(page.asNormalizedText(), not(containsString(EXPECTED)));
     }
 
     @Issue("JENKINS-26535")

--- a/src/test/java/hudson/tasks/junit/JUnitResultArchiverTest.java
+++ b/src/test/java/hudson/tasks/junit/JUnitResultArchiverTest.java
@@ -65,6 +65,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
+import hudson.tasks.test.helper.WebClientFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -112,7 +113,7 @@ public class JUnitResultArchiverTest {
 
         assertTestResults(build);
 
-        WebClient wc = j.new WebClient();
+        WebClient wc = WebClientFactory.createWebClientWithDisabledJavaScript(j);
         wc.getPage(project); // project page
         wc.getPage(build); // build page
         wc.getPage(build, "testReport");  // test report
@@ -423,43 +424,43 @@ public class JUnitResultArchiverTest {
 
         assertEquals(described, model.uninstantiate(model.instantiate(described)));
     }
-    
+
     @Test
     @Issue("SECURITY-521")
     public void testXxe() throws Exception {
         String oobInUserContentLink = j.getURL() + "userContent/oob.xml";
         String triggerLink = j.getURL() + "triggerMe";
-        
+
         String xxeFile = this.getClass().getResource("testXxe-xxe.xml").getFile();
         String xxeFileContent = FileUtils.readFileToString(new File(xxeFile), StandardCharsets.UTF_8);
         String adaptedXxeFileContent = xxeFileContent.replace("$OOB_LINK$", oobInUserContentLink);
-        
+
         String oobFile = this.getClass().getResource("testXxe-oob.xml").getFile();
         String oobFileContent = FileUtils.readFileToString(new File(oobFile), StandardCharsets.UTF_8);
         String adaptedOobFileContent = oobFileContent.replace("$TARGET_URL$", triggerLink);
-        
+
         File userContentDir = new File(j.jenkins.getRootDir(), "userContent");
         FileUtils.writeStringToFile(new File(userContentDir, "oob.xml"), adaptedOobFileContent);
-        
+
         FreeStyleProject project = j.createFreeStyleProject();
         DownloadBuilder builder = new DownloadBuilder();
         builder.fileContent = adaptedXxeFileContent;
         project.getBuildersList().add(builder);
-        
+
         JUnitResultArchiver publisher = new JUnitResultArchiver("xxe.xml");
         project.getPublishersList().add(publisher);
-    
+
         project.scheduleBuild2(0).get();
         // UNSTABLE
         // assertEquals(Result.SUCCESS, project.scheduleBuild2(0).get().getResult());
-        
+
         YouCannotTriggerMe urlHandler = j.jenkins.getExtensionList(UnprotectedRootAction.class).get(YouCannotTriggerMe.class);
         assertEquals(0, urlHandler.triggerCount);
     }
-    
+
     public static class DownloadBuilder extends Builder {
         String fileContent;
-        
+
         @Override
         public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
             try {
@@ -467,43 +468,43 @@ public class JUnitResultArchiverTest {
             } catch (IOException e) {
                 return false;
             }
-            
+
             return true;
         }
-        
+
         @Extension
         public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
             @Override
             public boolean isApplicable(Class<? extends AbstractProject> jobType) {
                 return true;
             }
-            
+
             @Override
             public String getDisplayName() {
                 return null;
             }
         }
     }
-    
+
     @TestExtension("testXxe")
     public static class YouCannotTriggerMe implements UnprotectedRootAction {
         private int triggerCount = 0;
-        
+
         @Override
         public String getIconFileName() {
             return null;
         }
-        
+
         @Override
         public String getDisplayName() {
             return null;
         }
-        
+
         @Override
         public String getUrlName() {
             return "triggerMe";
         }
-        
+
         public HttpResponse doIndex() {
             triggerCount++;
             return HttpResponses.plainText("triggered");

--- a/src/test/java/hudson/tasks/junit/TestResultPublishingTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultPublishingTest.java
@@ -299,7 +299,7 @@ public class TestResultPublishingTest {
 
     void assertPaneDiffText(String msg, int expectedValue, Object paneObj) {
         assertTrue( "paneObj should be an HtmlElement, it was " + paneObj.getClass(), paneObj instanceof HtmlElement );
-        String paneText = ((HtmlElement) paneObj).asText();
+        String paneText = ((HtmlElement) paneObj).asNormalizedText();
         if (expectedValue==0) {
             assertStringEmptyOrNull(msg, paneText);
         } else {

--- a/src/test/java/hudson/tasks/junit/TestResultPublishingTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultPublishingTest.java
@@ -37,6 +37,8 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.slaves.DumbSlave;
 import hudson.tasks.Builder;
+import hudson.tasks.test.helper.WebClientFactory;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -83,9 +85,7 @@ public class TestResultPublishingTest {
 
         assertTestResults(build);
 
-        WebClient wc = rule.createWebClient();
-        wc.getPage(project); // project page
-        wc.getPage(build); // build page
+        WebClient wc = WebClientFactory.createWebClientWithDisabledJavaScript(rule);
         wc.getPage(build, "testReport");  // test report
         wc.getPage(build, "testReport/hudson.security"); // package
         wc.getPage(build, "testReport/hudson.security/HudsonPrivateSecurityRealmTest/"); // class
@@ -107,7 +107,7 @@ public class TestResultPublishingTest {
 
         testBasic();
     }
-  
+
 
     /**
      * Verify that we can successfully parse and display test results in the
@@ -124,7 +124,7 @@ public class TestResultPublishingTest {
         assertNotNull("We should have a project named " + TEST_PROJECT_WITH_HISTORY, proj);
 
         // Validate that there are test results where I expect them to be:
-        WebClient wc = rule.createWebClient();
+        WebClient wc = WebClientFactory.createWebClientWithDisabledJavaScript(rule);
 
         // On the project page:
         HtmlPage projectPage = wc.getPage(proj);
@@ -138,12 +138,8 @@ public class TestResultPublishingTest {
         //      there should be a test result trend graph
         HtmlElement trendGraphCaption = (HtmlElement) projectPage.getByXPath( "//div[@class='test-trend-caption']").get(0);
         assertThat(trendGraphCaption.getTextContent(), is("Test Result Trend"));
-        HtmlElement testCanvas = ((HtmlElement) trendGraphCaption.getParentNode()).getElementsByTagName("canvas").get(0);
-        assertNotNull("couldn't find test result trend graph", testCanvas);
-
-        // The trend graph should be clickable and take us to a run details page
-        assertTrue("image node should be an HtmlCanvas object", testCanvas instanceof HtmlCanvas);
-        // TODO: Check that we can click on the graph and get to a particular run. How do I do this with HtmlUnit?
+        HtmlElement testCanvas = (HtmlElement) trendGraphCaption.getNextSibling().getFirstChild();
+        assertTrue("couldn't find test result trend graph", testCanvas.getAttribute("class").contains("echarts-trend"));
 
         XmlPage xmlProjectPage = wc.goToXml(proj.getUrl() + "/lastBuild/testReport/api/xml");
         rule.assertXPath(xmlProjectPage, "/testResult");
@@ -227,7 +223,7 @@ public class TestResultPublishingTest {
         assertNotNull("We should have a project named " + TEST_PROJECT_WITH_HISTORY, proj);
 
         // Validate that there are test results where I expect them to be:
-        WebClient wc = rule.createWebClient();
+        WebClient wc = WebClientFactory.createWebClientWithDisabledJavaScript(rule);
         Run theRun = proj.getBuildByNumber(4);
         assertTestResultsAsExpected(wc, theRun, "/testReport",
                         "org.jvnet.hudson.examples.small", "12 ms", "FAILURE",
@@ -250,11 +246,11 @@ public class TestResultPublishingTest {
         assertNotNull("We should have a project named " + TEST_PROJECT_WITH_HISTORY, proj);
 
         // Validate that there are test results where I expect them to be:
-        WebClient wc = rule.createWebClient();
+        WebClient wc = WebClientFactory.createWebClientWithDisabledJavaScript(rule);
 
         HtmlPage historyPage = wc.getPage(proj.getBuildByNumber(7),"/testReport/history/");
         rule.assertGoodStatus(historyPage);
-        HtmlElement historyCard = (HtmlElement) historyPage.getByXPath( "//div[@class='card-body']").get(0);
+        HtmlElement historyCard = (HtmlElement) historyPage.getByXPath( "//div[@class='card-body ']").get(0);
         assertThat(historyCard.getTextContent(), containsString("History"));
         DomElement wholeTable = historyPage.getElementById("testresult");
         assertNotNull("table with id 'testresult' exists", wholeTable);
@@ -292,7 +288,7 @@ public class TestResultPublishingTest {
             return true;
         }
     }
-  
+
     void assertStringEmptyOrNull(String msg, String str) {
         if (str==null)
             return;
@@ -301,7 +297,7 @@ public class TestResultPublishingTest {
         fail(msg + "(should be empty or null) : '" + str + "'");
     }
 
-    void assertPaneDiffText(String msg, int expectedValue, Object paneObj) { 
+    void assertPaneDiffText(String msg, int expectedValue, Object paneObj) {
         assertTrue( "paneObj should be an HtmlElement, it was " + paneObj.getClass(), paneObj instanceof HtmlElement );
         String paneText = ((HtmlElement) paneObj).asText();
         if (expectedValue==0) {

--- a/src/test/java/hudson/tasks/test/AggregatedTestResultPublisherTest.java
+++ b/src/test/java/hudson/tasks/test/AggregatedTestResultPublisherTest.java
@@ -10,6 +10,7 @@ import hudson.tasks.BuildTrigger;
 import hudson.tasks.Fingerprinter;
 import hudson.tasks.Shell;
 import hudson.tasks.junit.JUnitResultArchiver;
+import hudson.tasks.test.helper.WebClientFactory;
 import hudson.tasks.test.helper.BuildPage;
 import hudson.tasks.test.helper.ProjectPage;
 import org.junit.Before;
@@ -48,7 +49,7 @@ public class AggregatedTestResultPublisherTest {
 
     @Before
     public void setup() {
-        wc = j.createWebClient();
+        wc = WebClientFactory.createWebClientWithDisabledJavaScript(j);
     }
 
     @LocalData

--- a/src/test/java/hudson/tasks/test/helper/AbstractTestResultLink.java
+++ b/src/test/java/hudson/tasks/test/helper/AbstractTestResultLink.java
@@ -14,7 +14,7 @@ public class AbstractTestResultLink<T extends AbstractTestResultLink<T>> {
     }
 
     public String getResultText() {
-        return testResultLink.getNextSibling().asText();
+        return testResultLink.getNextSibling().asNormalizedText();
     }
     public T assertNoTests() {
         assertThat(getResultText(), containsString("no tests"));

--- a/src/test/java/hudson/tasks/test/helper/WebClientFactory.java
+++ b/src/test/java/hudson/tasks/test/helper/WebClientFactory.java
@@ -1,0 +1,22 @@
+package hudson.tasks.test.helper;
+
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
+
+import com.gargoylesoftware.htmlunit.NicelyResynchronizingAjaxController;
+
+/**
+ * Creates a {@link WebClient} with deactivated JS.
+ *
+ * @author Ullrich Hafner
+ */
+public class WebClientFactory {
+    public static WebClient createWebClientWithDisabledJavaScript(final JenkinsRule jenkinsRule) {
+        WebClient webClient = jenkinsRule.createWebClient();
+        webClient.setJavaScriptEnabled(false);
+        webClient.setAjaxController(new NicelyResynchronizingAjaxController());
+        webClient.getCookieManager().setCookiesEnabled(false);
+        webClient.getOptions().setCssEnabled(false);
+        return webClient;
+    }
+}


### PR DESCRIPTION
Clean cherry-pick of #272 and #359 onto the 1.54.x line. See the test failures in https://ci.jenkins.io/job/Tools/job/bom/job/PR-1059/50/ - I have no idea why current PCT doesn't fail in this way, but my improved framework from JENKINS-45047 catches this (legitimate, I think) compatibility problem on the 1.54.x line. Cherry-picking the mentioned PRs resolves the issue for me locally when running PCT with JENKINS-45047.

CC @jetersen @timja