### PR TITLE
Improve recently added log messages by adding context to indicate which build is relevant

### DIFF
--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -41,7 +41,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
@@ -269,7 +268,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         return Math.min(365.0f * 24 * 60 * 60, Math.max(0.0f, d));
     }
 
-    public static CaseResult parse(SuiteResult parent, final XMLStreamReader reader, String ver)
+    static CaseResult parse(SuiteResult parent, final XMLStreamReader reader, String context, String ver)
             throws XMLStreamException {
         CaseResult r = new CaseResult(parent, null, null, null);
         while (reader.hasNext()) {
@@ -318,19 +317,17 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
                         break;
                     case "properties":
                         r.properties = new HashMap<>();
-                        parseProperties(r.properties, reader, ver);
+                        parseProperties(r.properties, reader, context, ver);
                         break;
                     default:
-                        if (LOGGER.isLoggable(Level.FINEST)) {
-                            LOGGER.finest("CaseResult.parse encountered an unknown field: " + elementName);
-                        }
+                        LOGGER.finest(() -> "Unknown field in " + context + ": " + elementName);
                 }
             }
         }
         return r;
     }
 
-    public static void parseProperties(Map<String, String> r, final XMLStreamReader reader, String ver)
+    static void parseProperties(Map<String, String> r, final XMLStreamReader reader, String context, String ver)
             throws XMLStreamException {
         while (reader.hasNext()) {
             final int event = reader.next();
@@ -341,18 +338,16 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
                 final String elementName = reader.getLocalName();
                 switch (elementName) {
                     case "entry":
-                        parseProperty(r, reader, ver);
+                        parseProperty(r, reader, context, ver);
                         break;
                     default:
-                        if (LOGGER.isLoggable(Level.FINEST)) {
-                            LOGGER.finest("CaseResult.parseProperties encountered an unknown field: " + elementName);
-                        }
+                        LOGGER.finest(() -> "Unknown field in " + context + ": " + elementName);
                 }
             }
         }
     }
 
-    public static void parseProperty(Map<String, String> r, final XMLStreamReader reader, String ver)
+    static void parseProperty(Map<String, String> r, final XMLStreamReader reader, String context, String ver)
             throws XMLStreamException {
         String name = null, value = null;
         while (reader.hasNext()) {
@@ -374,9 +369,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
                         }
                         break;
                     default:
-                        if (LOGGER.isLoggable(Level.FINEST)) {
-                            LOGGER.finest("CaseResult.parseProperty encountered an unknown field: " + elementName);
-                        }
+                        LOGGER.finest(() -> "Unknown field in " + context + ": " + elementName);
                 }
             }
         }

--- a/src/main/java/hudson/tasks/junit/SuiteResult.java
+++ b/src/main/java/hudson/tasks/junit/SuiteResult.java
@@ -261,7 +261,8 @@ public final class SuiteResult implements Serializable {
         }
     }
 
