### PR TITLE
[JENKINS-69657] Un-inlining floatingBox.jelly for CSP compliance

### DIFF
--- a/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:c="/charts">
+<j:jelly xmlns:j="jelly:core" xmlns:c="/charts" xmlns:st="jelly:stapler">
   <c:trend-setup suffix="junit">
     <div class="mb-3">
       <input class="form-check-input" type="checkbox" value="" id="junit-use-blue" />
@@ -40,19 +40,6 @@ THE SOFTWARE.
 
   <c:trend-chart it="${from}" title="${%Test Result Trend}" enableLinks="true" configurationId="junit"/>
 
-  <script>
-    function fillJunit(trendConfiguration, jsonConfiguration) {
-      const useBlue = jsonConfiguration['useBlue'];
-      trendConfiguration.find('#junit-use-blue').prop('checked', !!useBlue);
-    }
-
-    function saveJunit(trendConfiguration) {
-      return {
-        'useBlue': trendConfiguration.find('#junit-use-blue').is(':checked')
-      };
-    }
-
-    echartsJenkinsApi.configureTrend('junit', fillJunit, saveJunit)
-  </script>
+  <st:adjunct includes="hudson.tasks.test.TestResultProjectAction.junit-trend-color-switcher" />
 
 </j:jelly>

--- a/src/main/resources/hudson/tasks/test/TestResultProjectAction/junit-trend-color-switcher.js
+++ b/src/main/resources/hudson/tasks/test/TestResultProjectAction/junit-trend-color-switcher.js
@@ -1,0 +1,12 @@
+function fillJunit(trendConfiguration, jsonConfiguration) {
+  const useBlue = jsonConfiguration['useBlue'];
+  trendConfiguration.find('#junit-use-blue').prop('checked', !!useBlue);
+}
+
+function saveJunit(trendConfiguration) {
+  return {
+    'useBlue': trendConfiguration.find('#junit-use-blue').is(':checked')
+  };
+}
+
+echartsJenkinsApi.configureTrend('junit', fillJunit, saveJunit);


### PR DESCRIPTION
Hello :wave: 

Here's another Hacktoberfest Pull Request to solve [JENKINS-69657](https://issues.jenkins.io/browse/JENKINS-69657), by un-inlining floatingBox.jelly, and then making a step forward towards CSP adoption in Jenkins.

Before submitting the PR, I tested the existing code, removed the script to show that my test was not working anymore, un-inlined the test and checked that I worked again. Here it is working with the script un-inlined (which is similar to the behavior before the PR):

![junit-switch-color](https://user-images.githubusercontent.com/311677/194716648-eedccc0e-04fc-4fa2-aa25-568388eafba6.gif)

Thanks a lot for your review, let me know if there's anything missing I can take care of :smile: 

Have a great day!

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
