### PR TITLE
Fix chart trend after moving from default storage to external storage

### DIFF
--- a/src/main/java/hudson/tasks/test/TestResultProjectAction.java
+++ b/src/main/java/hudson/tasks/test/TestResultProjectAction.java
@@ -43,6 +43,7 @@ import hudson.model.Action;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.tasks.junit.JUnitResultArchiver;
+import hudson.tasks.junit.TrendTestResultSummary;
 import hudson.tasks.test.TestResultTrendChart.PassedColor;
 
 import io.jenkins.plugins.echarts.AsyncConfigurableTrendChart;
@@ -131,7 +132,11 @@ public class TestResultProjectAction implements Action, AsyncTrendChart, AsyncCo
         JunitTestResultStorage storage = JunitTestResultStorage.find();
         if (!(storage instanceof FileJunitTestResultStorage)) {
             TestResultImpl pluggableStorage = storage.load(lastCompletedBuild.getParent().getFullName(), lastCompletedBuild.getNumber());
-            return new TestResultTrendChart().create(pluggableStorage.getTrendTestResultSummary(), passedColor);
+            List<TrendTestResultSummary> summary = pluggableStorage.getTrendTestResultSummary();
+            if (summary.isEmpty()) {
+                return new LinesChartModel();
+            }
+            return new TestResultTrendChart().create(summary, passedColor);
         }
 
         TestResultActionIterable buildHistory = createBuildHistory(lastCompletedBuild);


### PR DESCRIPTION
This fixes chart trend after moving from default storage to external storage

Fixes https://github.com/jenkinsci/junit-plugin/issues/570

Instead of loading forever just return an empty trends chart.

### Testing done

Create build with local storage
Switch to external storage
Check that there is no exception

**Before**

![junit_plugable_storage](https://github.com/jenkinsci/junit-plugin/assets/825750/5beeff2a-817e-44b6-9a1c-9dbe55dc22f8)

**After**

![junit_storage_1](https://github.com/jenkinsci/junit-plugin/assets/825750/e6820975-09ed-482b-8ace-827cac9d9f29)

Triggering more build continue to rebuild the trend chart

![junit_storage_2](https://github.com/jenkinsci/junit-plugin/assets/825750/d8bc8f33-0afd-476b-a82f-b8c4ef949392)

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

The situation is not ideal but I think is better than before.

Regards,
