### PR TITLE
Merge back SECURITY-2888 fix into master

### DIFF
--- a/src/main/java/hudson/tasks/test/TestResult.java
+++ b/src/main/java/hudson/tasks/test/TestResult.java
@@ -278,8 +278,7 @@ public abstract class TestResult extends TestObject {
     public String annotate(String text) {
         if (text == null)
                 return null;
-        text = text.replace("&", "&amp;").replace("<", "&lt;").replaceAll(
-                        "\\b(https?://[^\\s)>]+)", "<a href=\"$1\">$1</a>");
+        text = text.replace("&", "&amp;").replace("<", "&lt;");
 
         for (TestAction action: getTestActions()) {
                 text = action.annotate(text);

--- a/src/test/java/hudson/tasks/junit/CaseResultTest.java
+++ b/src/test/java/hudson/tasks/junit/CaseResultTest.java
@@ -85,24 +85,24 @@ public class CaseResultTest {
         // piggy back tests for annotate methods
         assertOutput(cr,"plain text", "plain text");
         assertOutput(cr,"line #1\nhttp://nowhere.net/\nline #2\n",
-                "line #1\n<a href=\"http://nowhere.net/\">http://nowhere.net/</a>\nline #2\n");
+                     "line #1\nhttp://nowhere.net/\nline #2\n");
         assertOutput(cr,"failed; see http://nowhere.net/",
-                "failed; see <a href=\"http://nowhere.net/\">http://nowhere.net/</a>");
+                     "failed; see http://nowhere.net/");
         assertOutput(cr,"failed (see http://nowhere.net/)",
-                "failed (see <a href=\"http://nowhere.net/\">http://nowhere.net/</a>)");
+                     "failed (see http://nowhere.net/)");
         assertOutput(cr,"http://nowhere.net/ - failed: http://elsewhere.net/",
-                "<a href=\"http://nowhere.net/\">http://nowhere.net/</a> - failed: " +
-                "<a href=\"http://elsewhere.net/\">http://elsewhere.net/</a>");
+                     "http://nowhere.net/ - failed: " +
+                     "http://elsewhere.net/");
         assertOutput(cr,"https://nowhere.net/",
-                "<a href=\"https://nowhere.net/\">https://nowhere.net/</a>");
+                     "https://nowhere.net/");
         assertOutput(cr,"stuffhttp://nowhere.net/", "stuffhttp://nowhere.net/");
         assertOutput(cr,"a < b && c < d", "a &lt; b &amp;&amp; c &lt; d");
         assertOutput(cr,"see <http://nowhere.net/>",
-                "see &lt;<a href=\"http://nowhere.net/\">http://nowhere.net/</a>>");
+                     "see &lt;http://nowhere.net/>");
         assertOutput(cr,"http://google.com/?q=stuff&lang=en",
-                "<a href=\"http://google.com/?q=stuff&amp;lang=en\">http://google.com/?q=stuff&amp;lang=en</a>");
+                     "http://google.com/?q=stuff&amp;lang=en");
         assertOutput(cr,"http://localhost:8080/stuff/",
-                "<a href=\"http://localhost:8080/stuff/\">http://localhost:8080/stuff/</a>");
+                     "http://localhost:8080/stuff/");
     }
 
 


### PR DESCRIPTION
For a plugin using maven-release-plugin, I would recommend that this PR should be merged using merge-commit, not using squash-commit or rebase-commit, to ensure the commits related to the release are on the history of the default branch. Unsure about JEP-229.