### PR TITLE
Add a "keepProperties" option

### DIFF
--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -161,7 +161,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         this.properties = Collections.emptyMap();
     }
 
-    CaseResult(SuiteResult parent, Element testCase, String testClassName, boolean keepLongStdio) {
+    CaseResult(SuiteResult parent, Element testCase, String testClassName, boolean keepLongStdio, boolean keepProperties) {
         // schema for JUnit report XML format is not available in Ant,
         // so I don't know for sure what means what.
         // reports in http://www.nabble.com/difference-in-junit-publisher-and-ant-junitreport-tf4308604.html#a12265700
@@ -199,15 +199,17 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
 
         // parse properties
         Map<String, String> properties = new HashMap<String, String>();
-        Element properties_element = testCase.element("properties");
-        if (properties_element != null) {
-            List<Element> property_elements = properties_element.elements("property");
-            for (Element prop : property_elements){
-                if (prop.attributeValue("name") != null) {
-                    if (prop.attributeValue("value") != null)
-                        properties.put(prop.attributeValue("name"), prop.attributeValue("value"));
-                    else
-                        properties.put(prop.attributeValue("name"), prop.getText());
+        if (keepProperties) {
+            Element properties_element = testCase.element("properties");
+            if (properties_element != null) {
+                List<Element> property_elements = properties_element.elements("property");
+                for (Element prop : property_elements){
+                    if (prop.attributeValue("name") != null) {
+                        if (prop.attributeValue("value") != null)
+                            properties.put(prop.attributeValue("name"), prop.attributeValue("value"));
+                        else
+                            properties.put(prop.attributeValue("name"), prop.getText());
+                    }
                 }
             }
         }

--- a/src/main/java/hudson/tasks/junit/JUnitTask.java
+++ b/src/main/java/hudson/tasks/junit/JUnitTask.java
@@ -11,6 +11,8 @@ public interface JUnitTask {
 
     boolean isKeepLongStdio();
 
+    boolean isKeepProperties();
+
     boolean isAllowEmptyResults();
     
     boolean isSkipPublishingChecks();

--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -122,6 +122,8 @@ public final class TestResult extends MetaTabulatedResult {
 
     private final boolean keepLongStdio;
 
+    private final boolean keepProperties;
+
     // default 3s as it depends on OS some can be good some not really....
     public static final long FILE_TIME_PRECISION_MARGIN = Long.getLong(TestResult.class.getName() + "filetime.precision.margin", 3000);
 
@@ -137,6 +139,7 @@ public final class TestResult extends MetaTabulatedResult {
      */
     public TestResult(boolean keepLongStdio) {
         this.keepLongStdio = keepLongStdio;
+        this.keepProperties = false;
         impl = null;
     }
 
@@ -154,6 +157,7 @@ public final class TestResult extends MetaTabulatedResult {
     public TestResult(long filesTimestamp, DirectoryScanner results, boolean keepLongStdio,
                       PipelineTestDetails pipelineTestDetails) throws IOException {
         this.keepLongStdio = keepLongStdio;
+        this.keepProperties = false;
         impl = null;
         parse(filesTimestamp, results, pipelineTestDetails);
     }
@@ -166,9 +170,10 @@ public final class TestResult extends MetaTabulatedResult {
      * @param skipOldReports to parse or not test files older than filesTimestamp
      * @since 1.22
      */
-    public TestResult(long filesTimestamp, DirectoryScanner results, boolean keepLongStdio,
+    public TestResult(long filesTimestamp, DirectoryScanner results, boolean keepLongStdio, boolean keepProperties,
                       PipelineTestDetails pipelineTestDetails, boolean skipOldReports) throws IOException {
         this.keepLongStdio = keepLongStdio;
+        this.keepProperties = keepProperties;
         impl = null;
         this.skipOldReports = skipOldReports;
         parse(filesTimestamp, results, pipelineTestDetails);
@@ -177,6 +182,7 @@ public final class TestResult extends MetaTabulatedResult {
     public TestResult(TestResultImpl impl) {
         this.impl = impl;
         keepLongStdio = false; // irrelevant
+        this.keepProperties = false; // irrelevant
     }
 
     @CheckForNull
@@ -381,7 +387,7 @@ public final class TestResult extends MetaTabulatedResult {
             throw new IllegalStateException("Cannot reparse using a pluggable impl");
         }
         try {
-            List<SuiteResult> suiteResults = SuiteResult.parse(reportFile, keepLongStdio, pipelineTestDetails);
+            List<SuiteResult> suiteResults = SuiteResult.parse(reportFile, keepLongStdio, keepProperties, pipelineTestDetails);
             for (SuiteResult suiteResult : suiteResults)
                 add(suiteResult);
 

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStep.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStep.java
@@ -40,6 +40,8 @@ public class JUnitResultsStep extends Step implements JUnitTask {
      */
     private boolean keepLongStdio;
 
+    private boolean keepProperties;
+
     /**
      * {@link TestDataPublisher}s configured for this archiver, to process the recorded data.
      * For compatibility reasons, can be null.
@@ -118,6 +120,21 @@ public class JUnitResultsStep extends Step implements JUnitTask {
      */
     @DataBoundSetter public final void setKeepLongStdio(boolean keepLongStdio) {
         this.keepLongStdio = keepLongStdio;
+    }
+
+    /**
+     * @return the keepProperties.
+     */
+    @Override
+    public boolean isKeepProperties() {
+        return keepProperties;
+    }
+
+    /**
+     * @param keepProperties Whether to keep the properties
+     */
+    @DataBoundSetter public final void setKeepProperties(boolean keepProperties) {
+        this.keepProperties = keepProperties;
     }
 
     /**

--- a/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
+++ b/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
@@ -33,6 +33,9 @@ THE SOFTWARE.
     <f:entry field="keepLongStdio" title="">
         <f:checkbox name="keepLongStdio" title="${%Retain long standard output/error}"/>
     </f:entry>
+    <f:entry field="keepProperties" title="">
+        <f:checkbox name="keepProperties" title="${%keep all the properties}"/>
+    </f:entry>
     <f:entry field="healthScaleFactor" title="${%Health report amplification factor}">
         <f:number default="1.0" min="0" step="0.1" size="10"/>
     </f:entry>

--- a/src/test/java/hudson/tasks/junit/SuiteResultTest.java
+++ b/src/test/java/hudson/tasks/junit/SuiteResultTest.java
@@ -63,11 +63,17 @@ public class SuiteResultTest {
     }
 
     private SuiteResult parseOne(File file) throws Exception {
-        List<SuiteResult> results = SuiteResult.parse(file, false, null);
+        List<SuiteResult> results = SuiteResult.parse(file, false, false, null);
         assertEquals(1,results.size());
         return results.get(0);
     }
     
+    private SuiteResult parseOneWithProperties(File file) throws Exception {
+        List<SuiteResult> results = SuiteResult.parse(file, false, true, null);
+        assertEquals(1,results.size());
+        return results.get(0);
+    }
+
     private List<SuiteResult> parseSuites(File file) throws Exception {
         return SuiteResult.parse(file, false, null);
     }
@@ -356,9 +362,9 @@ public class SuiteResultTest {
 
     @Test
     public void testProperties() throws Exception {
-        SuiteResult sr = parseOne(getDataFile("junit-report-with-properties.xml"));
+        SuiteResult sr = parseOneWithProperties(getDataFile("junit-report-with-properties.xml"));
         Map<String,String> props = sr.getProperties();
-        assertEquals(props.get("prop1"), "value1");
+        assertEquals("value1", props.get("prop1"));
         String[] lines = props.get("multiline").split("\n");
         assertEquals("", lines[0]);
         assertEquals("          Config line 1", lines[1]);

--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -295,7 +295,7 @@ public class TestResultTest {
         directoryScanner.setIncludes(new String[]{"*.xml"});
         directoryScanner.scan();
         assertEquals( "directory scanner must find 2 files", 2, directoryScanner.getIncludedFiles().length);
-        TestResult testResult = new TestResult(start, directoryScanner, true, new PipelineTestDetails(),true);
+        TestResult testResult = new TestResult(start, directoryScanner, true, false, new PipelineTestDetails(),true);
         testResult.tally();
 
         assertEquals("Wrong number of testsuites", 2, testResult.getSuites().size());
@@ -315,7 +315,7 @@ public class TestResultTest {
         directoryScanner.setIncludes(new String[]{"*.xml"});
         directoryScanner.scan();
         assertEquals( "directory scanner must find 2 files", 2, directoryScanner.getIncludedFiles().length);
-        TestResult testResult = new TestResult(start, directoryScanner, true, new PipelineTestDetails(),false);
+        TestResult testResult = new TestResult(start, directoryScanner, true, false, new PipelineTestDetails(),false);
         testResult.tally();
 
         assertEquals("Wrong number of testsuites", 4, testResult.getSuites().size());


### PR DESCRIPTION
If 'false' the properties attached to a test suite or a test case are ignored.
By default the properties are ignored.