### PR TITLE
Add flow node ID to external storage API

### DIFF
--- a/src/main/java/hudson/tasks/junit/JUnitParser.java
+++ b/src/main/java/hudson/tasks/junit/JUnitParser.java
@@ -129,8 +129,10 @@ public class JUnitParser extends TestResultParser {
     public TestResultSummary summarizeResult(String testResultLocations, Run<?,?> build, PipelineTestDetails pipelineTestDetails,
                                   FilePath workspace, Launcher launcher, TaskListener listener, JunitTestResultStorage storage)
             throws InterruptedException, IOException {
+        String nodeId = pipelineTestDetails != null ? pipelineTestDetails.getNodeId() : null;
+
         return workspace.act(new StorageParseResultCallable(testResultLocations, build, stdioRetention, keepProperties, allowEmptyResults,
-                pipelineTestDetails, listener, storage.createRemotePublisher(build), skipOldReports));
+                pipelineTestDetails, listener, storage.createRemotePublisher(build, nodeId), skipOldReports));
     }
 
     private static abstract class ParseResultCallable<T> extends MasterToSlaveFileCallable<T> {

--- a/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
+++ b/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
@@ -53,6 +53,7 @@ import io.jenkins.plugins.junit.storage.JunitTestResultStorage;
 import jenkins.tasks.SimpleBuildStep;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.types.FileSet;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;

--- a/src/main/java/io/jenkins/plugins/junit/storage/FileJunitTestResultStorage.java
+++ b/src/main/java/io/jenkins/plugins/junit/storage/FileJunitTestResultStorage.java
@@ -22,6 +22,11 @@ public class FileJunitTestResultStorage extends JunitTestResultStorage {
     }
 
     @Override
+    public RemotePublisher createRemotePublisher(Run<?, ?> build, String flowNodeId) throws IOException {
+        return null;
+    }
+
+    @Override
     public TestResultImpl load(String job, int build) {
         return null;
     }

--- a/src/main/java/io/jenkins/plugins/junit/storage/JunitTestResultStorage.java
+++ b/src/main/java/io/jenkins/plugins/junit/storage/JunitTestResultStorage.java
@@ -24,6 +24,7 @@
 
 package io.jenkins.plugins.junit.storage;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.ExtensionPoint;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Run;
@@ -41,10 +42,14 @@ import org.kohsuke.accmod.restrictions.Beta;
 @Restricted(Beta.class)
 public abstract class JunitTestResultStorage extends AbstractDescribableImpl<JunitTestResultStorage> implements ExtensionPoint {
 
+    public RemotePublisher createRemotePublisher(Run<?,?> build) throws IOException {
+        throw new UnsupportedOperationException("Implement createRemotePublisher(Run<?,?>, String) instead.");
+    }
+
     /**
      * Runs during {@link JUnitParser#summarizeResult}.
      */
-    public abstract RemotePublisher createRemotePublisher(Run<?,?> build) throws IOException;
+    public abstract RemotePublisher createRemotePublisher(Run<?,?> build, @CheckForNull String flowNodeId) throws IOException;
 
     /**
      * Remotable hook to perform test result publishing.

--- a/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
+++ b/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
@@ -267,7 +267,8 @@ public class TestResultStorageJunitTest {
 
         private final ConnectionSupplier connectionSupplier = new LocalConnectionSupplier();
 
-        @Override public RemotePublisher createRemotePublisher(Run<?, ?> build) throws IOException {
+        @Override
+        public RemotePublisher createRemotePublisher(Run<?, ?> build, String flowNodeId) throws IOException {
             try {
                 connectionSupplier.connection(); // make sure we start a local server and create table first
             } catch (SQLException x) {


### PR DESCRIPTION
This is currently a breaking change although it could likely be made more compatible.
There's only realtime junit to adapt anyway.

I'm not sure this is the best approach and would appreciate any guidance.

See https://github.com/jenkinsci/junit-sql-storage-plugin/pull/414/files#diff-1202c93b95ce3f5252dc25bf1a5ab73d75ebc67052d675c97d5e146a3448596aR140

In order to link the traces that are being used for instrumenting the junit sql plugin I need access to the `FlowNodeMonitoringAction` to get the open telemetry trace parent id.

That is attached to the flow node and I couldn't find a way other than passing it down to get to it.
The normal `Context.current` from otel doesn't work as the otel plugin uses actions for tracking and isn't able to setup block scopes and pass it along. 

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
