### PR TITLE
Check the card and not the card-body in TestResultPublishingTest

### DIFF
--- a/src/test/java/hudson/tasks/junit/TestResultPublishingTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultPublishingTest.java
@@ -256,7 +256,7 @@ public class TestResultPublishingTest {
 
         HtmlPage historyPage = wc.getPage(proj.getBuildByNumber(7),"/testReport/history/");
         rule.assertGoodStatus(historyPage);
-        HtmlElement historyCard = (HtmlElement) historyPage.getByXPath( "//div[@class='card-body ']").get(0);
+        HtmlElement historyCard = (HtmlElement) historyPage.getByXPath( "//div[@class='card ']").get(0);
         assertThat(historyCard.getTextContent(), containsString("History"));
         DomElement wholeTable = historyPage.getElementById("testresult");
         assertNotNull("table with id 'testresult' exists", wholeTable);


### PR DESCRIPTION
With `bootstrap5-api#5.2.0-3` the `history` text is inside a div with a `card-header` class instead inside the div with `card-body` this change will make the test work for both versions and IMO makes the test a bit less fragile, for example when running the PCT.

Updating the dependency would need a core bump and I am not sure how difficult that would be, and TBH I do not have time to do that. Anyway this change should be fine even after the core and boostrap5 update.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
