### PR TITLE
Add start time fields and logic for setting start time of results in epoch milliseconds

### DIFF
--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -67,6 +67,10 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     private static final Logger LOGGER = Logger.getLogger(CaseResult.class.getName());
     private final float duration;
     /**
+     * Start time in epoch milliseconds - default is -1 for unset
+     */
+    private long startTime;
+    /**
      * In JUnit, a test is a method of a class. This field holds the fully qualified class name
      * that the test was in.
      */
@@ -130,6 +134,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         this.stdout = null;
         this.stderr = null;
         this.duration = 0.0f;
+        this.startTime = -1;
         this.skipped = false;
         this.skippedMessage = null;
         this.properties = Collections.emptyMap();
@@ -155,6 +160,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         this.stdout = fixNULs(stdout);
         this.stderr = fixNULs(stderr);
         this.duration = duration;
+        this.startTime = -1;
         
         this.skipped = skippedMessage != null;
         this.skippedMessage = skippedMessage;
@@ -190,6 +196,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         errorDetails = getErrorMessage(testCase);
         this.parent = parent;
         duration = parseTime(testCase);
+        this.startTime = -1;
         skipped = isMarkedAsSkipped(testCase);
         skippedMessage = getSkippedMessage(testCase);
         @SuppressWarnings("LeakingThisInConstructor")
