### PR TITLE
Make trend charts theme-aware

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.version>2.387.1</jenkins.version>
         <no-test-jar>false</no-test-jar>
     </properties>
     <licenses>
@@ -46,6 +46,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>echarts-api</artifactId>
+            <version>5.4.0-4-rc818.6012a_fdb_2d9a_</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>

--- a/src/main/java/hudson/tasks/test/TestResultDurationChart.java
+++ b/src/main/java/hudson/tasks/test/TestResultDurationChart.java
@@ -4,8 +4,9 @@ import edu.hm.hafner.echarts.ChartModelConfiguration;
 import edu.hm.hafner.echarts.LineSeries;
 import edu.hm.hafner.echarts.LinesChartModel;
 import edu.hm.hafner.echarts.LinesDataSet;
-import edu.hm.hafner.echarts.Palette;
 import hudson.tasks.junit.TestDurationResultSummary;
+import io.jenkins.plugins.echarts.JenkinsPalette;
+
 import java.util.List;
 
 import static hudson.tasks.test.TestDurationTrendSeriesBuilder.SECONDS;
@@ -30,7 +31,7 @@ public class TestResultDurationChart {
     private LinesChartModel getLinesChartModel(LinesDataSet dataSet) {
         LinesChartModel model = new LinesChartModel(dataSet);
 
-        LineSeries duration = new LineSeries(SECONDS, Palette.GREEN.getNormal(),
+        LineSeries duration = new LineSeries(SECONDS, JenkinsPalette.GREEN.normal(),
                 LineSeries.StackedMode.STACKED, LineSeries.FilledMode.FILLED);
         duration.addAll(dataSet.getSeries(SECONDS));
         model.addSeries(duration);

--- a/src/main/java/hudson/tasks/test/TestResultTrendChart.java
+++ b/src/main/java/hudson/tasks/test/TestResultTrendChart.java
@@ -6,10 +6,10 @@ import edu.hm.hafner.echarts.ChartModelConfiguration;
 import edu.hm.hafner.echarts.LineSeries;
 import edu.hm.hafner.echarts.LinesChartModel;
 import edu.hm.hafner.echarts.LinesDataSet;
-import edu.hm.hafner.echarts.Palette;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import hudson.tasks.junit.TrendTestResultSummary;
+import io.jenkins.plugins.echarts.JenkinsPalette;
 
 import static hudson.tasks.test.TestResultTrendSeriesBuilder.*;
 
@@ -56,17 +56,17 @@ public class TestResultTrendChart {
         LinesChartModel model = new LinesChartModel(dataSet);
 
         LineSeries passed = new LineSeries("Passed",
-                passedColor == PassedColor.BLUE ? Palette.BLUE.getNormal() : Palette.GREEN.getNormal(),
+                passedColor == PassedColor.BLUE ? JenkinsPalette.BLUE.normal() : JenkinsPalette.GREEN.normal(),
                 LineSeries.StackedMode.STACKED, LineSeries.FilledMode.FILLED);
         passed.addAll(dataSet.getSeries(PASSED_KEY));
         model.addSeries(passed);
 
-        LineSeries skipped = new LineSeries("Skipped", Palette.GRAY.getNormal(),
+        LineSeries skipped = new LineSeries("Skipped", JenkinsPalette.GREY.normal(),
                 LineSeries.StackedMode.STACKED, LineSeries.FilledMode.FILLED);
         skipped.addAll(dataSet.getSeries(SKIPPED_KEY));
         model.addSeries(skipped);
 
-        LineSeries failed = new LineSeries("Failed", Palette.RED.getNormal(),
+        LineSeries failed = new LineSeries("Failed", JenkinsPalette.RED.normal(),
                 LineSeries.StackedMode.STACKED, LineSeries.FilledMode.FILLED);
         failed.addAll(dataSet.getSeries(FAILED_KEY));
         model.addSeries(failed);


### PR DESCRIPTION
Use colors from the new Echarts `JenkinsPalette` for trend charts.

Downstream PR of https://github.com/jenkinsci/echarts-api-plugin/pull/287.

![Bildschirmfoto 2023-05-15 um 23 23 08](https://github.com/jenkinsci/junit-plugin/assets/503338/36898001-2cc7-4147-b70e-ecc51c1178d7)
![Bildschirmfoto 2023-05-15 um 23 23 48](https://github.com/jenkinsci/junit-plugin/assets/503338/60e28942-daaa-41cd-99c4-1110ab66feb7)
![Bildschirmfoto 2023-05-15 um 23 24 16](https://github.com/jenkinsci/junit-plugin/assets/503338/a4f5f7ab-1037-4542-8cd2-7a4decff56b1)
