### PR TITLE
Add support for 'properties'

### DIFF
--- a/src/main/java/hudson/tasks/junit/SuiteResult.java
+++ b/src/main/java/hudson/tasks/junit/SuiteResult.java
@@ -73,6 +73,8 @@ public final class SuiteResult implements Serializable {
     private final String stdout;
     private final String stderr;
     private float duration;
+    private final Map<String, String> properties;
+
     /**
      * The 'timestamp' attribute of  the test suite.
      * AFAICT, this is not a required attribute in XML, so the value may be null.
@@ -125,6 +127,7 @@ public final class SuiteResult implements Serializable {
             this.nodeId = null;
         }
         this.file = null;
+        this.properties = Collections.emptyMap();
     }
 
     private synchronized Map<String, CaseResult> casesByName() {
@@ -285,6 +288,23 @@ public final class SuiteResult implements Serializable {
 
         this.stdout = CaseResult.fixNULs(stdout);
         this.stderr = CaseResult.fixNULs(stderr);
+
+        // parse properties
+        Map<String, String> properties = new HashMap<String, String>();
+        Element properties_element = suite.element("properties");
+        if (properties_element != null) {
+            List<Element> property_elements = properties_element.elements("property");
+            for (Element prop : property_elements){
+                if (prop.attributeValue("name") != null) {
+                    if (prop.attributeValue("value") != null)
+                        properties.put(prop.attributeValue("name"), prop.attributeValue("value"));
+                    else
+                        properties.put(prop.attributeValue("name"), prop.getText());
+                }
+            }
+        }
+
+        this.properties = properties;
     }
 
     public void addCase(CaseResult cr) {
@@ -377,6 +397,16 @@ public final class SuiteResult implements Serializable {
     @Exported
     public String getStderr() {
         return stderr;
+    }
+
+    /**
+     * The properties of this test.
+     *
+     * @return the properties of this test.
+     */
+    @Exported
+    public Map<String, String> getProperties() {
+        return properties;
     }
 
     /**

--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -657,6 +657,11 @@ public final class TestResult extends MetaTabulatedResult {
         return sb.toString();
     }
 
+    @Override
+    public Map<String, String> getProperties() {
+        return Collections.emptyMap();
+    }
+
     /**
      * If there was an error or a failure, this is the stack trace, or otherwise null.
      */

--- a/src/main/java/hudson/tasks/test/TestResult.java
+++ b/src/main/java/hudson/tasks/test/TestResult.java
@@ -28,6 +28,8 @@ import hudson.model.Run;
 import hudson.model.Result;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 
 import static java.util.Collections.emptyList;
 
@@ -247,6 +249,10 @@ public abstract class TestResult extends TestObject {
      */
     public String getErrorDetails() {
         return ""; 
+    }
+
+    public Map<String, String> getProperties() {
+        return Collections.emptyMap();
     }
 
     /**

--- a/src/main/resources/hudson/tasks/junit/CaseResult/index.jelly
+++ b/src/main/resources/hudson/tasks/junit/CaseResult/index.jelly
@@ -68,6 +68,11 @@ THE SOFTWARE.
 		    </j:forEach>
       </table>
 
+       <j:forEach var="p" items="${it.properties}">
+         <h3>${p.key}</h3>
+         <pre><j:out value="${p.value}"/></pre>
+       </j:forEach>
+
       <j:if test="${!empty(it.skippedMessage)}">
         <h3>${%Skip Message}</h3>
         <pre><j:out value="${it.annotate(it.skippedMessage)}"/></pre>

--- a/src/main/resources/hudson/tasks/junit/CaseResult/summary.jelly
+++ b/src/main/resources/hudson/tasks/junit/CaseResult/summary.jelly
@@ -55,6 +55,9 @@ THE SOFTWARE.
   <j:set var="id" value="${h.generateId()}"/>
 
   <local:item id="${id}" name="error" title="${%Error Details}" value="${it.errorDetails}" opened="true"/>
+  <j:forEach var="p" items="${it.properties}">
+    <local:item id="${id}" name="${p.key}" title="${p.key}" value="${p.value}"/>
+  </j:forEach>
   <local:item id="${id}" name="stacktrace" title="${%Stack Trace}" value="${it.errorStackTrace}"/>
   <local:item id="${id}" name="stdout" title="${%Standard Output}" value="${it.stdout}"/>
   <local:item id="${id}" name="stderr" title="${%Standard Error}" value="${it.stderr}"/>

--- a/src/test/java/hudson/tasks/junit/SuiteResultTest.java
+++ b/src/test/java/hudson/tasks/junit/SuiteResultTest.java
@@ -26,6 +26,7 @@ package hudson.tasks.junit;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 import java.net.URISyntaxException;
 import org.apache.commons.io.FileUtils;
 
@@ -351,5 +352,24 @@ public class SuiteResultTest {
         assertEquals(22.0f, results.get(1).getDuration(),2); //sum of test cases time
         assertEquals(40.0f, results.get(2).getDuration(), 2); //testsuit time
         assertEquals(20.0f, results.get(3).getDuration(), 2); //sum of test cases time
+    }
+
+    @Test
+    public void testProperties() throws Exception {
+        SuiteResult sr = parseOne(getDataFile("junit-report-with-properties.xml"));
+        Map<String,String> props = sr.getProperties();
+        assertEquals(props.get("prop1"), "value1");
+        String[] lines = props.get("multiline").split("\n");
+        assertEquals("", lines[0]);
+        assertEquals("          Config line 1", lines[1]);
+        assertEquals("          Config line 2", lines[2]);
+        assertEquals("          Config line 3", lines[3]);
+
+        assertEquals(2, sr.getCases().size());
+        CaseResult cr;
+        cr = sr.getCase("io.jenkins.example.with.properties.testCaseA");
+        assertEquals("description of test testCaseA", cr.getProperties().get("description"));
+        cr = sr.getCase("io.jenkins.example.with.properties.testCaseZ");
+        assertEquals(0, cr.getProperties().size());
     }
 }

--- a/src/test/resources/hudson/tasks/junit/junit-report-with-properties.xml
+++ b/src/test/resources/hudson/tasks/junit/junit-report-with-properties.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<testsuites>
+  <testsuite name="io.jenkins.example.with.properties" time="2.000" tests="2" errors="0" skipped="0" failures="1">
+    <properties>
+      <property name="prop1" value="value1" />
+      <property name="multiline">
+          Config line 1
+          Config line 2
+          Config line 3
+      </property>
+    </properties>
+    <testcase name="testCaseA" classname="io.jenkins.example.with.properties" time="1.000">
+      <failure message="expected: [a] but was: [b]" type="org.junit.ComparisonFailure">
+        org.junit.ComparisonFailure: expected: [a] but was: [b]
+      </failure>
+      <properties>
+        <property name="description">description of test testCaseA</property>
+      </properties>
+    </testcase>
+    <testcase name="testCaseZ" classname="io.jenkins.example.with.properties" time="1.000" />
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
This PR adds support for the 'properties'  in a junit file.
More specifically it parses the properties node in the JUnit file and the properties of the the testcases are displayed along the other elements of the test execution (stdout, stderr, ...) 
Properties are often used to give describe the context of a test execution and having this information under the eye when looking at a test result seems valuable.

Properties are also used to attach files to a test result. This has not been handled in this PR.

This work is based on the ideas of Thomas Dee (https://github.com/jenkinsci/junit-plugin/pull/129)
