### PR TITLE
Defending against past corrupt builds

### DIFF
--- a/src/main/java/hudson/tasks/test/TestResult.java
+++ b/src/main/java/hudson/tasks/test/TestResult.java
@@ -23,12 +23,15 @@
  */
 package hudson.tasks.test;
 
+import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.tasks.junit.TestAction;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A class that represents a general concept of a test result, without any
@@ -38,6 +41,7 @@ import java.util.Map;
  * @since 1.343
  */
 public abstract class TestResult extends TestObject {
+    private static final Logger LOGGER = Logger.getLogger(TestResult.class.getName());
 
     /**
      * If the concept of a parent action is important to a subclass, then it should
@@ -132,7 +136,8 @@ public abstract class TestResult extends TestObject {
      */
     @Override
     public TestResult getPreviousResult() {
-        Run<?, ?> b = getRun();
+        Run<?, ?> originBuild = getRun();
+        Run<?, ?> b = originBuild;
         if (b == null) {
             return null;
         }
@@ -141,12 +146,22 @@ public abstract class TestResult extends TestObject {
             if (b == null) {
                 return null;
             }
-            AbstractTestResultAction r = b.getAction(getParentAction().getClass());
-            if (r != null) {
-                TestResult result = r.findCorrespondingResult(this.getId());
-                if (result != null) {
-                    return result;
+            try {
+                AbstractTestResultAction r = b.getAction(getParentAction().getClass());
+                if (r != null) {
+                    TestResult result = r.findCorrespondingResult(this.getId());
+                    if (result != null) {
+                        return result;
+                    }
                 }
+            } catch (RuntimeException e) {
+                Job<?, ?> job = originBuild.getParent();
+                Run<?, ?> loggedBuild = b;
+                LOGGER.log(
+                        Level.WARNING,
+                        e,
+                        () -> "Failed to load (corrupt?) build " + job.getFullName() + " #" + loggedBuild.getNumber()
+                                + ", skipping");
             }
         }
     }

--- a/src/main/java/hudson/tasks/test/TestResult.java
+++ b/src/main/java/hudson/tasks/test/TestResult.java
@@ -136,11 +136,11 @@ public abstract class TestResult extends TestObject {
      */
     @Override
     public TestResult getPreviousResult() {
-        Run<?, ?> originBuild = getRun();
-        Run<?, ?> b = originBuild;
+        Run<?, ?> b = getRun();
         if (b == null) {
             return null;
         }
+        Job<?, ?> job = b.getParent();
         while (true) {
             b = b.getPreviousBuild();
             if (b == null) {
@@ -155,7 +155,6 @@ public abstract class TestResult extends TestObject {
                     }
                 }
             } catch (RuntimeException e) {
-                Job<?, ?> job = originBuild.getParent();
                 Run<?, ?> loggedBuild = b;
                 LOGGER.log(
                         Level.WARNING,


### PR DESCRIPTION
cc @jglick @lemeurherve 

I've seen builds failing in the wild during `junit` step execution with an exception like

```
java.lang.NullPointerException: Cannot invoke "hudson.model.Run.getRootDir()" because "this.run" is null
	at PluginClassLoader for junit//hudson.tasks.junit.TestResultAction.getDataFilePath(TestResultAction.java:154)
	at PluginClassLoader for junit//hudson.tasks.junit.TestResultAction.loadCached(TestResultAction.java:317)
	at PluginClassLoader for junit//hudson.tasks.junit.TestResultAction.load(TestResultAction.java:279)
	at PluginClassLoader for junit//hudson.tasks.junit.TestResultAction.getResult(TestResultAction.java:166)
	at PluginClassLoader for junit//hudson.tasks.junit.TestResultAction.getResult(TestResultAction.java:70)
	at PluginClassLoader for junit//hudson.tasks.test.AbstractTestResultAction.findCorrespondingResult(AbstractTestResultAction.java:286)
	at PluginClassLoader for junit//hudson.tasks.test.TestResult.getPreviousResult(TestResult.java:146)
	at PluginClassLoader for junit//hudson.tasks.junit.TestResult.getPreviousResult(TestResult.java:467)
	at PluginClassLoader for junit//hudson.tasks.junit.CaseResult.getPreviousResult(CaseResult.java:768)
	at PluginClassLoader for junit//hudson.tasks.junit.CaseResult.recomputeFailedSinceIfNeeded(CaseResult.java:669)
	at PluginClassLoader for junit//hudson.tasks.junit.CaseResult.freeze(CaseResult.java:950)
	at PluginClassLoader for junit//hudson.tasks.junit.SuiteResult.freeze(SuiteResult.java:730)
	at PluginClassLoader for junit//hudson.tasks.junit.TestResult.freeze(TestResult.java:1119)
	at PluginClassLoader for junit//hudson.tasks.junit.TestResultAction.setResult(TestResultAction.java:125)
	at PluginClassLoader for junit//hudson.tasks.junit.TestResultAction.<init>(TestResultAction.java:96)
	at PluginClassLoader for junit//hudson.tasks.junit.JUnitResultArchiver.parseAndSummarize(JUnitResultArchiver.java:301)
	at PluginClassLoader for junit//hudson.tasks.junit.pipeline.JUnitResultsStepExecution.run(JUnitResultsStepExecution.java:62)
	at PluginClassLoader for junit//hudson.tasks.junit.pipeline.JUnitResultsStepExecution.run(JUnitResultsStepExecution.java:27)
	at PluginClassLoader for workflow-step-api//org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

While the root cause for such corruption is still to be identified, the plugin should defend against that condition and ignore such a build.

Similar to https://github.com/jenkinsci/parallel-test-executor-plugin/pull/282

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
