### PR TITLE
Use `XStream2` where possible

### DIFF
--- a/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
+++ b/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
@@ -44,6 +44,7 @@ import hudson.tasks.junit.TestResult;
 import hudson.tasks.junit.TestResultAction;
 import hudson.tasks.junit.TestResultSummary;
 import hudson.tasks.junit.TrendTestResultSummary;
+import hudson.util.XStream2;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -941,7 +942,7 @@ public class TestResultStorageJunitTest {
          */
         static class RemoteConnectionSupplier extends ConnectionSupplier implements SerializableOnlyOverRemoting {
 
-            private static final XStream XSTREAM = new XStream();
+            private static final XStream XSTREAM = new XStream2();
             private final String databaseXml;
 
             static {


### PR DESCRIPTION
While working on a different core PR, I noticed this plugin was using vanilla XStream rather than the Jenkins-specific `XStream2` in one test. Since we generally prefer XStream2, and since the other test in this repository already uses XStream2, and since using XStream2 doesn't make the test start failing, I thought it would be best to make this usage consistent with the other test in this repository and with our general preference for XStream2.