### PR TITLE
Slim down JPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,11 @@
                     <groupId>com.google.code.gson</groupId>
                     <artifactId>gson</artifactId>
                 </exclusion>
+                <!-- Provided by Jenkins core -->
+                <exclusion>
+                    <groupId>jfree</groupId>
+                    <artifactId>jfreechart</artifactId>
+                </exclusion>
             </exclusions> 
         </dependency>
     </dependencies>


### PR DESCRIPTION
Stop bundling the `jfreechart` and `jcommons` JAR files, as they are already shipped in the WAR file by Jenkins core.

### Testing done

`mvn clean verify -Dtest=InjectedTest`