### PR TITLE
EOL usages of `StringUtils`

### DIFF
--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -28,9 +28,7 @@ import io.jenkins.plugins.junit.storage.FileJunitTestResultStorage;
 import io.jenkins.plugins.junit.storage.TestResultImpl;
 import io.jenkins.plugins.junit.storage.JunitTestResultStorage;
 import hudson.util.TextFile;
-import org.apache.commons.collections.iterators.ReverseListIterator;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
 import org.jvnet.localizer.Localizable;
 
 import hudson.model.Run;
@@ -318,7 +316,9 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
             if (r != null) {
                 TestResultAction action = r.getAction(TestResultAction.class);
                 if (action != null && action.getResult().hasMultipleBlocks()) {
-                    return StringUtils.join(new ReverseListIterator(getEnclosingFlowNodeNames()), " / ") + " / " + rawName;
+                    List<String> enclosingFlowNodeNames = getEnclosingFlowNodeNames();
+                    Collections.reverse(enclosingFlowNodeNames);
+                    return String.join(" / ", enclosingFlowNodeNames) + " / " + rawName;
                 }
             }
         }
@@ -333,7 +333,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
      */
     @Exported(visibility=999)
     public @Override String getName() {
-        if (StringUtils.isEmpty(testName)) {
+        if (testName == null || testName.isEmpty()) {
             return "(?)";
         }
         return testName;

--- a/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
+++ b/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
@@ -50,8 +50,6 @@ import io.jenkins.plugins.junit.checks.JUnitChecksPublisher;
 import io.jenkins.plugins.junit.storage.FileJunitTestResultStorage;
 import io.jenkins.plugins.junit.storage.JunitTestResultStorage;
 import jenkins.tasks.SimpleBuildStep;
-import org.apache.commons.collections.iterators.ReverseListIterator;
-import org.apache.commons.lang.StringUtils;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.types.FileSet;
 import org.kohsuke.stapler.AncestorInPath;
@@ -309,7 +307,8 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
                 if (checksName == null && pipelineTestDetails != null) {
                     List<String> checksComponents = new ArrayList<>(pipelineTestDetails.getEnclosingBlockNames());
                     checksComponents.add(DEFAULT_CHECKS_NAME);
-                    checksName = StringUtils.join(new ReverseListIterator(checksComponents), " / ");
+                    Collections.reverse(checksComponents);
+                    checksName = String.join(" / ", checksComponents);
                 }
                 if (Util.fixEmpty(checksName) == null) {
                     checksName = DEFAULT_CHECKS_NAME;

--- a/src/main/java/hudson/tasks/junit/XMLEntityResolver.java
+++ b/src/main/java/hudson/tasks/junit/XMLEntityResolver.java
@@ -23,7 +23,6 @@
  */
 package hudson.tasks.junit;
 
-import org.apache.commons.lang.StringUtils;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -62,7 +61,7 @@ public class XMLEntityResolver implements EntityResolver {
             // TestNG system-ids
             if (systemId.startsWith(TESTNG_HTTP_NAMESPACE) || systemId.startsWith(TESTNG_HTTPS_NAMESPACE)) {
                 LOGGER.fine("It's a TestNG document, will try to lookup DTD in classpath");
-                String dtdFileName = StringUtils.substringAfterLast(systemId, "/");
+                String dtdFileName = systemId.substring(systemId.lastIndexOf("/") + 1);
 
                 URL url = getClass().getClassLoader().getResource(dtdFileName);
                 if (url != null)

--- a/src/main/java/hudson/tasks/test/TestObject.java
+++ b/src/main/java/hudson/tasks/test/TestObject.java
@@ -38,7 +38,6 @@ import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
@@ -418,7 +417,7 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
      * @return the string with the unsafe characters replaced.
      */
     public static String safe(String s) {
-        if (StringUtils.isEmpty(s)) {
+        if (s == null || s.isEmpty()) {
             return "(empty)";
         } else {
             // this still seems to be a bit faster than a single replace with regexp

--- a/src/main/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisher.java
@@ -12,7 +12,6 @@ import io.jenkins.plugins.checks.api.ChecksOutput;
 import io.jenkins.plugins.checks.api.ChecksPublisher;
 import io.jenkins.plugins.checks.api.ChecksPublisherFactory;
 import io.jenkins.plugins.checks.api.ChecksStatus;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -87,23 +86,23 @@ public class JUnitChecksPublisher {
         builder.append("## `").append(failedTest.getTransformedFullDisplayName().trim()).append("`")
                 .append("\n");
 
-        if (StringUtils.isNotBlank(failedTest.getErrorDetails())) {
+        if (failedTest.getErrorDetails() != null && !failedTest.getErrorDetails().trim().isEmpty()) {
             builder.append(codeTextFencedBlock(failedTest.getErrorDetails()))
                     .append("\n");
         }
-        if (StringUtils.isNotBlank(failedTest.getErrorStackTrace())) {
+        if (failedTest.getErrorStackTrace() != null && !failedTest.getErrorStackTrace().trim().isEmpty()) {
             builder.append("<details><summary>Stack trace</summary>\n")
                     .append(codeTextFencedBlock(failedTest.getErrorStackTrace()))
                     .append("</details>\n");
         }
 
-        if (StringUtils.isNotBlank(failedTest.getStderr())) {
+        if (failedTest.getStderr() != null && !failedTest.getStderr().trim().isEmpty()) {
             builder.append("<details><summary>Standard error</summary>\n")
                     .append(codeTextFencedBlock(failedTest.getStderr()))
                     .append("</details>\n");
         }
 
-        if (StringUtils.isNotBlank(failedTest.getStdout())) {
+        if (failedTest.getStdout() != null && !failedTest.getStdout().trim().isEmpty()) {
             builder.append("<details><summary>Standard out</summary>\n")
                     .append(codeTextFencedBlock(failedTest.getStdout()))
                     .append("</details>\n");

--- a/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
+++ b/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
@@ -70,7 +70,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import hudson.tasks.junit.HistoryTestResultSummary;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.database.Database;
 import org.jenkinsci.plugins.database.GlobalDatabaseConfiguration;
 import org.jenkinsci.plugins.database.h2.LocalH2Database;
@@ -803,17 +802,17 @@ public class TestResultStorageJunitTest {
                                     statement.setNull(8, Types.VARCHAR);
                                 }
                                 statement.setFloat(9, caseResult.getDuration());
-                                if (StringUtils.isNotEmpty(caseResult.getStdout())) {
+                                if (caseResult.getStdout() != null && !caseResult.getStdout().isEmpty()) {
                                     statement.setString(10, caseResult.getStdout());
                                 } else {
                                     statement.setNull(10, Types.VARCHAR);
                                 }
-                                if (StringUtils.isNotEmpty(caseResult.getStderr())) {
+                                if (caseResult.getStderr() != null && !caseResult.getStderr().isEmpty()) {
                                     statement.setString(11, caseResult.getStderr());
                                 } else {
                                     statement.setNull(11, Types.VARCHAR);
                                 }
-                                if (StringUtils.isNotEmpty(caseResult.getErrorStackTrace())) {
+                                if (caseResult.getErrorStackTrace() != null && !caseResult.getErrorStackTrace().isEmpty()) {
                                     statement.setString(12, caseResult.getErrorStackTrace());
                                 } else {
                                     statement.setNull(12, Types.VARCHAR);


### PR DESCRIPTION
Got these baffling errors when running PCT with `copyartifact` in the managed set in https://github.com/jenkinsci/bom/pull/1385:

- https://ci.jenkins.io/job/Tools/job/bom/job/PR-1385/3/testReport/junit/(root)/ArchitectureTest/pct_checks_api_2_319_x___NO_JENKINS_INSTANCE_CALL/
- https://ci.jenkins.io/job/Tools/job/bom/job/PR-1385/3/testReport/junit/(root)/ArchitectureTest/pct_checks_api_2_319_x___NO_FORBIDDEN_PACKAGE_ACCESSED/

```
Architecture Violation [Priority: MEDIUM] - Rule 'no classes that do not have simple name 'JenkinsFacade' should call method Jenkins.getInstance() or should call method Jenkins.getInstanceOrNull() or should call method Jenkins.getActiveInstance() or should call method Jenkins.get()' was violated (2 times):
Method <io.jenkins.plugins.junit.storage.JunitTestResultStorageDescriptor.all()> calls method <jenkins.model.Jenkins.get()> in (JunitTestResultStorageDescriptor.java:12)
Method <io.jenkins.plugins.junit.storage.TestResultImpl.getRun()> calls method <jenkins.model.Jenkins.get()> in (TestResultImpl.java:87)
```

and

```
Architecture Violation [Priority: MEDIUM] - Rule 'no classes should depend on classes that reside in any package ['org.apache.commons.lang..', 'org.joda.time..', 'javax.xml.bind..', 'net.jcip.annotations..', 'javax.annotation..', 'junit..', 'org.hamcrest..', 'com.google.common..', 'org.junit']' was violated (4 times):
Method <io.jenkins.plugins.junit.checks.JUnitChecksPublisher.mapFailedTestToTestReport(hudson.tasks.junit.CaseResult)> calls method <org.apache.commons.lang.StringUtils.isNotBlank(java.lang.String)> in (JUnitChecksPublisher.java:100)
Method <io.jenkins.plugins.junit.checks.JUnitChecksPublisher.mapFailedTestToTestReport(hudson.tasks.junit.CaseResult)> calls method <org.apache.commons.lang.StringUtils.isNotBlank(java.lang.String)> in (JUnitChecksPublisher.java:106)
Method <io.jenkins.plugins.junit.checks.JUnitChecksPublisher.mapFailedTestToTestReport(hudson.tasks.junit.CaseResult)> calls method <org.apache.commons.lang.StringUtils.isNotBlank(java.lang.String)> in (JUnitChecksPublisher.java:90)
Method <io.jenkins.plugins.junit.checks.JUnitChecksPublisher.mapFailedTestToTestReport(hudson.tasks.junit.CaseResult)> calls method <org.apache.commons.lang.StringUtils.isNotBlank(java.lang.String)> in (JUnitChecksPublisher.java:94)
```

No idea why checks API would be complaining about this usage in `junit` plugin when `copyartifact` is present, but so it goes. The use of `StringUtils` seems unnecessary so why not replace it with simpler Java Platform methods and chase away this problem at the same time.

If accepted I will want a backport to 2.319.x for BOM.