### PR TITLE
Remove stack trace when there are no test failures

### DIFF
--- a/src/main/resources/hudson/tasks/test/AbstractTestResultAction/show-failures.js
+++ b/src/main/resources/hudson/tasks/test/AbstractTestResultAction/show-failures.js
@@ -28,6 +28,8 @@ document.addEventListener('DOMContentLoaded', (event) => {
   // in the showFailures method above.
   const showFailuresLink = document.getElementById("showLink");
 
-  showFailuresLink.onclick = (_) => showFailures();
+  if (showFailuresLink) {
+      showFailuresLink.onclick = (_) => showFailures();
+  }
 
 });


### PR DESCRIPTION
Amends #444 by @aneveux. When there are no test failures, I get this stack trace:

```
Uncaught TypeError: showFailuresLink is null
    <anonymous> http://127.0.0.1/adjuncts/10fef6b6/hudson/tasks/test/AbstractTestResultAction/show-failures.js:31
    EventListener.handleEvent* http://127.0.0.1/adjuncts/10fef6b6/hudson/tasks/test/AbstractTestResultAction/show-failures.js:24
show-failures.js:31:3
```

This was not an issue previously because prior to #444 this code would only run if there were failures. After this PR the stack trace is gone.