### PR TITLE
Make it possible to include custom columns from TestActions in case, class and package tables

### DIFF
--- a/src/main/java/hudson/tasks/junit/ClassResult.java
+++ b/src/main/java/hudson/tasks/junit/ClassResult.java
@@ -102,6 +102,11 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
         return "Class Results";
     }
 
+    @Override
+    public String getChildType() {
+        return "case";
+    }
+
     @Exported(visibility=999)
     @Override
     public String getName() {

--- a/src/main/java/hudson/tasks/junit/PackageResult.java
+++ b/src/main/java/hudson/tasks/junit/PackageResult.java
@@ -121,6 +121,11 @@ public final class PackageResult extends MetaTabulatedResult implements Comparab
         return Messages.PackageResult_getChildTitle();
     }
 
+    @Override
+    public String getChildType() {
+        return "class";
+    }
+
     // TODO: wait until stapler 1.60 to do this @Exported
     @Override
     public float getDuration() {

--- a/src/main/java/hudson/tasks/junit/TestAction.java
+++ b/src/main/java/hudson/tasks/junit/TestAction.java
@@ -33,6 +33,10 @@ import org.kohsuke.stapler.export.ExportedBean;
  * <li>index.jelly: included at the top of the test page</li>
  * <li>summary.jelly: included in a collapsed panel on the test parent page</li>
  * <li>badge.jelly: shown after the test link on the test parent page</li>
+ * <li>casetableheader.jelly: allows additional table headers to be shown in tables that list test methods</li>
+ * <li>classtableheader.jelly: allows additional table headers to be shown in tables that list test classes</li>
+ * <li>packagetableheader.jelly: allows additional table headers to be shown in tables that list test packages</li>
+ * <li>tablerow.jelly: allows additional table cells to be shown in tables that list test methods, classes and packages</li>
  * </ul>
  * 
  * @author tom

--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -479,6 +479,11 @@ public final class TestResult extends MetaTabulatedResult {
         return Messages.TestResult_getChildTitle();
     }
 
+    @Override
+    public String getChildType() {
+        return "package";
+    }
+
     @Exported(visibility=999)
     @Override
     public float getDuration() {

--- a/src/main/java/hudson/tasks/test/TabulatedResult.java
+++ b/src/main/java/hudson/tasks/test/TabulatedResult.java
@@ -121,4 +121,14 @@ public abstract class TabulatedResult extends TestResult {
     public String getChildTitle() {
         return "";
     }
+
+    /**
+     * Get a simple name for the type of children the {@link #getChildren()} method returns, for example "case", "class"
+     * or "package".
+     *
+     * @return the type of children this result has, all lowercase.
+     */
+    public String getChildType() {
+        return "";
+    }
 }

--- a/src/main/resources/hudson/tasks/junit/ClassResult/body.jelly
+++ b/src/main/resources/hudson/tasks/junit/ClassResult/body.jelly
@@ -32,6 +32,9 @@ THE SOFTWARE.
           <th class="pane-header">${%Test name}</th>
           <th class="pane-header" style="width:6em">${%Duration}</th>
           <th class="pane-header" style="width:6em">${%Status}</th>
+          <j:forEach var="tableheader" items="${it.testActions}">
+            <st:include it="${tableheader}" page="${it.childType}tableheader.jelly" optional="true"/>
+          </j:forEach>
         </tr>
       </thead>
       <tbody>
@@ -50,6 +53,9 @@ THE SOFTWARE.
                 ${pst.message}
               </span>
             </td>
+            <j:forEach var="tablerow" items="${p.testActions}">
+              <st:include it="${tablerow}" page="tablerow.jelly" optional="true"/>
+            </j:forEach>
           </tr>
         </j:forEach>
       </tbody>

--- a/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
+++ b/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
@@ -27,12 +27,15 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson/test">
   <j:if test="${it.failCount!=0}">
     <h2>${%All Failed Tests}</h2>
-    <table class="jenkins-table sortable">
+    <table class="jenkins-table sortable" id="failedtestresult">
       <thead>
         <tr>
           <th class="pane-header">${%Test Name}</th>
           <th class="pane-header" style="width:4em">${%Duration}</th>
           <th class="pane-header" style="width:3em">${%Age}</th>
+          <j:forEach var="tableheader" items="${it.testActions}">
+            <st:include it="${tableheader}" page="casetableheader.jelly" optional="true"/>
+          </j:forEach>
         </tr>
       </thead>
       <j:forEach var="f" items="${it.failedTests}" varStatus="i">
@@ -44,6 +47,9 @@ THE SOFTWARE.
           <td class="pane" style="text-align:right;">
             <a href="${rootURL}/${f.failedSinceRun.url}">${f.age}</a>
           </td>
+          <j:forEach var="tablerow" items="${f.testActions}">
+            <st:include it="${tablerow}" page="tablerow.jelly" optional="true"/>
+          </j:forEach>
         </tr>
       </j:forEach>
     </table>
@@ -64,6 +70,9 @@ THE SOFTWARE.
           <th class="pane-header" style="width:3em; text-align:right; white-space:nowrap;">(${%diff})</th>
           <th class="pane-header" style="width:5em; text-align:right">${%Total}</th>
           <th class="pane-header" style="width:3em; text-align:right; white-space:nowrap;">(${%diff})</th>
+          <j:forEach var="tableheader" items="${it.testActions}">
+            <st:include it="${tableheader}" page="${it.childType}tableheader.jelly" optional="true"/>
+          </j:forEach>
         </tr>
       </thead>
       <tbody>
@@ -94,6 +103,9 @@ THE SOFTWARE.
             <td class="pane" style="text-align:right" data="${p.totalCount-prev.totalCount}">
               ${h.getDiffString2(p.totalCount-prev.totalCount)}
             </td>
+            <j:forEach var="tablerow" items="${p.testActions}">
+              <st:include it="${tablerow}" page="tablerow.jelly" optional="true"/>
+            </j:forEach>
           </tr>
         </j:forEach>
       </tbody>

--- a/src/test/java/hudson/tasks/junit/CustomColumnsTest.java
+++ b/src/test/java/hudson/tasks/junit/CustomColumnsTest.java
@@ -1,0 +1,113 @@
+package hudson.tasks.junit;
+
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlTable;
+import com.gargoylesoftware.htmlunit.html.HtmlTableCell;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.tasks.junit.rot13.Rot13Publisher;
+import hudson.tasks.test.helper.WebClientFactory;
+import org.apache.commons.lang3.tuple.Pair;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestBuilder;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Verifies that TestDataPublishers can contribute custom columns to html tables in result pages.
+ */
+public class CustomColumnsTest {
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    private FreeStyleProject project;
+
+    private static final String reportFileName = "junit-report-494.xml";
+
+    @Before
+    public void setUp() throws Exception {
+        project = jenkins.createFreeStyleProject("customcolumns");
+        JUnitResultArchiver archiver = new JUnitResultArchiver("*.xml");
+        archiver.setTestDataPublishers(Collections.singletonList(new Rot13Publisher()));
+        archiver.setSkipPublishingChecks(true);
+        project.getPublishersList().add(archiver);
+        project.getBuildersList().add(new TestBuilder() {
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
+                build.getWorkspace().child(reportFileName).copyFrom(getClass().getResource(reportFileName));
+                return true;
+            }
+        });
+        FreeStyleBuild build = project.scheduleBuild2(0).get(5, TimeUnit.MINUTES);
+        jenkins.assertBuildStatus(Result.UNSTABLE, build);
+    }
+
+    @SafeVarargs
+    private void verifyThatTableContainsExpectedValues(String pathToPage, String tableId, String headerName,
+                                                       Pair<String, String>... rowValues) throws Exception {
+
+        JenkinsRule.WebClient wc = WebClientFactory.createWebClientWithDisabledJavaScript(jenkins);
+        HtmlPage projectPage = wc.getPage(project);
+        jenkins.assertGoodStatus(projectPage);
+        HtmlPage classReportPage = wc.getPage(project, pathToPage);
+        jenkins.assertGoodStatus(classReportPage);
+
+        HtmlTable testResultTable = (HtmlTable) classReportPage.getFirstByXPath("//table[@id='" + tableId + "']");
+        List<HtmlTableCell> headerRowCells = testResultTable.getHeader().getRows().get(0).getCells();
+        int numberOfColumns = headerRowCells.size();
+        assertEquals(headerName, headerRowCells.get(numberOfColumns - 1).asNormalizedText());
+
+        for (int x = 0; x < rowValues.length; x++) {
+            List<HtmlTableCell> bodyRowCells = testResultTable.getBodies().get(0).getRows().get(x).getCells();
+            assertThat(bodyRowCells.get(0).asNormalizedText(), CoreMatchers.containsString(rowValues[x].getLeft()));
+            assertEquals(rowValues[x].getRight(), bodyRowCells.get(numberOfColumns - 1).asNormalizedText());
+        }
+    }
+
+    @Test
+    public void verifyThatCustomColumnIsAddedToTheTestsTableOnTheClassResultPage() throws Exception {
+        verifyThatTableContainsExpectedValues("/lastBuild/testReport/junit/io.jenkins.example/AnExampleTestClass/",
+                "testresult", "ROT13 for cases on class page", Pair.of("testCaseA", "grfgPnfrN for case"), Pair.of(
+                        "testCaseZ", "grfgPnfrM for case"));
+    }
+
+    @Test
+    public void verifyThatCustomColumnIsAddedToTheFailedTestsTableOnThePackageResultPage() throws Exception {
+        verifyThatTableContainsExpectedValues("/lastBuild/testReport/junit/io.jenkins.example/", "failedtestresult",
+                "ROT13 for failed cases on package page", Pair.of("testCaseA", "grfgPnfrN for case"));
+    }
+
+    @Test
+    public void verifyThatCustomColumnIsAddedToTheClassesTableOnThePackageResultPage() throws Exception {
+        verifyThatTableContainsExpectedValues("/lastBuild/testReport/junit/io.jenkins.example/", "testresult",
+                "ROT13 for all classes on package page", Pair.of("AnExampleTestClass", "NaRknzcyrGrfgPynff for class"));
+    }
+
+    @Test
+    public void verifyThatCustomColumnIsAddedToTheFailedTestsTableOnTheTestResultPage() throws Exception {
+        verifyThatTableContainsExpectedValues("/lastBuild/testReport/", "failedtestresult",
+                "ROT13 for failed cases on test page", Pair.of("testCaseA", "grfgPnfrN for case"));
+    }
+
+    @Test
+    public void verifyThatCustomColumnIsAddedToTheClassesTableOnTheTestResultPage() throws Exception {
+        verifyThatTableContainsExpectedValues("/lastBuild/testReport/", "testresult",
+                "ROT13 for all packages on test page", Pair.of("io.jenkins.example", "vb.wraxvaf.rknzcyr for package"));
+    }
+}

--- a/src/test/java/hudson/tasks/junit/rot13/Rot13CaseAction.java
+++ b/src/test/java/hudson/tasks/junit/rot13/Rot13CaseAction.java
@@ -1,0 +1,9 @@
+package hudson.tasks.junit.rot13;
+
+public class Rot13CaseAction extends Rot13CipherAction {
+
+    public Rot13CaseAction(String ciphertext) {
+        super(ciphertext);
+    }
+
+}

--- a/src/test/java/hudson/tasks/junit/rot13/Rot13CipherAction.java
+++ b/src/test/java/hudson/tasks/junit/rot13/Rot13CipherAction.java
@@ -1,0 +1,32 @@
+package hudson.tasks.junit.rot13;
+
+import hudson.tasks.junit.TestAction;
+
+public abstract class Rot13CipherAction extends TestAction {
+
+    private final String ciphertext;
+
+    public Rot13CipherAction(String ciphertext) {
+        this.ciphertext = ciphertext;
+    }
+
+    @Override
+    public final String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public final String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+
+    public String getCiphertext() {
+        return ciphertext;
+    }
+
+}

--- a/src/test/java/hudson/tasks/junit/rot13/Rot13ClassAction.java
+++ b/src/test/java/hudson/tasks/junit/rot13/Rot13ClassAction.java
@@ -1,0 +1,9 @@
+package hudson.tasks.junit.rot13;
+
+public class Rot13ClassAction extends Rot13CipherAction {
+
+    public Rot13ClassAction(String ciphertext) {
+        super(ciphertext);
+    }
+
+}

--- a/src/test/java/hudson/tasks/junit/rot13/Rot13PackageAction.java
+++ b/src/test/java/hudson/tasks/junit/rot13/Rot13PackageAction.java
@@ -1,0 +1,9 @@
+package hudson.tasks.junit.rot13;
+
+public class Rot13PackageAction extends Rot13CipherAction {
+
+    public Rot13PackageAction(String ciphertext) {
+        super(ciphertext);
+    }
+
+}

--- a/src/test/java/hudson/tasks/junit/rot13/Rot13Publisher.java
+++ b/src/test/java/hudson/tasks/junit/rot13/Rot13Publisher.java
@@ -1,0 +1,121 @@
+package hudson.tasks.junit.rot13;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Descriptor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.junit.CaseResult;
+import hudson.tasks.junit.ClassResult;
+import hudson.tasks.junit.PackageResult;
+import hudson.tasks.junit.TestAction;
+import hudson.tasks.junit.TestDataPublisher;
+import hudson.tasks.junit.TestResult;
+import hudson.tasks.junit.TestResultAction;
+import hudson.tasks.test.TestObject;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A TestDataPublisher that adds a custom column containing the ROT13-encoded name of each test case, class and package
+ * in html tables across result pages. This publisher is intended to be used for validating that custom columns work as
+ * expected, but also as an illustration of how to provide custom columns. In this publisher, the values in the columns
+ * explicitly state where they're expected to be displayed (for example "ROT13 for failed cases on package page") to
+ * make it possible to validate that the correct jelly view is used in the correct page. Real-life implementations of
+ * custom columns will likely not need to distinguish between different pages and can get away with fewer TestActions,
+ * allowing greater reuse of jelly views.
+ */
+public class Rot13Publisher extends TestDataPublisher {
+
+    @DataBoundConstructor
+    public Rot13Publisher() {
+    }
+
+    @Override
+    public Data contributeTestData(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener,
+                                   TestResult testResult) throws IOException, InterruptedException {
+        Map<String, String> ciphertextMap = new HashMap<>();
+        for (PackageResult packageResult : testResult.getChildren()) {
+            ciphertextMap.put(packageResult.getName(), rot13(packageResult.getName()));
+            for (ClassResult classResult : packageResult.getChildren()) {
+                ciphertextMap.put(classResult.getFullName(), rot13(classResult.getName()));
+                for (CaseResult caseResult : classResult.getChildren()) {
+                    ciphertextMap.put(caseResult.getFullName(), rot13(caseResult.getName()));
+                }
+            }
+        }
+        return new Data(ciphertextMap);
+    }
+
+    private static String rot13(String cleartext) {
+        StringBuilder ciphertext = new StringBuilder();
+        cleartext.chars().forEach(c -> {
+            if ('a' <= c && c <= 'z') {
+                c = c + 13;
+                if ('z' < c) {
+                    c = c - 26;
+                }
+            }
+            if ('A' <= c && c <= 'Z') {
+                c = c + 13;
+                if ('Z' < c) {
+                    c = c - 26;
+                }
+            }
+            ciphertext.append((char) c);
+        });
+        return ciphertext.toString();
+    }
+
+    public static class Data extends TestResultAction.Data {
+
+        private Map<String, String> ciphertextMap;
+
+        public Data(Map<String, String> ciphertextMap) {
+            this.ciphertextMap = ciphertextMap;
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public List<TestAction> getTestAction(hudson.tasks.junit.TestObject t) {
+            TestObject testObject = (TestObject) t;
+
+            if (testObject instanceof CaseResult) {
+                return Collections.<TestAction>singletonList(new Rot13CaseAction(ciphertextMap.get(
+                        ((CaseResult) testObject).getFullName())));
+            }
+            if (testObject instanceof ClassResult) {
+                return Collections.<TestAction>singletonList(new Rot13ClassAction(ciphertextMap.get(
+                        ((ClassResult) testObject).getFullName())));
+            }
+            if (testObject instanceof PackageResult) {
+                return Collections.<TestAction>singletonList(new Rot13PackageAction(ciphertextMap.get(
+                        ((PackageResult) testObject).getName())));
+            }
+            if (testObject instanceof TestResult) {
+                return Collections.<TestAction>singletonList(new Rot13TestAction());
+            }
+            return Collections.emptyList();
+        }
+
+    }
+
+    @Extension
+    @Symbol("rot13")
+    public static class DescriptorImpl extends Descriptor<TestDataPublisher> {
+
+        @Override
+        public String getDisplayName() {
+            return "ROT13-encoded test case, class and package names";
+        }
+
+    }
+
+}

--- a/src/test/java/hudson/tasks/junit/rot13/Rot13TestAction.java
+++ b/src/test/java/hudson/tasks/junit/rot13/Rot13TestAction.java
@@ -1,0 +1,25 @@
+package hudson.tasks.junit.rot13;
+
+import hudson.tasks.junit.TestAction;
+
+public class Rot13TestAction extends TestAction {
+
+    public Rot13TestAction() {
+    }
+
+    @Override
+    public final String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public final String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+
+}

--- a/src/test/resources/hudson/tasks/junit/junit-report-494.xml
+++ b/src/test/resources/hudson/tasks/junit/junit-report-494.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<testsuites>
+  <testsuite name="io.jenkins.example.AnExampleTestClass" time="2.000" tests="2" errors="0" skipped="0" failures="1">
+    <testcase name="testCaseA" classname="io.jenkins.example.AnExampleTestClass" time="1.000">
+      <failure message="expected: [a] but was: [b]" type="org.junit.ComparisonFailure">
+        org.junit.ComparisonFailure: expected: [a] but was: [b]
+      </failure>
+    </testcase>
+    <testcase name="testCaseZ" classname="io.jenkins.example.AnExampleTestClass" time="1.000" />
+  </testsuite>
+</testsuites>

--- a/src/test/resources/hudson/tasks/junit/rot13/Rot13CaseAction/tablerow.jelly
+++ b/src/test/resources/hudson/tasks/junit/rot13/Rot13CaseAction/tablerow.jelly
@@ -1,0 +1,1 @@
+<td class="pane no-wrap" data="${it.ciphertext}">${it.ciphertext} for case</td>

--- a/src/test/resources/hudson/tasks/junit/rot13/Rot13ClassAction/casetableheader.jelly
+++ b/src/test/resources/hudson/tasks/junit/rot13/Rot13ClassAction/casetableheader.jelly
@@ -1,0 +1,1 @@
+<th class="pane-header" style="width:6em">ROT13 for cases on class page</th>

--- a/src/test/resources/hudson/tasks/junit/rot13/Rot13ClassAction/tablerow.jelly
+++ b/src/test/resources/hudson/tasks/junit/rot13/Rot13ClassAction/tablerow.jelly
@@ -1,0 +1,1 @@
+<td class="pane no-wrap" data="${it.ciphertext}">${it.ciphertext} for class</td>

--- a/src/test/resources/hudson/tasks/junit/rot13/Rot13PackageAction/casetableheader.jelly
+++ b/src/test/resources/hudson/tasks/junit/rot13/Rot13PackageAction/casetableheader.jelly
@@ -1,0 +1,1 @@
+<th class="pane-header" style="width:6em">ROT13 for failed cases on package page</th>

--- a/src/test/resources/hudson/tasks/junit/rot13/Rot13PackageAction/classtableheader.jelly
+++ b/src/test/resources/hudson/tasks/junit/rot13/Rot13PackageAction/classtableheader.jelly
@@ -1,0 +1,1 @@
+<th class="pane-header" style="width:6em">ROT13 for all classes on package page</th>

--- a/src/test/resources/hudson/tasks/junit/rot13/Rot13PackageAction/tablerow.jelly
+++ b/src/test/resources/hudson/tasks/junit/rot13/Rot13PackageAction/tablerow.jelly
@@ -1,0 +1,1 @@
+<td class="pane no-wrap" data="${it.ciphertext}">${it.ciphertext} for package</td>

--- a/src/test/resources/hudson/tasks/junit/rot13/Rot13TestAction/casetableheader.jelly
+++ b/src/test/resources/hudson/tasks/junit/rot13/Rot13TestAction/casetableheader.jelly
@@ -1,0 +1,1 @@
+<th class="pane-header" style="width:6em">ROT13 for failed cases on test page</th>

--- a/src/test/resources/hudson/tasks/junit/rot13/Rot13TestAction/packagetableheader.jelly
+++ b/src/test/resources/hudson/tasks/junit/rot13/Rot13TestAction/packagetableheader.jelly
@@ -1,0 +1,1 @@
+<th class="pane-header" style="width:6em">ROT13 for all packages on test page</th>


### PR DESCRIPTION
Add optional jelly hooks that allow TestActions to contribute custom columns to tables that list CaseResults, ClassResults and PackageResults.

More details in the corresponding enhancement issue:
Fixes https://github.com/jenkinsci/junit-plugin/issues/494

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