-    static void parseCases(SuiteResult r, final XMLStreamReader reader, String context, String ver) throws XMLStreamException {
+    static void parseCases(SuiteResult r, final XMLStreamReader reader, String context, String ver)
+            throws XMLStreamException {
         while (reader.hasNext()) {
             final int event = reader.next();
             if (event == XMLStreamReader.END_ELEMENT && reader.getLocalName().equals("cases")) {

--- a/src/main/java/hudson/tasks/junit/SuiteResult.java
+++ b/src/main/java/hudson/tasks/junit/SuiteResult.java
@@ -40,7 +40,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -160,7 +159,7 @@ public final class SuiteResult implements Serializable {
         this.properties.putAll(src.properties);
     }
 
-    public static SuiteResult parse(final XMLStreamReader reader, String ver) throws XMLStreamException {
+    static SuiteResult parse(final XMLStreamReader reader, String context, String ver) throws XMLStreamException {
         SuiteResult r = new SuiteResult("", null, null, null);
         while (reader.hasNext()) {
             final int event = reader.next();
@@ -171,7 +170,7 @@ public final class SuiteResult implements Serializable {
                 final String elementName = reader.getLocalName();
                 switch (elementName) {
                     case "cases":
-                        parseCases(r, reader, ver);
+                        parseCases(r, reader, context, ver);
                         break;
                     case "file":
                         r.file = reader.getElementText();
@@ -199,10 +198,10 @@ public final class SuiteResult implements Serializable {
                         r.nodeId = reader.getElementText();
                         break;
                     case "enclosingBlocks":
-                        parseEnclosingBlocks(r, reader, ver);
+                        parseEnclosingBlocks(r, reader, context, ver);
                         break;
                     case "enclosingBlockNames":
-                        parseEnclosingBlockNames(r, reader, ver);
+                        parseEnclosingBlockNames(r, reader, context, ver);
                         break;
                     case "stdout":
                         r.stdout = reader.getElementText();
@@ -212,19 +211,17 @@ public final class SuiteResult implements Serializable {
                         break;
                     case "properties":
                         r.properties = new HashMap<>();
-                        CaseResult.parseProperties(r.properties, reader, ver);
+                        CaseResult.parseProperties(r.properties, reader, context, ver);
                         break;
                     default:
-                        if (LOGGER.isLoggable(Level.FINEST)) {
-                            LOGGER.finest("SuiteResult.parse encountered an unknown field: " + elementName);
-                        }
+                        LOGGER.finest(() -> "Unknown field in " + context + ": " + elementName);
                 }
             }
         }
         return r;
     }
 
-    public static void parseEnclosingBlocks(SuiteResult r, final XMLStreamReader reader, String ver)
+    static void parseEnclosingBlocks(SuiteResult r, final XMLStreamReader reader, String context, String ver)
             throws XMLStreamException {
         while (reader.hasNext()) {
             final int event = reader.next();
@@ -238,16 +235,13 @@ public final class SuiteResult implements Serializable {
                         r.enclosingBlocks.add(reader.getElementText());
                         break;
                     default:
-                        if (LOGGER.isLoggable(Level.FINEST)) {
-                            LOGGER.finest(
-                                    "SuiteResult.parseEnclosingBlocks encountered an unknown field: " + elementName);
-                        }
+                        LOGGER.finest(() -> "Unknown field in " + context + ": " + elementName);
                 }
             }
         }
     }
 
-    public static void parseEnclosingBlockNames(SuiteResult r, final XMLStreamReader reader, String ver)
+    static void parseEnclosingBlockNames(SuiteResult r, final XMLStreamReader reader, String context, String ver)
             throws XMLStreamException {
         while (reader.hasNext()) {
             final int event = reader.next();
@@ -261,16 +255,13 @@ public final class SuiteResult implements Serializable {
                         r.enclosingBlockNames.add(reader.getElementText());
                         break;
                     default:
-                        if (LOGGER.isLoggable(Level.FINEST)) {
-                            LOGGER.finest("SuiteResult.parseEnclosingBlockNames encountered an unknown field: "
-                                    + elementName);
-                        }
+                        LOGGER.finest(() -> "Unknown field in " + context + ": " + elementName);
                 }
             }
         }
     }
 
-    public static void parseCases(SuiteResult r, final XMLStreamReader reader, String ver) throws XMLStreamException {
+    static void parseCases(SuiteResult r, final XMLStreamReader reader, String context, String ver) throws XMLStreamException {
         while (reader.hasNext()) {
             final int event = reader.next();
             if (event == XMLStreamReader.END_ELEMENT && reader.getLocalName().equals("cases")) {
@@ -280,12 +271,10 @@ public final class SuiteResult implements Serializable {
                 final String elementName = reader.getLocalName();
                 switch (elementName) {
                     case "case":
-                        r.cases.add(CaseResult.parse(r, reader, ver));
+                        r.cases.add(CaseResult.parse(r, reader, context, ver));
                         break;
                     default:
-                        if (LOGGER.isLoggable(Level.FINEST)) {
-                            LOGGER.finest("SuiteResult.parseCases encountered an unknown field: " + elementName);
-                        }
+                        LOGGER.finest(() -> "Unknown field in " + context + ": " + elementName);
                 }
             }
         }

--- a/src/main/java/hudson/tasks/junit/TestResultAction.java
+++ b/src/main/java/hudson/tasks/junit/TestResultAction.java
@@ -51,6 +51,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.tasks.SimpleBuildStep;
@@ -69,7 +70,6 @@ import org.kohsuke.stapler.StaplerProxy;
 @SuppressFBWarnings(value = "UG_SYNC_SET_UNSYNC_GET", justification = "False positive")
 public class TestResultAction extends AbstractTestResultAction<TestResultAction>
         implements StaplerProxy, SimpleBuildStep.LastBuildAction {
-    private static final Logger LOGGER = Logger.getLogger(TestResultAction.class.getName());
     private transient WeakReference<TestResult> result;
 
     /** null only if there is a {@link JunitTestResultStorage} */
@@ -179,8 +179,8 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
             skipCount = r.getSkipCount();
         }
         long d = System.nanoTime() - started;
-        if (d > 500000000L && LOGGER.isLoggable(Level.WARNING)) {
-            LOGGER.warning("TestResultAction.load took " + d / 1000000L + " ms.");
+        if (d > TimeUnit.MILLISECONDS.toNanos(500)) {
+            logger.warning(() -> "Took " + TimeUnit.NANOSECONDS.toMillis(d) + " ms to load test results for " + run);
         }
         return r;
     }


### PR DESCRIPTION
Amends #625. @olamy recently saw a bunch of these log messages, which were added in that PR I guess to help detect slow loading, but they are not really useful without indicating which build is relevant:

```
2024-08-22 08:03:49.329+0000 [id=465]	WARNING	h.tasks.junit.TestResultAction#getResult: TestResultAction.load took 1060 ms.
```

This PR does 3 main things:
* For the new log messages added in #625, it adds either `Run.toString()` or `File.toString()` to the message to provide context
* It removes the hard-coded `Class.method` parts of the messages, which are added automatically by the default Jenkins logger
* It changes the visibility of the new static `parse` methods in #625 that as far as I understand were only intended for internal use from `public` to package-private. This plugin is a dependency of various other plugns, so I think it is desirable to avoid accidentally increasing the API surface

### Testing done

I mangled some test files locally and enabled FINEST logging to check that log messages worked and indicated which build was relevant.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