@@ -381,6 +388,13 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     @Override
     public float getDuration() {
         return duration;
+    }
+    
+    /**
+     * Gets the start time of the test, in epoch milliseconds
+     */
+    public long getStartTime() {
+        return startTime;
     }
 
     /**
@@ -783,6 +797,10 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
 
     public void setClass(ClassResult classResult) {
         this.classResult = classResult;
+    }
+    
+    public void setStartTime(long start) {
+    	startTime = start;
     }
 
     void replaceParent(SuiteResult parent) {

--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -800,7 +800,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     }
     
     public void setStartTime(long start) {
-    	startTime = start;
+        startTime = start;
     }
 
     void replaceParent(SuiteResult parent) {

--- a/src/main/java/hudson/tasks/junit/ClassResult.java
+++ b/src/main/java/hudson/tasks/junit/ClassResult.java
@@ -49,12 +49,15 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
     private int passCount,failCount,skipCount;
     
     private float duration; 
+    
+    private long startTime;
 
     private final PackageResult parent;
 
     public ClassResult(PackageResult parent, String className) {
         this.parent = parent;
         this.className = className;
+        this.startTime = -1;
     }
 
     @Override
@@ -156,6 +159,10 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
     @Override
     public float getDuration() {
         return duration; 
+    }
+    
+    public long getStartTime() {
+        return startTime;
     }
     
     @Exported
@@ -266,6 +273,10 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
         } else {
             return super.getRelativePathFrom(it);
         }
+    }
+    
+    public void setStartTime(long start) { 
+        this.startTime = start;
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/tasks/junit/ClassResult.java
+++ b/src/main/java/hudson/tasks/junit/ClassResult.java
@@ -184,6 +184,11 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
     }
 
     public void add(CaseResult r) {
+        if (startTime == -1) {
+            startTime = r.getStartTime();
+        } else if (r.getStartTime() != -1) {
+            startTime = Math.min(startTime, r.getStartTime());
+        }
         cases.add(r);
     }
 

--- a/src/main/java/hudson/tasks/junit/PackageResult.java
+++ b/src/main/java/hudson/tasks/junit/PackageResult.java
@@ -362,7 +362,7 @@ public final class PackageResult extends MetaTabulatedResult implements Comparab
     }
     
     public void setStartTime(long time) {
-    	startTime = time;
+        startTime = time;
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/tasks/junit/PackageResult.java
+++ b/src/main/java/hudson/tasks/junit/PackageResult.java
@@ -49,10 +49,12 @@ public final class PackageResult extends MetaTabulatedResult implements Comparab
     private int passCount,failCount,skipCount;
     private final hudson.tasks.junit.TestResult parent;
     private float duration; 
+    private long startTime; 
 
     public PackageResult(hudson.tasks.junit.TestResult parent, String packageName) {
         this.packageName = packageName;
         this.parent = parent;
+        this.startTime = -1;
     }
     
     @Override
@@ -130,6 +132,10 @@ public final class PackageResult extends MetaTabulatedResult implements Comparab
     @Override
     public float getDuration() {
         return duration; 
+    }
+    
+    public long getStartTime() {
+        return startTime;
     }
     
     @Exported
@@ -353,6 +359,10 @@ public final class PackageResult extends MetaTabulatedResult implements Comparab
     @Override
     public String getDisplayName() {
         return TestNameTransformer.getTransformedName(packageName);
+    }
+    
+    public void setStartTime(long time) {
+    	startTime = time;
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/tasks/junit/SuiteResult.java
+++ b/src/main/java/hudson/tasks/junit/SuiteResult.java
@@ -265,7 +265,7 @@ public final class SuiteResult implements Serializable {
         }
 
         // offset for start time of cases if none is case timestamp is not specified
-        double caseStartOffset = 0;
+        long caseStartOffset = 0;
         List<Element> testCases = suite.elements("testcase");
         for (Element e : testCases) {
             // https://issues.jenkins-ci.org/browse/JENKINS-1233 indicates that
@@ -297,8 +297,8 @@ public final class SuiteResult implements Serializable {
             }
             // Else estimate start time using sum of previous case durations in suite
             else if (startTime != -1) {
-                caze.setStartTime((long)(startTime + caseStartOffset));
-                caseStartOffset += caze.getDuration();
+                caze.setStartTime(startTime + caseStartOffset);
+                caseStartOffset += (long)(caze.getDuration() * 1000);
             }
         }
 

--- a/src/main/java/hudson/tasks/junit/SuiteResult.java
+++ b/src/main/java/hudson/tasks/junit/SuiteResult.java
@@ -246,10 +246,12 @@ public final class SuiteResult implements Serializable {
         }
         
         // check for timestamp attribute and set start time if present
-        if(timestamp != null && !timestamp.equals("")) 
+        if (timestamp != null && !timestamp.equals("")) {
             this.startTime = parseTime(timestamp);
-        else
-        	this.startTime = -1;
+        }
+        else {
+            this.startTime = -1;
+        }
 
         // check for test suite time attribute
         if ((this.time = suite.attributeValue("time")) != null) {
@@ -290,12 +292,13 @@ public final class SuiteResult implements Serializable {
             
             // If timestamp is present for <testcase> set startTime of new CaseResult.
             String caseStart = e.attributeValue("timestamp");
-            if(caseStart != null && !caseStart.equals(""))
-            		caze.setStartTime(parseTime(caseStart));
+            if (caseStart != null && !caseStart.equals("")) {
+                caze.setStartTime(parseTime(caseStart));
+            }
             // Else estimate start time using sum of previous case durations in suite
-            else if(startTime != -1) {
-            	caze.setStartTime((long)(startTime + caseStartOffset));
-            	caseStartOffset += caze.getDuration();
+            else if (startTime != -1) {
+                caze.setStartTime((long)(startTime + caseStartOffset));
+                caseStartOffset += caze.getDuration();
             }
         }
 
@@ -531,17 +534,17 @@ public final class SuiteResult implements Serializable {
      * @return time in epoch milli
      */
     public long parseTime(String time) {
-    	try {
-    		// if time is not in supported format due to missing zulu and offset
-    		if(time.charAt(time.length() - 1) != 'Z' && !time.contains("+") && time.lastIndexOf("-") <= 7)
-    			time += 'Z';
-    		OffsetDateTime odt = OffsetDateTime.parse(time.replace(" ", "")); 
-	    	return odt.toInstant().toEpochMilli();
-    	} catch(Exception e) {
-    		// If time format causes error in parsing print message and return -1
-    		LOGGER.warning("Could not parse start time from timestamp.");
-    		return -1;
-    	}
+        try {
+            // if time is not in supported format due to missing zulu and offset
+            if (time.charAt(time.length() - 1) != 'Z' && !time.contains("+") && time.lastIndexOf("-") <= 7)
+                time += 'Z';
+            OffsetDateTime odt = OffsetDateTime.parse(time.replace(" ", "")); 
+            return odt.toInstant().toEpochMilli();
+        } catch (Exception e) {
+            // If time format causes error in parsing print message and return -1
+            LOGGER.warning("Could not parse start time from timestamp.");
+            return -1;
+        }
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/tasks/junit/SuiteResult.java
+++ b/src/main/java/hudson/tasks/junit/SuiteResult.java
@@ -287,9 +287,8 @@ public final class SuiteResult implements Serializable {
             // one wants to use @name from <testsuite>,
             // the other wants to use @classname from <testcase>.
             
-            CaseResult caze;
-            addCase(caze = new CaseResult(this, e, classname, keepLongStdio, keepProperties));
-            
+            CaseResult caze = new CaseResult(this, e, classname, keepLongStdio, keepProperties);
+
             // If timestamp is present for <testcase> set startTime of new CaseResult.
             String caseStart = e.attributeValue("timestamp");
             if (caseStart != null && !caseStart.equals("")) {
@@ -300,6 +299,7 @@ public final class SuiteResult implements Serializable {
                 caze.setStartTime(startTime + caseStartOffset);
                 caseStartOffset += (long)(caze.getDuration() * 1000);
             }
+            addCase(caze);
         }
 
         String stdout = CaseResult.possiblyTrimStdio(cases, keepLongStdio, suite.elementText("system-out"));

--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -334,9 +334,9 @@ public final class TestResult extends MetaTabulatedResult {
                     nullSafeEq(s.getEnclosingBlockNames(),sr.getEnclosingBlockNames())) {
 
                 // Set start time to earliest set start of a suite
-                if(startTime == -1) {
+                if (startTime == -1) {
                     startTime = suiteStart;
-                } else if(suiteStart != -1){
+                } else if (suiteStart != -1){
                     startTime = Math.min(startTime, suiteStart);
                 }
                 
@@ -347,9 +347,9 @@ public final class TestResult extends MetaTabulatedResult {
         }
 
         // Set start time to earliest set start of a suite
-        if(startTime == -1) {
+        if (startTime == -1) {
             startTime = suiteStart;
-        } else if(suiteStart != -1){
+        } else if (suiteStart != -1){
             startTime = Math.min(startTime, suiteStart);
         }
         
@@ -518,11 +518,11 @@ public final class TestResult extends MetaTabulatedResult {
     }
     
     public void setStartTime(long start) {
-    	startTime = start;
+        startTime = start;
     }
 
     public long getStartTime() {
-    	return startTime;
+        return startTime;
     }
 
     @Exported(visibility=999)

--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -870,7 +870,12 @@ public final class TestResult extends MetaTabulatedResult {
                 PackageResult pr = byPackage(spkg);
                 if(pr==null)
                     byPackages.put(spkg,pr=new PackageResult(this,pkg));
-                pr.setStartTime(s.getStartTime());
+                
+                if (pr.getStartTime() == -1) {
+                    pr.setStartTime(s.getStartTime());
+                } else if (s.getStartTime() != -1){
+                    pr.setStartTime(Math.min(pr.getStartTime(), s.getStartTime()));
+                }
                 pr.add(cr);
             }
         }
@@ -935,7 +940,12 @@ public final class TestResult extends MetaTabulatedResult {
                 PackageResult pr = byPackage(spkg);
                 if(pr==null)
                     byPackages.put(spkg,pr=new PackageResult(this,pkg));
-                pr.setStartTime(s.getStartTime());
+                
+                if (pr.getStartTime() == -1) {
+                    pr.setStartTime(s.getStartTime());
+                } else if (s.getStartTime() != -1){
+                    pr.setStartTime(Math.min(pr.getStartTime(), s.getStartTime()));
+                }
                 pr.add(cr);
             }
         }

--- a/src/test/java/hudson/tasks/junit/SuiteResultTest.java
+++ b/src/test/java/hudson/tasks/junit/SuiteResultTest.java
@@ -362,7 +362,7 @@ public class SuiteResultTest {
 
     @Test
     public void testTestParseTimeMethod() throws Exception {
-        // A report with blocks of testsuites some with and some without time attrs  
+    	// Tests parseTime() with various valid and invalid datetimes   
         SuiteResult emptyResult = new SuiteResult("Test parseTime", "", "", null);
         assertEquals(0, emptyResult.parseTime("1970-01-01T00:00:00.00")); 
         assertEquals(1704280980000L, emptyResult.parseTime("2024-01-03T11:23:00.00"));

--- a/src/test/java/hudson/tasks/junit/SuiteResultTest.java
+++ b/src/test/java/hudson/tasks/junit/SuiteResultTest.java
@@ -361,6 +361,23 @@ public class SuiteResultTest {
     }
 
     @Test
+    public void testTestParseTimeMethod() throws Exception {
+        // A report with blocks of testsuites some with and some without time attrs  
+        SuiteResult emptyResult = new SuiteResult("Test parseTime", "", "", null);
+        assertEquals(0, emptyResult.parseTime("1970-01-01T00:00:00.00")); 
+        assertEquals(1704280980000L, emptyResult.parseTime("2024-01-03T11:23:00.00"));
+        assertEquals(1704284831000L, emptyResult.parseTime("2024-01-03T12:27:11"));
+        assertEquals(1704285613000L, emptyResult.parseTime("2024-01-03T 12:40:13"));
+        assertEquals(1704284864000L, emptyResult.parseTime("2024-01-03T12:27:44Z"));
+        assertEquals(1704281235000L, emptyResult.parseTime("2024-01-03T12:27:15+01:00"));
+        assertEquals(1704288431210L, emptyResult.parseTime("2024-01-03T12:27:11.21-01:00"));
+        assertEquals(-1, emptyResult.parseTime("2024-01-03T12:27:11.21+1:00"));
+        assertEquals(-1, emptyResult.parseTime("2024-01-03 12:27:54Z"));
+        assertEquals(-1, emptyResult.parseTime("2024-01-03"));
+        assertEquals(-1, emptyResult.parseTime(""));
+    }
+
+    @Test
     public void testProperties() throws Exception {
         SuiteResult sr = parseOneWithProperties(getDataFile("junit-report-with-properties.xml"));
         Map<String,String> props = sr.getProperties();

--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -324,7 +324,7 @@ public class TestResultTest {
     }
     
     @Test
-    public void testTestStartTimes() throws Exception {
+    public void testStartTimes() throws Exception {
     	// Tests that start times are as expected for file with a mix of valid,
     	// invalid, and unspecified timestamps.
         TestResult testResult = new TestResult();

--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -322,5 +322,84 @@ public class TestResultTest {
         assertEquals("Wrong number of test cases", 6, testResult.getTotalCount());
 
     }
+    
+    @Test
+    public void testTestStartTimes() throws Exception {
+    	// Tests that start times are as expected for file with a mix of valid,
+    	// invalid, and unspecified timestamps.
+        TestResult testResult = new TestResult();
+        testResult.parse(getDataFile("junit-report-testsuite-various-timestamps.xml"));
+        testResult.tally();
+
+        // Test that TestResult startTime is the startTime of the earliest suite.
+        assertEquals(1704281235000L, testResult.getStartTime());
+        
+        // Test that suites have correct start times
+        List<SuiteResult> suites = (List<SuiteResult>)testResult.getSuites();
+        assertEquals(-1, suites.get(0).getStartTime());
+        assertEquals(1704284831000L, suites.get(1).getStartTime());
+        assertEquals(1704285613000L, suites.get(2).getStartTime());
+        assertEquals(1704284864000L, suites.get(3).getStartTime());
+        assertEquals(-1, suites.get(4).getStartTime());
+        assertEquals(-1, suites.get(5).getStartTime());
+        assertEquals(1704288431210L, suites.get(6).getStartTime());
+        assertEquals(1704281235000L, suites.get(7).getStartTime());
+        
+        // Test each package and its descendants for correct start times.
+        PackageResult pkg =  testResult.byPackage("(root)");
+        assertEquals(1704281235000L, pkg.getStartTime());
+        
+        ClassResult class1 = pkg.getClassResult("contents adjust properly when resizing test");
+        CaseResult case1 = class1.getCaseResult("testResize");
+        assertEquals(1704288431210L, class1.getStartTime());
+        assertEquals(1704288431210L, case1.getStartTime());
+        
+        ClassResult class2 = pkg.getClassResult("date reflects offset test");
+        CaseResult case2 = class2.getCaseResult("testDate");
+        assertEquals(-1, class2.getStartTime());
+        assertEquals(-1, case2.getStartTime());
+        
+        ClassResult class3 = pkg.getClassResult("get test");
+        CaseResult case3 = class3.getCaseResult("testGet");
+        assertEquals(-1, class3.getStartTime());
+        assertEquals(-1, case3.getStartTime());
+        
+        ClassResult class4 = pkg.getClassResult("testButtons");
+        CaseResult case4 = class4.getCaseResult("home_button_redirects_to_home_test");
+        CaseResult case5 = class4.getCaseResult("sign_out_button_ends_session_test");
+        CaseResult case6 = class4.getCaseResult("sign_out_button_redirects_to_sign_in_test");
+        assertEquals(1704285613000L, class4.getStartTime());
+        assertEquals(1704285613000L, case4.getStartTime());
+        assertEquals(1704285617000L, case5.getStartTime());
+        assertEquals(1704285628000L, case6.getStartTime());
+        
+        ClassResult class5 = pkg.getClassResult("testPassword");
+        CaseResult case7 = class5.getCaseResult("invalid_if_password_does_not_match_test");
+        CaseResult case8 = class5.getCaseResult("invalid_if_password_is_weak_test");
+        assertEquals(1704284831000L, class5.getStartTime());
+        assertEquals(1704284831000L, case7.getStartTime());
+        assertEquals(1704284838000L, case8.getStartTime());
+        
+        ClassResult class6 = pkg.getClassResult("pages load in under ten seconds under ideal conditions test");
+        CaseResult case9 = class6.getCaseResult("testExperience");
+        assertEquals(1704284864000L, class6.getStartTime());
+        assertEquals(1704284864000L, case9.getStartTime());
+        
+        ClassResult class7 = pkg.getClassResult("popups triggered when hovering test");
+        CaseResult case10 = class7.getCaseResult("testPopup");
+        assertEquals(-1, class7.getStartTime());
+        assertEquals(-1, case10.getStartTime());
+        
+        ClassResult class8 = pkg.getClassResult("proper images displayed when items added");
+        CaseResult case11 = class8.getCaseResult("testShop");
+        assertEquals(1704281235000L, class8.getStartTime());
+        assertEquals(1704281235000L, case11.getStartTime());
+       
+        ClassResult class9 = pkg.getClassResult("time offset is correct test");
+        CaseResult case12 = class9.getCaseResult("testOffset");
+        assertEquals(-1, class9.getStartTime());
+        assertEquals(-1, case12.getStartTime());
+        
+    }
 
 }

--- a/src/test/resources/hudson/tasks/junit/junit-report-testsuite-various-timestamps.xml
+++ b/src/test/resources/hudson/tasks/junit/junit-report-testsuite-various-timestamps.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Frontend Tests" tests="8" errors="0" failures="0" ignored="0" timestamp="2024-01-03T11:23:00.00">
+    <testsuite name="datetime tests" time="2503.1">
+      <testcase name="testOffset" classname="time offset is correct test" time="10.45"/>
+      <testcase name="testDate" classname="date reflects offset test" time="11"/>
+    </testsuite>
+    <testsuite name="password validation tests" timestamp="2024-01-03T12:27:11">
+      <testcase name="invalid if password does not match test" classname="testPassword" time="1" timestamp="2024-01-03T12:27:11"/>
+      <testcase name="invalid if password is weak test" classname="testPassword" time="0.32" timestamp="2024-01-03T12:27:18"/>
+    </testsuite>
+    <testsuite name="functional tests" >
+      <testsuite name="test.RestMethods" time="40" timestamp="2024-01-03T 12:40:13">
+        <testcase name="home button redirects to home test" classname="testButtons" time="4"/>
+        <testcase name="sign out button ends session test" classname="testButtons" time="11"/>
+        <testcase name="sign out button redirects to sign in test" classname="testButtons" time="13"/>
+      </testsuite>
+    </testsuite>
+    <testsuite name="ui tests" timestamp="2024-01-03T12:27:44Z">
+      <testcase name="testExperience" classname="pages load in under ten seconds under ideal conditions test" time="11"/>
+    </testsuite>
+    <testsuite name="api tests" timestamp="2024-01-03 12:27:54Z">
+      <testcase name="testGet" classname="get test" time="133.01"/>
+    </testsuite>
+    <testsuite name="javascript tests" timestamp="2024-01-03">
+      <testcase name="testPopup" classname="popups triggered when hovering test" time="23"/>
+    </testsuite>
+    <testsuite name="flexbox tests" timestamp="2024-01-03T12:27:11.21-01:00">
+      <testcase name="testResize" classname="contents adjust properly when resizing test" time="41"/>
+    </testsuite>
+    <testsuite name="misc tests" timestamp="2024-01-03T12:27:15+01:00">
+      <testcase name="testShop" classname="proper images displayed when items added" time="29"/>
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
…s, test packages, and test suites

This pull request is to add information about start times to the different test result classes. Start times are recorded using epoch milliseconds. Many tests in JUnit (and even more converted to JUnit via other plugins i.e. xUnit) include start times for test suites as well as test cases which could be useful information for third-party plugins to have. The default value is -1 for an unset start time and the package start time is the earliest start time of its test cases. Additionally, the overall test result start time is the earliest set start time of a SuiteResult. The largest adds are the parseTime method for parsing the epoch millisecond time from a timestamp and the logic for setting start times. It is intended to be as non-invasive as possible, so no logic is introduced to derive the start time of a test class, but that can be derived by those that want to use the start times. This introduces no breaking changes and no change to the frontend.  It will not affect the performance or output of the plugin itself and only introduces more possible information for those extending the plugin. 

### Testing done

No unit tests were added for the change. However, I made the change alongside my development of an extended TestDataPublisher for pseudo-tracing and metric data collection and was able to verify that start time for suites and test cases matched what was parsed from their reports. Additionally, all unit tests are still passing as the parsing of a start time does not affect the plugin's performance. Omission of a start time simply means it is set to -1 which I verified when testing my extension. Additionally, inclusion of a non-ISO start time results in a LOGGER.warning but does not affect the program's ability to run.

```[tasklist]
### Submitter checklist
- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x ] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

