### PR TITLE
[JENKINS-69656] Un-inlining AbstractTestResultAction/summary.jelly for CSP compliance

### DIFF
--- a/src/main/resources/hudson/tasks/test/AbstractTestResultAction/show-failures.js
+++ b/src/main/resources/hudson/tasks/test/AbstractTestResultAction/show-failures.js
@@ -1,0 +1,33 @@
+/**
+* Displays all the tests failures, and hides the link allowing to display them from UI.
+*/
+function showFailures() {
+    // Displaying all the hidden elements from the page (those are the failed tests)
+    let hiddenElements = document.getElementsByClassName("hidden");
+
+    // DEV MEMO:
+    // hiddenElements is not an array but an HTMLCollection.
+    // To allow using forEach, we need an array, so I'm using the spread operator below to get that.
+    [...hiddenElements].forEach(element => { element.style.display = ""; });
+
+    // Now hiding the link from UI allowing to show all failed tests
+    let showFailuresLink = document.getElementById("showLink");
+    showFailuresLink.style.display = "none";
+}
+
+// Adding an onclick listener to the link in UI allowing to display all failed tests
+// DEV MEMO:
+// We are doing it after DOM content is loaded as a good practice to ensure we are not slowing down
+// the page rendering. In that particular situation the addition of the onclick handler shouldn't
+// really impact the page performances, but rather stick with good practices.
+
+document.addEventListener('DOMContentLoaded', (event) => {
+
+  // Retrieving the link from UI allowing to show all failed tests
+  // Note: we are retrieving the link by its ID to match how it was already done
+  // in the showFailures method above.
+  const showFailuresLink = document.getElementById("showLink");
+
+  showFailuresLink.onclick = (_) => showFailures();
+
+});

--- a/src/main/resources/hudson/tasks/test/AbstractTestResultAction/summary.jelly
+++ b/src/main/resources/hudson/tasks/test/AbstractTestResultAction/summary.jelly
@@ -26,17 +26,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:test="/lib/hudson/test" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
 
-  <script type="text/javascript">
-    function showFailures() {
-
-    var elms = document.getElementsByClassName("hidden");
-    for(var i = 0; i &lt; elms.length; i++) {
-    elms[i].style.display = "";
-    }
-    elm = document.getElementById("showLink");
-    elm.style.display = "none";
-    }
-  </script>
+  <st:adjunct includes="hudson.tasks.test.AbstractTestResultAction.show-failures" />
 
   <!-- summary -->
   <t:summary icon="clipboard.png">
@@ -75,8 +65,7 @@ THE SOFTWARE.
       <!-- Show failures link -->
       <j:if test="${displayedCount &lt; failedTests.size() }">
         <a id="showLink" name="editFailuresLink"
-           href="#showFailuresLink"
-           onclick="javascript:showFailures()">${%Show all failed tests} ${">>>"}</a>
+           href="#showFailuresLink">${%Show all failed tests} ${">>>"}</a>
       </j:if>
     </j:if>
 


### PR DESCRIPTION
Hello there :wave:

Hacktoberfest PR here to solve [JENKINS-69656](https://issues.jenkins.io/browse/JENKINS-69656), by un-inlining AbstractTestResultAction/summary.jelly, and then making a step forward towards CSP adoption in Jenkins.

I tested that PR by following the details shared in the Jira ticket, and ensured my contribution didn't break the
current behavior.

While extracting the inline script to a js file, I also did a little bit of refactoring to the JavaScript source code, I
hope that's OK. Let me know if you don't like that part and I'll revert to the previous content of the JavaScript part.

Thanks a lot for your review, let me know if there's anything missing I can take care of :smile:

Have a great day!


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
