### PR TITLE
[JENKINS-71139] Do not even try to save NULs

### DIFF
--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -148,8 +148,8 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         this.errorStackTrace = stacktrace;
         this.errorDetails = errorDetails;
         this.parent = parent;
-        this.stdout = stdout;
-        this.stderr = stderr;
+        this.stdout = fixNULs(stdout);
+        this.stderr = fixNULs(stderr);
         this.duration = duration;
         
         this.skipped = skippedMessage != null;
@@ -189,8 +189,8 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         skippedMessage = getSkippedMessage(testCase);
         @SuppressWarnings("LeakingThisInConstructor")
         Collection<CaseResult> _this = Collections.singleton(this);
-        stdout = possiblyTrimStdio(_this, keepLongStdio, testCase.elementText("system-out"));
-        stderr = possiblyTrimStdio(_this, keepLongStdio, testCase.elementText("system-err"));
+        stdout = fixNULs(possiblyTrimStdio(_this, keepLongStdio, testCase.elementText("system-out")));
+        stderr = fixNULs(possiblyTrimStdio(_this, keepLongStdio, testCase.elementText("system-err")));
     }
 
     static String possiblyTrimStdio(Collection<CaseResult> results, boolean keepLongStdio, String stdio) { // HUDSON-6516
@@ -207,6 +207,10 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
             return stdio;
         }
         return stdio.subSequence(0, halfMaxSize) + "\n...[truncated " + middle + " chars]...\n" + stdio.subSequence(len - halfMaxSize, len);
+    }
+
+    static String fixNULs(String stdio) { // JENKINS-71139
+        return stdio == null ? null : stdio.replace("\u0000", "^@");
     }
 
     /**

--- a/src/main/java/hudson/tasks/junit/SuiteResult.java
+++ b/src/main/java/hudson/tasks/junit/SuiteResult.java
@@ -114,8 +114,8 @@ public final class SuiteResult implements Serializable {
      */
     public SuiteResult(String name, String stdout, String stderr, @CheckForNull PipelineTestDetails pipelineTestDetails) {
         this.name = name;
-        this.stderr = stderr;
-        this.stdout = stdout;
+        this.stderr = CaseResult.fixNULs(stderr);
+        this.stdout = CaseResult.fixNULs(stdout);
         // runId is generally going to be not null, but we only care about it if both it and nodeId are not null.
         if (pipelineTestDetails != null && pipelineTestDetails.getNodeId() != null) {
             this.nodeId = pipelineTestDetails.getNodeId();
@@ -283,8 +283,8 @@ public final class SuiteResult implements Serializable {
             }
         }
 
-        this.stdout = stdout;
-        this.stderr = stderr;
+        this.stdout = CaseResult.fixNULs(stdout);
+        this.stderr = CaseResult.fixNULs(stderr);
     }
 
     public void addCase(CaseResult cr) {

--- a/src/test/java/hudson/tasks/junit/SuiteResultTest.java
+++ b/src/test/java/hudson/tasks/junit/SuiteResultTest.java
@@ -311,7 +311,7 @@ public class SuiteResultTest {
         System.out.println();
         sr = (SuiteResult) f.read();
         System.out.println(TestResultAction.XSTREAM.toXML(sr));
-        assertEquals("foo\u0000bar", sr.getStdout());
+        assertEquals("foo^@bar", sr.getStdout());
     }
 
     /**


### PR DESCRIPTION
Continues #520 by just avoiding the core regression (if it is even considered valid).

There may be other Unicode characters which cause problems in XML serialization; for purposes of this PR I am focusing just on NUL.