### PR TITLE
Remove dependencies on `commons-math3` and `ssj` by implementing simple linear regression directly, replacing the build duration distribution chart with a histogram, and deleting the smoothed trend lines in the test history charts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,11 +97,6 @@
       <artifactId>plugin-util-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-math3</artifactId>
-      <version>3.6.1</version>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>display-url-api</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -60,18 +60,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>ca.umontreal.iro.simul</groupId>
-      <artifactId>ssj</artifactId>
-      <version>3.3.2</version>
-      <!-- Dependencies are unused, provided by Jenkins core, have unusual licenses, unclear artifact ownership, and/or are obsolete. We only use SmoothingCubicSpline, which does not require dependencies. -->
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.pivovarit</groupId>
       <artifactId>parallel-collectors</artifactId>
       <version>2.6.1</version>

--- a/src/main/java/hudson/tasks/junit/History.java
+++ b/src/main/java/hudson/tasks/junit/History.java
@@ -49,7 +49,6 @@ import jenkins.util.SystemProperties;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
-import umontreal.ssj.functionfit.SmoothingCubicSpline;
 
 /**
  * History of {@link hudson.tasks.test.TestObject} over time.
@@ -208,16 +207,6 @@ public class History {
                     0,
                     0,
                     roundMul); // "--blue"
-            createSplineTrend(
-                    series,
-                    history,
-                    lrX,
-                    lrY,
-                    "Smooth of " + durationStr,
-                    "rgba(120, 50, 255, 0.5)",
-                    0,
-                    0,
-                    roundMul); // "--indigo"
         }
         root.set("series", series);
         root.set("domainAxisLabels", domainAxisLabels);
@@ -276,51 +265,6 @@ public class History {
         for (int index = 0; index < history.size(); ++index) {
             // Use float to reduce JSON size.
             lrData.add((float) (Math.round((intercept + index * slope) * roundMul) / roundMul));
-        }
-    }
-
-    private void createSplineTrend(
-            ArrayNode series,
-            List<HistoryTestResultSummary> history,
-            double[] lrX,
-            double[] lrY,
-            String title,
-            String color,
-            int xAxisIndex,
-            int yAxisIndex,
-            double roundMul) {
-        if (history.size() < 200) {
-            return;
-        }
-        double rho = Math.min(1.0, 1.0 / Math.max(1, (history.size() / 2)));
-        if (rho > 0.75) {
-            return; // Too close to linear
-        }
-        SmoothingCubicSpline scs = new SmoothingCubicSpline(lrX, lrY, 0.001);
-        ObjectNode lrSeries = MAPPER.createObjectNode();
-        series.add(lrSeries);
-        lrSeries.put("name", title);
-        lrSeries.put("preferScreenOrient", "landscape");
-        lrSeries.put("type", "line");
-        lrSeries.put("symbol", "circle");
-        lrSeries.put("symbolSize", 0);
-        lrSeries.put("xAxisIndex", xAxisIndex);
-        lrSeries.put("yAxisIndex", yAxisIndex);
-        ArrayNode lrData = MAPPER.createArrayNode();
-        lrSeries.set("data", lrData);
-        ObjectNode lrStyle = MAPPER.createObjectNode();
-        lrSeries.set("itemStyle", lrStyle);
-        lrStyle.put("color", color);
-        ObjectNode lrAreaStyle = MAPPER.createObjectNode();
-        lrSeries.set("areaStyle", lrAreaStyle);
-        lrAreaStyle.put("color", "rgba(0, 0, 0, 0)");
-
-        if (roundMul < 10.0) {
-            roundMul = 10.0;
-        }
-        for (int index = 0; index < history.size(); ++index) {
-            // Use float to reduce JSON size.
-            lrData.add((float) (Math.round(scs.evaluate(index) * roundMul) / roundMul));
         }
     }
 
@@ -464,8 +408,6 @@ public class History {
                     1,
                     1,
                     10.0); // "--dark-blue"
-            createSplineTrend(
-                    series, history, lrX, lrY, "Smooth of Passed", "rgba(255, 50, 255, 0.5)", 1, 1, 10.0); // "--purple"
         }
 
         root.set("series", series);

--- a/src/main/java/hudson/tasks/junit/History.java
+++ b/src/main/java/hudson/tasks/junit/History.java
@@ -442,7 +442,6 @@ public class History {
                 minDuration = h.getDuration();
             }
         }
-        // double extraDuration = Math.max(0.001, (maxDuration - minDuration) * 0.05);
         minDuration = Math.max(0.0, minDuration);
         int buckets = 50;
         double[] lrX = new double[buckets];

--- a/src/main/resources/hudson/tasks/junit/History/history.js
+++ b/src/main/resources/hudson/tasks/junit/History/history.js
@@ -323,12 +323,16 @@ function onBuildIntervalChange(selectObj) {
                     top: '20%',
                 },
                 xAxis: {
-                    type: 'category',
-                    boundaryGap: false,
+                    type: 'value',
                     axisLabel: {
-                        color: textColor
+                        color: textColor,
+                        formatter: function(value) {
+                            return Math.round(value * model.distribution.xAxis.roundingFactor) / model.distribution.xAxis.roundingFactor;
+                        }
                     },
-                    data: model.distribution.domainAxisLabels,
+                    min: model.distribution.xAxis.min,
+                    max: model.distribution.xAxis.max,
+                    minInterval: model.distribution.xAxis.interval,
                     name: model.distribution.xAxis.name,
                     nameLocation: 'middle',
                     nameGap: 26,
@@ -343,6 +347,7 @@ function onBuildIntervalChange(selectObj) {
                     axisLabel: {
                         color: textColor
                     },
+                    minInterval: model.result.integerRangeAxis ? 1 : null,
                     name: 'Build Count',
                     nameLocation: 'middle',
                     nameGap: 60,

--- a/src/test/java/hudson/tasks/junit/SimpleLinearRegressionTest.java
+++ b/src/test/java/hudson/tasks/junit/SimpleLinearRegressionTest.java
@@ -1,0 +1,73 @@
+package hudson.tasks.junit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notANumber;
+import static org.junit.Assert.assertThrows;
+
+import hudson.tasks.junit.History.SimpleLinearRegression;
+import org.junit.Test;
+
+public class SimpleLinearRegressionTest {
+
+    @Test
+    public void smokes() {
+        // Results checked in Excel.
+        double[] xs = {2, 3, 4, 5, 6, 8, 10, 11};
+        double[] ys = {21.05, 23.51, 24.23, 27.71, 30.86, 45.85, 52.12, 55.98};
+        double[] cs = SimpleLinearRegression.coefficients(xs, ys);
+        assertThat(cs[0], closeTo(9.4763, 0.0001));
+        assertThat(cs[1], closeTo(4.1939, 0.0001));
+
+        xs = new double[] {1.47, 1.5, 1.52, 1.55, 1.57, 1.6, 1.63, 1.65, 1.68, 1.7, 1.73, 1.75, 1.78, 1.8, 1.83};
+        ys = new double[] {
+            52.21, 53.12, 54.48, 55.84, 57.2, 58.57, 59.93, 61.29, 63.11, 64.47, 66.28, 68.1, 69.92, 72.19, 74.46
+        };
+        cs = SimpleLinearRegression.coefficients(xs, ys);
+        assertThat(cs[0], closeTo(-39.0620, 0.0001));
+        assertThat(cs[1], closeTo(61.2722, 0.0001));
+    }
+
+    @Test
+    public void requires2DataPoints() {
+        var t = assertThrows(
+                IllegalArgumentException.class,
+                () -> SimpleLinearRegression.coefficients(new double[0], new double[0]));
+        assertThat(t.getMessage(), containsString("At least two data points are required"));
+        t = assertThrows(
+                IllegalArgumentException.class,
+                () -> SimpleLinearRegression.coefficients(new double[1], new double[1]));
+        assertThat(t.getMessage(), containsString("At least two data points are required"));
+        double[] cs = SimpleLinearRegression.coefficients(new double[] {0.0, 1.0}, new double[] {1.0, 1.0});
+        assertThat(cs[0], closeTo(1.0, 0.001));
+        assertThat(cs[1], closeTo(0, 0.001));
+    }
+
+    @Test
+    public void requiresArraysWithSameLength() {
+        var t = assertThrows(
+                IllegalArgumentException.class,
+                () -> SimpleLinearRegression.coefficients(new double[3], new double[4]));
+        assertThat(t.getMessage(), containsString("Array lengths do not match"));
+        t = assertThrows(
+                IllegalArgumentException.class,
+                () -> SimpleLinearRegression.coefficients(new double[4], new double[3]));
+        assertThat(t.getMessage(), containsString("Array lengths do not match"));
+    }
+
+    @Test
+    public void returnsNanIfXValuesDoNotVaryEnough() {
+        double[] xs = {Double.MIN_VALUE, 1e162 * Double.MIN_VALUE};
+        double[] ys = {0.0, 1.0};
+        double[] cs = SimpleLinearRegression.coefficients(xs, ys);
+        assertThat(cs[0], notANumber());
+        assertThat(cs[1], notANumber());
+
+        xs = new double[] {Double.MIN_VALUE, 1e163 * Double.MIN_VALUE};
+        ys = new double[] {0.0, 1.0};
+        cs = SimpleLinearRegression.coefficients(xs, ys);
+        assertThat(cs[0], closeTo(0.0, 0.001));
+        assertThat(cs[1], closeTo(2.0e160, 1e159));
+    }
+}


### PR DESCRIPTION
This is a followup to https://github.com/jenkinsci/junit-plugin/pull/638 and https://github.com/jenkinsci/junit-plugin/pull/625 to further simplify the dependencies after I discussed it with some colleagues. This plugin is used pretty widely in the Jenkins ecosystem, so it seems worth trying to minimize its dependencies, especially to eliminate dependencies which are not being actively maintained.

This PR does 3 things (you can review commit by commit if you like):
* It gets rid of the `commons-math3` dependency by just directly implementing a simple linear regression algorithm. This is very straightforward since we are only using it for a trend line and don't care about any other data related to the regression.
* It replaces the `SmoothingCubicSpline`-based build duration distribution chart with a histogram, which I think is a better representation of the data anyway.
* It completely deletes the two `SmoothingCubicSpline`-based "Smooth of X" trend lines that are only shown in the test history widget if more than 200 builds' worth of test results are available. I did this so we could get rid of the `ssj` dependency completely. Here is my justification:
    * I do not think pluggable storage for test results is in widespread use, so most users set up build retention policies that will prevent them from getting anywhere close to 201 builds' worth of test results, so those users can never see these trend lines anyway
    * Even for users who do have at least 201 build's worth of test results, by default the page only shows 100 builds' worth test results, so only users who actively play around with the options on the page would ever see these trend lines
    * These trend lines were introduced for the first time in https://github.com/jenkinsci/junit-plugin/pull/625, so this is not removing long-lived functionality
    * I could not find any simple replacement for `SmoothingCubicSpline` in an actively-maintained library, and I am not confident in being able to reimplement it from scratch correctly in a reasonable amount of time
    * `ssj` is not actively maintained and has some warning signs, for example its 3.3.2 release is not listed anywhere in publicly available Git commit history
    * I am totally ok with adding this functionality back to the plugin with any of these three approaches:
        * If someone can find a replacement for `SmoothingCubicSpline` in an actively-maintained library with minimal dependencies and that ideally is not pulling in a whole grab bag of unrelated functionality that we do not need
        * If someone is willing to implement an equivalent algorithm directly
        * If someone wants to make it possible for https://github.com/jenkinsci/license-maven-plugin to support manually-specified license information, so that we could copy/paste the implementation of `SmoothingCubicSpline` into this repository while still having license information be reported accurately in Jenkins on the `/manage/about/` page

Here are screenshots with and without the PR:

With this PR:

<img width="1728" alt="Screen Shot 2024-08-20 at 1 46 41 PM" src="https://github.com/user-attachments/assets/bab0cb51-55a5-4f08-8977-4573c8fe5921">

Without this PR:

<img width="1728" alt="Screen Shot 2024-08-20 at 1 45 38 PM" src="https://github.com/user-attachments/assets/cfd358b9-e304-436a-984c-1aaa48f24507">

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
