### PR TITLE
Test results summary: fix JavaScript console error when 'showLink' HTML element is missing

### DIFF
--- a/src/main/resources/hudson/tasks/test/AbstractTestResultAction/summary.jelly
+++ b/src/main/resources/hudson/tasks/test/AbstractTestResultAction/summary.jelly
@@ -26,8 +26,6 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:test="/lib/hudson/test" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
 
-  <st:adjunct includes="hudson.tasks.test.AbstractTestResultAction.show-failures" />
-
   <!-- summary -->
   <t:summary icon="clipboard.png">
     <a href="${it.urlName}/">${it.displayName}</a>
@@ -64,6 +62,7 @@ THE SOFTWARE.
 
       <!-- Show failures link -->
       <j:if test="${displayedCount &lt; failedTests.size() }">
+        <st:adjunct includes="hudson.tasks.test.AbstractTestResultAction.show-failures" />
         <a id="showLink" name="editFailuresLink"
            href="#showFailuresLink">${%Show all failed tests} ${">>>"}</a>
       </j:if>


### PR DESCRIPTION
The [`showLink` HTML anchor element](https://github.com/jenkinsci/junit-plugin/blob/19a5192cc1fc758a680695463392c2388318f59a/src/main/resources/hudson/tasks/test/AbstractTestResultAction/summary.jelly#L67) is only rendered server-side when fewer tests are displayed on the page than exist in the job result.

So if the job passes (zero failures displayed, zero failures exist), or if there are up to ten failures (up-to-ten failures displayed, up-to-ten failures exist), then the `showLink` HTML element won't be present on the page.

The associated `show-failures.js` adjunct code attempts to add an `onclick` event handler to a `showLink`-ID'd element on the page after the HTML DOM loads: https://github.com/jenkinsci/junit-plugin/blob/19a5192cc1fc758a680695463392c2388318f59a/src/main/resources/hudson/tasks/test/AbstractTestResultAction/show-failures.js#L29-L31

This results in an error appearing in the browser's JavaScript console when the `showLink` element is not present in the HTML.

The fix suggested here is to only include the [relevant JavaScript adjunct](https://github.com/jenkinsci/junit-plugin/blob/19a5192cc1fc758a680695463392c2388318f59a/src/main/resources/hudson/tasks/test/AbstractTestResultAction/summary.jelly#L29) when the link itself is also placed on the page.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
  - Not done, however I have reproduced and confirmed the issue locally
    - Checked that the error occurred before the fix was applied
    - Checked that the error is resolved after the fix is applied

### Related issues
- Resolves #480
- Resolves #513 
- :warning: Affects a similar part of the code to #451 -- but does not conflict with it, I don't think (cc @Artmorse)