### PR TITLE
Fix AggregatedTestResultPublisherTest on 2.434+

### DIFF
--- a/src/test/java/hudson/tasks/test/helper/TestResultsPage.java
+++ b/src/test/java/hudson/tasks/test/helper/TestResultsPage.java
@@ -14,6 +14,6 @@ public class TestResultsPage {
     }
 
     public void hasLinkToTestResultOfBuild(String projectName, int buildNumber) {
-        htmlPage.getAnchorByText(projectName + " #" + buildNumber);
+        htmlPage.getAnchorByHref("/jenkins/job/" + projectName + "/" + buildNumber + "/testReport/");
     }
 }


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/junit-plugin/issues/588

There's now an SVG in the link with the text Unstable. The previous API does a value comparison which isn't possible to make work without including the whole svg inline exactly the same.

Checking the link destination does the same thing here.