### PR TITLE
Use ionicons in test result overview

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.332.1</jenkins.version>
+        <jenkins.version>2.346.1</jenkins.version>
         <no-test-jar>false</no-test-jar>
     </properties>
     <licenses>
@@ -47,6 +47,11 @@
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>echarts-api</artifactId>
             <version>5.3.2-3</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>ionicons-api</artifactId>
+            <version>28.va_f3a_84439e5f</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
@@ -196,7 +201,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.332.x</artifactId>
+                <artifactId>bom-2.346.x</artifactId>
                 <version>1607.va_c1576527071</version>
                 <scope>import</scope>
                 <type>pom</type>

--- a/src/main/resources/hudson/tasks/junit/CaseResult/summary.jelly
+++ b/src/main/resources/hudson/tasks/junit/CaseResult/summary.jelly
@@ -35,10 +35,10 @@ THE SOFTWARE.
         <j:set var="close" value="javascript:hideFailureSummary('${id}')"/>
         <h4>
           <a id="${id}-showlink" href="${open}" title="Show ${title}" style="display: ${idisplay}">
-            <l:icon class="icon-document-add icon-sm"/><st:nbsp/>${title}
+            <l:icon src="symbol-add-outline plugin-ionicons-api" class="icon-sm"/><st:nbsp/>${title}
           </a>
           <a id="${id}-hidelink" href="${close}" title="Hide ${title}" style="display: ${display}">
-            <l:icon class="icon-document-delete icon-sm"/><st:nbsp/>${title}
+            <l:icon src="symbol-remove-outline plugin-ionicons-api" class="icon-sm"/><st:nbsp/>${title}
           </a>
         </h4>
         <pre id="${id}" style="display: ${display}">

--- a/src/main/resources/lib/hudson/test/failed-test.jelly
+++ b/src/main/resources/lib/hudson/test/failed-test.jelly
@@ -85,10 +85,10 @@ THE SOFTWARE.
   <j:set var="open" value="showFailureSummary('test-${id}','${url}/summary')"/>
   <j:set var="close" value="hideFailureSummary('test-${id}')"/>
   <a id="test-${id}-showlink" onclick="${open}" title="${%Show details}">
-    <l:icon class="icon-document-add icon-sm"/>
+    <l:icon src="symbol-add-outline plugin-ionicons-api" class="icon-sm"/>
   </a>
   <a id="test-${id}-hidelink" onclick="${close}" title="${%Hide details}" style="display:none">
-    <l:icon class="icon-document-delete icon-sm"/>
+    <l:icon src="symbol-remove-outline plugin-ionicons-api" class="icon-sm"/>
   </a>
   <st:nbsp/>
   <a href="${url}"><st:out value="${result.fullDisplayName}"/></a>


### PR DESCRIPTION
The change proposed replaces the tango icons with ionicons in the test overview.

Before:

![Screenshot 2022-10-01 at 10 08 00](https://user-images.githubusercontent.com/13383509/193399903-3c746383-bc7b-4883-8c95-6c307bda2fc5.png)

After:
![Screenshot 2022-10-01 at 10 06 56](https://user-images.githubusercontent.com/13383509/193399908-6eb47c6e-5770-4c33-8fcf-d3d66438fcff.png)