### PR TITLE
Remove unused imports of ServletException

### DIFF
--- a/src/main/java/hudson/tasks/junit/TestObject.java
+++ b/src/main/java/hudson/tasks/junit/TestObject.java
@@ -187,12 +187,4 @@ public abstract class TestObject extends AbstractModelObject implements Serializ
     public abstract int getTotalCount();
 
     public abstract History getHistory();
-
-    //    public abstract Object getDynamic(String token, StaplerRequest req,
-    //			StaplerResponse rsp);
-    //
-    //    public abstract  HttpResponse doSubmitDescription(
-    //			@QueryParameter String description) throws IOException,
-    //			ServletException;
-
 }

--- a/src/main/java/hudson/tasks/test/TestObject.java
+++ b/src/main/java/hudson/tasks/test/TestObject.java
@@ -46,7 +46,6 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
@@ -480,8 +479,7 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
     }
 
     @RequirePOST
-    public synchronized HttpResponse doSubmitDescription(@QueryParameter String description)
-            throws IOException, ServletException {
+    public synchronized HttpResponse doSubmitDescription(@QueryParameter String description) throws IOException {
         Run<?, ?> run = getRun();
         if (run == null) {
             LOGGER.severe("getRun() is null, can't save description.");

--- a/src/main/java/hudson/tasks/test/TestResultProjectAction.java
+++ b/src/main/java/hudson/tasks/test/TestResultProjectAction.java
@@ -40,7 +40,6 @@ import io.jenkins.plugins.junit.storage.JunitTestResultStorage;
 import io.jenkins.plugins.junit.storage.TestResultImpl;
 import java.io.IOException;
 import java.util.List;
-import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import org.kohsuke.stapler.Ancestor;
@@ -172,7 +171,7 @@ public class TestResultProjectAction implements Action, AsyncTrendChart, AsyncCo
      * @deprecated Replaced by echarts in TODO
      */
     @Deprecated
-    public void doTrend(final StaplerRequest req, final StaplerResponse rsp) throws IOException, ServletException {
+    public void doTrend(final StaplerRequest req, final StaplerResponse rsp) throws IOException {
         AbstractTestResultAction a = getLastTestResultAction();
         if (a != null) {
             a.doGraph(req, rsp);
@@ -187,7 +186,7 @@ public class TestResultProjectAction implements Action, AsyncTrendChart, AsyncCo
      * @deprecated Replaced by echarts in TODO
      */
     @Deprecated
-    public void doTrendMap(final StaplerRequest req, final StaplerResponse rsp) throws IOException, ServletException {
+    public void doTrendMap(final StaplerRequest req, final StaplerResponse rsp) throws IOException {
         AbstractTestResultAction a = getLastTestResultAction();
         if (a != null) {
             a.doGraphMap(req, rsp);
@@ -199,7 +198,7 @@ public class TestResultProjectAction implements Action, AsyncTrendChart, AsyncCo
     /**
      * Changes the test result report display mode.
      */
-    public void doFlipTrend(final StaplerRequest req, final StaplerResponse rsp) throws IOException, ServletException {
+    public void doFlipTrend(final StaplerRequest req, final StaplerResponse rsp) throws IOException {
         boolean failureOnly = false;
 
         // check the current preference value


### PR DESCRIPTION
I'm seeing builds failing due to attempts to load ServletException on agent side when running `mvn hpi:run` on Kubernetes plugin. Not sure what differs compared to a regular run but in any case, this can be avoided.

`JUnitParser$ParseResultCallable.invoke` creates a
`hudson.tasks.junit.TestObject`, which imports `ServletException` for a web method. This can actually be avoided because the exception is unused.

Also removed other usages of this exception which turn out to be unused.

Attached logs for reference

```
Remote call on JNLP4-connect connection from localhost/[0:0:0:0:0:0:0:1]:55516 failed
[Pipeline] }
[Pipeline] // node
[Pipeline] }
[Pipeline] // retry
[Pipeline] }
[Pipeline] // podTemplate
[Pipeline] End of Pipeline
Also:   hudson.remoting.ProxyException: hudson.remoting.Channel$CallSiteStackTrace: Remote call to JNLP4-connect connection to jenkins.default/10.96.19.40:8001
		at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1923)
		at hudson.remoting.Request.call(Request.java:204)
		at hudson.remoting.RemoteInvocationHandler.invoke(RemoteInvocationHandler.java:312)
		at jdk.proxy2/jdk.proxy2.$Proxy7.fetch(Unknown Source)
		at hudson.remoting.RemoteClassLoader.loadRemoteClass(RemoteClassLoader.java:309)
		at hudson.remoting.RemoteClassLoader.loadWithMultiClassLoader(RemoteClassLoader.java:277)
		at hudson.remoting.RemoteClassLoader.findClass(RemoteClassLoader.java:236)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:593)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
		at PluginClassLoader for junit//hudson.tasks.junit.JUnitParser$ParseResultCallable.invoke(JUnitParser.java:238)
		at Jenkins v2.462.1//hudson.FilePath$FileCallableWrapper.call(FilePath.java:3615)
		at hudson.remoting.UserRequest.perform(UserRequest.java:225)
		at hudson.remoting.UserRequest.perform(UserRequest.java:50)
		at hudson.remoting.Request$2.run(Request.java:391)
		at hudson.remoting.InterceptingExecutorService.lambda$wrap$0(InterceptingExecutorService.java:81)
		at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
		at hudson.remoting.Engine$1.lambda$newThread$0(Engine.java:140)
		at java.base/java.lang.Thread.run(Thread.java:1583)
hudson.remoting.ProxyException: java.lang.ClassNotFoundException: javax.servlet.ServletException
	at hudson.remoting.RemoteClassLoader$ClassLoaderProxy.fetch(RemoteClassLoader.java:1029)
	at jdk.internal.reflect.GeneratedMethodAccessor152.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at hudson.remoting.RemoteInvocationHandler$RPCRequest.perform(RemoteInvocationHandler.java:924)
	at hudson.remoting.Request$2.run(Request.java:377)
	at hudson.remoting.InterceptingExecutorService.lambda$wrap$0(InterceptingExecutorService.java:78)
	at org.jenkinsci.remoting.CallableDecorator.call(CallableDecorator.java:18)
	at hudson.remoting.CallableDecoratorList.lambda$applyDecorator$0(CallableDecoratorList.java:19)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:80)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
Also:   hudson.remoting.ProxyException: hudson.remoting.Channel$CallSiteStackTrace: Remote call to JNLP4-connect connection from localhost/[0:0:0:0:0:0:0:1]:55516
		at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1826)
		at hudson.remoting.UserRequest$ExceptionResponse.retrieve(UserRequest.java:356)
		at hudson.remoting.Channel.call(Channel.java:1042)
		at hudson.FilePath.act(FilePath.java:1229)
		at hudson.FilePath.act(FilePath.java:1218)
		at PluginClassLoader for junit//hudson.tasks.junit.JUnitParser.parseResult(JUnitParser.java:146)
		at PluginClassLoader for junit//hudson.tasks.junit.JUnitResultArchiver.parse(JUnitResultArchiver.java:177)
		at PluginClassLoader for junit//hudson.tasks.junit.JUnitResultArchiver.parseAndSummarize(JUnitResultArchiver.java:282)
		at PluginClassLoader for junit//hudson.tasks.junit.pipeline.JUnitResultsStepExecution.run(JUnitResultsStepExecution.java:62)
		at PluginClassLoader for junit//hudson.tasks.junit.pipeline.JUnitResultsStepExecution.run(JUnitResultsStepExecution.java:27)
		at PluginClassLoader for workflow-step-api//org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
		at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
		at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264)
		at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
		at java.base/java.lang.Thread.run(Thread.java:840)
Caused: hudson.remoting.ProxyException: java.lang.NoClassDefFoundError: javax/servlet/ServletException
	at PluginClassLoader for junit//hudson.tasks.junit.JUnitParser$ParseResultCallable.invoke(JUnitParser.java:238)
	at Jenkins v2.462.1//hudson.FilePath$FileCallableWrapper.call(FilePath.java:3615)
	at hudson.remoting.UserRequest.perform(UserRequest.java:225)
	at hudson.remoting.UserRequest.perform(UserRequest.java:50)
	at hudson.remoting.Request$2.run(Request.java:391)
	at hudson.remoting.InterceptingExecutorService.lambda$wrap$0(InterceptingExecutorService.java:81)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at hudson.remoting.Engine$1.lambda$newThread$0(Engine.java:140)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Also:   hudson.remoting.ProxyException: org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: 8829a6ed-8644-424a-a333-b38043e2c7f7
Caused: hudson.remoting.ProxyException: java.io.IOException: Remote call on JNLP4-connect connection from localhost/[0:0:0:0:0:0:0:1]:55516 failed
	at hudson.remoting.Channel.call(Channel.java:1046)
	at hudson.FilePath.act(FilePath.java:1229)
	at hudson.FilePath.act(FilePath.java:1218)
	at PluginClassLoader for junit//hudson.tasks.junit.JUnitParser.parseResult(JUnitParser.java:146)
	at PluginClassLoader for junit//hudson.tasks.junit.JUnitResultArchiver.parse(JUnitResultArchiver.java:177)
	at PluginClassLoader for junit//hudson.tasks.junit.JUnitResultArchiver.parseAndSummarize(JUnitResultArchiver.java:282)
	at PluginClassLoader for junit//hudson.tasks.junit.pipeline.JUnitResultsStepExecution.run(JUnitResultsStepExecution.java:62)
	at PluginClassLoader for junit//hudson.tasks.junit.pipeline.JUnitResultsStepExecution.run(JUnitResultsStepExecution.java:27)
	at PluginClassLoader for workflow-step-api//org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
