### PR TITLE
Add getSuites() method in TestResultImpl

### DIFF
--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -695,6 +695,9 @@ public final class TestResult extends MetaTabulatedResult {
 
     @Exported(inline=true,visibility=9)
     public Collection<SuiteResult> getSuites() {
+        if (impl != null) {
+            return impl.getSuites();
+        }
         return suites;
     }
 

--- a/src/main/java/io/jenkins/plugins/junit/storage/TestResultImpl.java
+++ b/src/main/java/io/jenkins/plugins/junit/storage/TestResultImpl.java
@@ -34,6 +34,9 @@ import hudson.tasks.junit.SuiteResult;
 import hudson.tasks.junit.TestDurationResultSummary;
 import hudson.tasks.junit.TestResult;
 import hudson.tasks.junit.TrendTestResultSummary;
+
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import hudson.tasks.junit.HistoryTestResultSummary;
@@ -108,6 +111,12 @@ public interface TestResultImpl {
     @CheckForNull
     TestResult getPreviousResult();
     SuiteResult getSuite(String name);
+
+
+    default Collection<SuiteResult> getSuites() {
+        return Collections.emptyList();
+    };
+
 
     float getTotalTestDuration();
 }

--- a/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
+++ b/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
@@ -55,7 +55,15 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -87,6 +95,7 @@ import static java.util.Objects.requireNonNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
@@ -221,7 +230,21 @@ public class TestResultStorageJunitTest {
 
             final List<TestDurationResultSummary> testDurationResultSummary = pluggableStorage.getTestDurationResultSummary();
             assertThat(testDurationResultSummary.get(0).getDuration(), is(200));
-            
+
+            //check storage getSuites method
+            Collection<SuiteResult> suiteResults = pluggableStorage.getSuites();
+            assertThat(suiteResults, hasSize(2));
+            //check the two suites name
+            assertThat(suiteResults, containsInAnyOrder(hasProperty("name", equalTo("supersweet")), hasProperty("name", equalTo("sweet"))));
+
+            //check one suite detail
+            SuiteResult supersweetSuite = suiteResults.stream()
+                    .filter(suite -> suite.getName().equals("supersweet"))
+                    .findFirst()
+                    .get();
+            assertThat(supersweetSuite.getCases(), hasSize(1));
+            assertThat(supersweetSuite.getCases().get(0).getName(), equalTo("test1"));
+            assertThat(supersweetSuite.getCases().get(0).getClassName(), equalTo("another.Klazz"));
             // TODO test result summary i.e. failure content
             // TODO getFailedSinceRun, TestResult#getChildren, TestObject#getTestResultAction
             // TODO more detailed Java queries incl. ClassResult

--- a/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
+++ b/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
@@ -55,14 +55,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -175,6 +168,7 @@ public class TestResultStorageJunitTest {
             assertEquals(1, a.getResult().getSkipCount());
             assertEquals(4, a.getResult().getTotalCount());
             assertEquals(1, a.getResult().getPassCount());
+            assertEquals(2, a.getResult().getSuites().size());
             List<CaseResult> failedTests = a.getFailedTests();
             assertEquals(2, failedTests.size());
             final CaseResult klazzTest1 = failedTests.get(0);
@@ -674,6 +668,50 @@ public class TestResultStorageJunitTest {
                     });
 
                 }
+
+                public Collection<SuiteResult> getSuites() {
+                    return query(connection -> {
+                        try (PreparedStatement statement = connection.prepareStatement("SELECT suite, testname, package, classname, errordetails, skipped, duration, stdout, stderr, stacktrace FROM " + Impl.CASE_RESULTS_TABLE + " WHERE job = ? AND build = ? ORDER BY suite")) {
+                            statement.setString(1, job);
+                            statement.setInt(2, build);
+                            try (ResultSet result = statement.executeQuery()) {
+                                SuiteResult suiteResult = null;
+                                TestResult parent = new TestResult(this);
+                                boolean isFirst = true;
+                                List <SuiteResult> suites = new ArrayList<SuiteResult>();
+                                while (result.next()) {
+                                    String suiteName = result.getString("suite");
+                                    if (isFirst || !suiteResult.getName().equals(suiteName)) {
+                                        suiteResult = new SuiteResult(suiteName, null, null, null);
+                                        suites.add(suiteResult);
+                                        isFirst = false;
+                                    }
+                                    String resultTestName = result.getString("testname");
+                                    String errorDetails = result.getString("errordetails");
+                                    String packageName = result.getString("package");
+                                    String className = result.getString("classname");
+                                    String skipped = result.getString("skipped");
+                                    String stdout = result.getString("stdout");
+                                    String stderr = result.getString("stderr");
+                                    String stacktrace = result.getString("stacktrace");
+                                    float duration = result.getFloat("duration");
+
+                                    suiteResult.setParent(parent);
+                                    CaseResult caseResult = new CaseResult(suiteResult, className, resultTestName, errorDetails, skipped, duration, stdout, stderr, stacktrace);
+                                    final PackageResult packageResult = new PackageResult(parent, packageName);
+                                    packageResult.add(caseResult);
+                                    ClassResult classResult = new ClassResult(packageResult, className);
+                                    classResult.add(caseResult);
+                                    caseResult.setClass(classResult);
+                                    suiteResult.addCase(caseResult);
+                                }
+                                return suites;
+                            }
+                        }
+                    });
+                };
+
+
 
                 @Override
                 public float getTotalTestDuration() {


### PR DESCRIPTION
There's an issue that testReport/api/json doesn't display the suites list. Add the missing getSuites method in the TestResultImpl interface, and integrate it with Junit TestResult.

junit-sql-storage plugin will adopt this interface once it is released.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
