### PR TITLE
[JENKINS-59846] Hyperlink URLs in JUnit Test Report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,11 @@
             <artifactId>pipeline-utility-steps</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+            <artifactId>owasp-java-html-sanitizer</artifactId>
+            <version>20220608.1</version>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/hudson/tasks/test/TestResult.java
+++ b/src/main/java/hudson/tasks/test/TestResult.java
@@ -45,6 +45,13 @@ import static java.util.Collections.emptyList;
  */
 public abstract class TestResult extends TestObject {
 
+    private static final PolicyFactory POLICY_DEFINITION= new HtmlPolicyBuilder()
+            .allowElements("a")
+            .allowUrlProtocols("https")
+            .allowUrlProtocols("http")
+            .allowAttributes("href").onElements("a")
+            .toFactory();;
+
     /**
      * If the concept of a parent action is important to a subclass, then it should
      * provide a non-noop implementation of this method. 
@@ -290,13 +297,6 @@ public abstract class TestResult extends TestObject {
 
         text = text.replace("&", "&amp;").replace("<", "&lt;").replaceAll("\\b(https?://[^\\s)>]+)", "<a href=\"$1\">$1</a>");
 
-        PolicyFactory policy = new HtmlPolicyBuilder()
-                .allowElements("a")
-                .allowUrlProtocols("https")
-                .allowUrlProtocols("http")
-                .allowAttributes("href").onElements("a")
-                .toFactory();
-
-        return policy.sanitize(text);
+        return POLICY_DEFINITION.sanitize(text);
     }
 }

--- a/src/main/java/hudson/tasks/test/TestResult.java
+++ b/src/main/java/hudson/tasks/test/TestResult.java
@@ -296,7 +296,7 @@ public abstract class TestResult extends TestObject {
         if (text == null)
                 return null;
 
-        text = text.replace("&", "&amp;").replace("<", "&lt;").replaceAll("\\b(https?://[^\\s)>]+)", "<a href=\"$1\">$1</a>");
+        text = text.replaceAll("\\b(https?://[^\\s)>]+)", "<a href=\"$1\">$1</a>");
 
         for (TestAction action: getTestActions()) {
             text = action.annotate(text);

--- a/src/main/java/hudson/tasks/test/TestResult.java
+++ b/src/main/java/hudson/tasks/test/TestResult.java
@@ -23,6 +23,7 @@
  */
 package hudson.tasks.test;
 
+import hudson.tasks.junit.TestAction;
 import hudson.model.Run;
 import hudson.model.Result;
 
@@ -296,6 +297,10 @@ public abstract class TestResult extends TestObject {
                 return null;
 
         text = text.replace("&", "&amp;").replace("<", "&lt;").replaceAll("\\b(https?://[^\\s)>]+)", "<a href=\"$1\">$1</a>");
+
+        for (TestAction action: getTestActions()) {
+            text = action.annotate(text);
+        }
 
         return POLICY_DEFINITION.sanitize(text);
     }

--- a/src/test/java/hudson/tasks/junit/CaseResultTest.java
+++ b/src/test/java/hudson/tasks/junit/CaseResultTest.java
@@ -119,7 +119,6 @@ public class CaseResultTest {
                      "<a href=\"https://google.com\">https://google.com&#34;onclick&#61;alert(1</a>)&#34;");
         assertOutput(cr,"unsafe characters are = \" ' < > &",
                      "unsafe characters are &#61; &#34; &#39; &lt; &gt; &amp;");
-
     }
 
     /**

--- a/src/test/java/hudson/tasks/junit/CaseResultTest.java
+++ b/src/test/java/hudson/tasks/junit/CaseResultTest.java
@@ -115,6 +115,10 @@ public class CaseResultTest {
                      "<a href=\"http://google.com/?q&#61;stuff&amp;lang&#61;en\">http://google.com/?q&#61;stuff&amp;lang&#61;en</a>");
         assertOutput(cr,"http://localhost:8080/stuff/",
                      "<a href=\"http://localhost:8080/stuff/\">http://localhost:8080/stuff/</a>");
+        assertOutput(cr,"https://google.com\"onclick=alert(1)\"",
+                     "<a href=\"https://google.com\">https://google.com&#34;onclick&#61;alert(1</a>)&#34;");
+        assertOutput(cr,"unsafe characters are = \" ' < > &",
+                     "unsafe characters &#61; &#34; &#39; &lt; &gt; &amp;");
     }
 
     /**

--- a/src/test/java/hudson/tasks/junit/CaseResultTest.java
+++ b/src/test/java/hudson/tasks/junit/CaseResultTest.java
@@ -98,24 +98,23 @@ public class CaseResultTest {
         // piggy back tests for annotate methods
         assertOutput(cr,"plain text", "plain text");
         assertOutput(cr,"line #1\nhttp://nowhere.net/\nline #2\n",
-                     "line #1\nhttp://nowhere.net/\nline #2\n");
+                     "line #1\n" + "<a href=\"http://nowhere.net/\">http://nowhere.net/</a>\n" + "line #2\n");
         assertOutput(cr,"failed; see http://nowhere.net/",
-                     "failed; see http://nowhere.net/");
+                     "failed; see <a href=\"http://nowhere.net/\">http://nowhere.net/</a>");
         assertOutput(cr,"failed (see http://nowhere.net/)",
-                     "failed (see http://nowhere.net/)");
+                     "failed (see <a href=\"http://nowhere.net/\">http://nowhere.net/</a>)");
         assertOutput(cr,"http://nowhere.net/ - failed: http://elsewhere.net/",
-                     "http://nowhere.net/ - failed: " +
-                     "http://elsewhere.net/");
+                     "<a href=\"http://nowhere.net/\">http://nowhere.net/</a> - failed: <a href=\"http://elsewhere.net/\">http://elsewhere.net/</a>");
         assertOutput(cr,"https://nowhere.net/",
-                     "https://nowhere.net/");
+                     "<a href=\"https://nowhere.net/\">https://nowhere.net/</a>");
         assertOutput(cr,"stuffhttp://nowhere.net/", "stuffhttp://nowhere.net/");
         assertOutput(cr,"a < b && c < d", "a &lt; b &amp;&amp; c &lt; d");
         assertOutput(cr,"see <http://nowhere.net/>",
-                     "see &lt;http://nowhere.net/>");
+                     "see &lt;<a href=\"http://nowhere.net/\">http://nowhere.net/</a>&gt;");
         assertOutput(cr,"http://google.com/?q=stuff&lang=en",
-                     "http://google.com/?q=stuff&amp;lang=en");
+                     "<a href=\"http://google.com/?q&#61;stuff&amp;lang&#61;en\">http://google.com/?q&#61;stuff&amp;lang&#61;en</a>");
         assertOutput(cr,"http://localhost:8080/stuff/",
-                     "http://localhost:8080/stuff/");
+                     "<a href=\"http://localhost:8080/stuff/\">http://localhost:8080/stuff/</a>");
     }
 
     /**
@@ -188,8 +187,9 @@ public class CaseResultTest {
 
 	assertEquals(cr.annotate(cr.getErrorDetails()).replaceAll("&lt;", "<"), errorMsg.getTextContent());
 	HtmlElement errorStackTrace = (HtmlElement) page.getByXPath("//h3[text()='Stacktrace']/following-sibling::*").get(0);
-	// Have to do some annoying replacing here to get the same text Jelly produces in the end.
-	assertEquals(cr.annotate(cr.getErrorStackTrace()).replaceAll("&lt;", "<").replace("\r\n", "\n"),
+
+    // Have to do some annoying replacing here to get the same text Jelly produces in the end.
+	assertEquals(cr.annotate(cr.getErrorStackTrace()).replaceAll("&lt;", "<").replaceAll("&gt;", ">").replace("\r\n", "\n"),
 		     errorStackTrace.getTextContent());
     }
     

--- a/src/test/java/hudson/tasks/junit/CaseResultTest.java
+++ b/src/test/java/hudson/tasks/junit/CaseResultTest.java
@@ -191,7 +191,7 @@ public class CaseResultTest {
 
 	assertEquals(cr.annotate(cr.getErrorDetails()).replaceAll("&lt;", "<"), errorMsg.getTextContent());
 	HtmlElement errorStackTrace = (HtmlElement) page.getByXPath("//h3[text()='Stacktrace']/following-sibling::*").get(0);
-    // Have to do some annoying replacing here to get the same text Jelly produces in the end.
+        // Have to do some annoying replacing here to get the same text Jelly produces in the end.
 	assertEquals(cr.annotate(cr.getErrorStackTrace()).replaceAll("&lt;", "<").replaceAll("&gt;", ">").replace("\r\n", "\n"),
 		     errorStackTrace.getTextContent());
     }

--- a/src/test/java/hudson/tasks/junit/CaseResultTest.java
+++ b/src/test/java/hudson/tasks/junit/CaseResultTest.java
@@ -119,6 +119,9 @@ public class CaseResultTest {
                      "<a href=\"https://google.com\">https://google.com&#34;onclick&#61;alert(1</a>)&#34;");
         assertOutput(cr,"unsafe characters are = \" ' < > &",
                      "unsafe characters are &#61; &#34; &#39; &lt; &gt; &amp;");
+        assertOutput(cr,"this is <strong>some text</strong> in an assertion that failed",
+                     "this is some text in an assertion that failed");
+
     }
 
     /**

--- a/src/test/java/hudson/tasks/junit/CaseResultTest.java
+++ b/src/test/java/hudson/tasks/junit/CaseResultTest.java
@@ -118,7 +118,7 @@ public class CaseResultTest {
         assertOutput(cr,"https://google.com\"onclick=alert(1)\"",
                      "<a href=\"https://google.com\">https://google.com&#34;onclick&#61;alert(1</a>)&#34;");
         assertOutput(cr,"unsafe characters are = \" ' < > &",
-                     "unsafe characters &#61; &#34; &#39; &lt; &gt; &amp;");
+                     "unsafe characters are &#61; &#34; &#39; &lt; &gt; &amp;");
     }
 
     /**

--- a/src/test/java/hudson/tasks/junit/CaseResultTest.java
+++ b/src/test/java/hudson/tasks/junit/CaseResultTest.java
@@ -119,8 +119,6 @@ public class CaseResultTest {
                      "<a href=\"https://google.com\">https://google.com&#34;onclick&#61;alert(1</a>)&#34;");
         assertOutput(cr,"unsafe characters are = \" ' < > &",
                      "unsafe characters are &#61; &#34; &#39; &lt; &gt; &amp;");
-        assertOutput(cr,"this is <strong>some text</strong> in an assertion that failed",
-                     "this is some text in an assertion that failed");
 
     }
 

--- a/src/test/java/hudson/tasks/junit/CaseResultTest.java
+++ b/src/test/java/hudson/tasks/junit/CaseResultTest.java
@@ -191,7 +191,6 @@ public class CaseResultTest {
 
 	assertEquals(cr.annotate(cr.getErrorDetails()).replaceAll("&lt;", "<"), errorMsg.getTextContent());
 	HtmlElement errorStackTrace = (HtmlElement) page.getByXPath("//h3[text()='Stacktrace']/following-sibling::*").get(0);
-
     // Have to do some annoying replacing here to get the same text Jelly produces in the end.
 	assertEquals(cr.annotate(cr.getErrorStackTrace()).replaceAll("&lt;", "<").replaceAll("&gt;", ">").replace("\r\n", "\n"),
 		     errorStackTrace.getTextContent());


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Some history on this ticket - for [SECURITY-2888](https://issues.jenkins.io/browse/SECURITY-2888) a while back, I removed the ability to click on the links in the test report. The original annotate method allowed unsafe links to be clickable, it was unsafe because it allowed anything to be passed in and annotated as a link.

In this PR what I have done is revert the removal of clickable links, I have added some security on top in the form of using the [OWASP Java HTML Sanitizer](https://owasp.org/www-project-java-html-sanitizer/). This enables the links to be clickable but sanitises them, so nothing nasty can get passed through.

### Testing done
I have run mvn verify locally and all working. Also I have manually tested this it againts the original vulnerability to make sure it still blocks unsafe links tso you can't trigger anthing unsafe.

I would really appreciate some more testing particularly from @Ingo987 @academic-sakharov 🙂

Before:
![image](https://github.com/jenkinsci/junit-plugin/assets/55280278/c659087f-72e4-4d64-a913-0379735fecd7)

After:
![image](https://github.com/jenkinsci/junit-plugin/assets/55280278/61f44c56-2db3-46fc-a36a-97c02084127d)

Testing running with a malicious report with `https://google.com\:quot;onclick=alert(1)` as the test URL:
![image](https://github.com/jenkinsci/junit-plugin/assets/55280278/bf9c1457-9a5f-4815-ab84-d7dd27056414)
You can see the tiny escaped URL at the bottom 

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

