### PR TITLE
Manage kotlin version to work around RequireUpperBoundDeps failure (#504)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,14 @@
                 <artifactId>byte-buddy</artifactId>
                 <version>1.14.0</version>
             </dependency>
+            <!-- Workaround until https://github.com/jenkinsci/plugin-pom/issues/705 is fixed -->
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>1.8.10</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
As a workaround until jenkinsci/plugin-pom#705 is fixed and propagated, the kotlin version is explicitly set to match what okhttp-api-plugin provides.

This prevents a RequireUpperBoundDeps failure to be triggered for different kotlin versions in the okhttp-api-plugin dependency subtree.

More information in the related issue:
#504 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
