### PR TITLE
Replace tango icon with modern symbol for history link

### DIFF
--- a/src/main/resources/hudson/tasks/test/TestObject/sidepanel.jelly
+++ b/src/main/resources/hudson/tasks/test/TestObject/sidepanel.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
       <j:set var="buildUrl" value="${h.decompose(request)}" />
       <j:set var="baseUrl" value="${request.findAncestor(it).relativePath}"/>
       <st:include it="${it.run}" page="tasks.jelly" optional="true"/>
-      <l:task href="${baseUrl}/history" icon="icon-graph icon-md" title="${%History}"/>
+      <l:task href="${baseUrl}/history" icon="symbol-bar-chart-outline plugin-ionicons-api" title="${%History}"/>
       <st:include it="${it.run}" page="actions.jelly" optional="true" />
 
       <t:actions actions="${it.testActions}" />


### PR DESCRIPTION
Replace tango icon with modern symbol for history link

**Before**

![history_before](https://github.com/user-attachments/assets/2bd9970c-d4dc-46fd-9afc-aa5c09d2011d)

After

![history_after](https://github.com/user-attachments/assets/587ee6b7-eb17-438f-9e9a-d27cc73ac665)

### Testing done

Visual. See screenhost.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
