### PR TITLE
[JENKINS-73943] Remove legacy `checkUrl` usage in AggregatedTestResutPublisher/config.jelly

### DIFF
--- a/src/main/java/hudson/tasks/test/AggregatedTestResultPublisher.java
+++ b/src/main/java/hudson/tasks/test/AggregatedTestResultPublisher.java
@@ -370,7 +370,7 @@ public class AggregatedTestResultPublisher extends Recorder {
             return Messages.AggregatedTestResultPublisher_DisplayName();
         }
 
-        public FormValidation doCheck(@AncestorInPath AbstractProject project, @QueryParameter String value) {
+        public FormValidation doCheckJobs(@AncestorInPath AbstractProject project, @QueryParameter String value) {
             // Require CONFIGURE permission on this project
             if (!project.hasPermission(Item.CONFIGURE)) {
                 return FormValidation.ok();

--- a/src/main/resources/hudson/tasks/test/AggregatedTestResultPublisher/config.jelly
+++ b/src/main/resources/hudson/tasks/test/AggregatedTestResultPublisher/config.jelly
@@ -34,7 +34,6 @@ THE SOFTWARE.
         <f:entry title="${%Jobs to aggregate}"
                  help="/descriptorByName/hudson.tasks.test.AggregatedTestResultPublisher/help/manual-list">
           <f:textbox name="aggregatedTestResult.jobs" value="${instance.jobs}"
-                     checkUrl="'descriptorByName/hudson.tasks.test.AggregatedTestResultPublisher/check?value='+encodeURIComponent(this.value)"
                      field="jobs"
                      autoCompleteDelimChar="," />
         </f:entry>        


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-73943

I've renamed the check method and dropped `checkUrl` attribute completely to let https://github.com/jenkinsci/jenkins/blob/dc4ad7e1a872e6dd9504f6c1ff1f95d84ca6046b/core/src/main/java/hudson/util/FormValidation.java#L625-L727 do its magic and wire things up for us. 
While `doCheck` sounded generic to me I found no places in code referencing it, so I assume it's safe to rename.

### Testing done

https://www.loom.com/share/27c91cc2a4d9480c867ed7cca651bd77?sid=ad8da66b-e52e-4e6e-bfc1-3b9525fb384d

https://www.loom.com/share/aaca1ff0b6274d44a102257baacc9fd9?sid=c8d997ed-11d7-4165-825c-ce5d2defcee7

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
