### PR TITLE
Brackets fix for all failed tests sections

### DIFF
--- a/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
+++ b/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
@@ -40,14 +40,15 @@ THE SOFTWARE.
       </thead>
       <j:forEach var="f" items="${it.failedTests}" varStatus="i">
         <tr>
-          <td class="pane no-wrap">
-            <t:failed-test result="${f}">
-              <j:invokeStatic var="encodedRelativePath" className="hudson.Util" method="rawEncode">
-                <j:arg value="${f.getRelativePathFrom(it)}" />
-              </j:invokeStatic>
-              <a href="${encodedRelativePath}">${f.name}</a>
-            </t:failed-test>
-          </td>
+          <!-- Temporarily replace slashes to prevent rawEncode from encoding them. -->
+          <j:set var="tempPath" value="${f.getRelativePathFrom(it).replace('/', '__SLASH__')}" />
+          <j:set var="rawEncodedPath">
+            <j:invokeStatic className="hudson.Util" method="rawEncode">
+              <j:arg value="${tempPath}" />
+            </j:invokeStatic>
+          </j:set>
+          <j:set var="encodedRelativePath" value="${rawEncodedPath.replace('__SLASH__', '/')}" />        
+          <td class="pane no-wrap"><t:failed-test result="${f}" url="${encodedRelativePath}"/></td>
           <td class="pane no-wrap" style="text-align:right;" data="${f.duration}">
             ${f.durationString}
           </td>

--- a/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
+++ b/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
@@ -40,11 +40,14 @@ THE SOFTWARE.
       </thead>
       <j:forEach var="f" items="${it.failedTests}" varStatus="i">
         <tr>
-          <j:set var="rawPath" value="${f.getRelativePathFrom(it)}" />
-          <j:set var="encodedRelativePath">
-              ${rawPath.replace('[', '%5B').replace(']', '%5D')}
-          </j:set>
-          <td class="pane no-wrap"><t:failed-test result="${f}" url="${encodedRelativePath}"/></td>
+          <td class="pane no-wrap">
+            <t:failed-test result="${f}">
+              <j:invokeStatic var="encodedRelativePath" className="hudson.Util" method="encodeEachPathComponent">
+                <j:arg value="${f.getRelativePathFrom(it)}" />
+              </j:invokeStatic>
+              <a href="${encodedRelativePath}">${f.name}</a>
+            </t:failed-test>
+          </td>
           <td class="pane no-wrap" style="text-align:right;" data="${f.duration}">
             ${f.durationString}
           </td>

--- a/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
+++ b/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
@@ -40,7 +40,11 @@ THE SOFTWARE.
       </thead>
       <j:forEach var="f" items="${it.failedTests}" varStatus="i">
         <tr>
-          <td class="pane no-wrap"><t:failed-test result="${f}" url="${f.getRelativePathFrom(it)}"/></td>
+          <j:set var="rawPath" value="${f.getRelativePathFrom(it)}" />
+          <j:set var="encodedRelativePath">
+              ${rawPath.replace('[', '%5B').replace(']', '%5D')}
+          </j:set>
+          <td class="pane no-wrap"><t:failed-test result="${f}" url="${encodedRelativePath}"/></td>
           <td class="pane no-wrap" style="text-align:right;" data="${f.duration}">
             ${f.durationString}
           </td>

--- a/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
+++ b/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
@@ -42,7 +42,7 @@ THE SOFTWARE.
         <tr>
           <td class="pane no-wrap">
             <t:failed-test result="${f}">
-              <j:invokeStatic var="encodedRelativePath" className="hudson.Util" method="encodeEachPathComponent">
+              <j:invokeStatic var="encodedRelativePath" className="hudson.Util" method="rawEncode">
                 <j:arg value="${f.getRelativePathFrom(it)}" />
               </j:invokeStatic>
               <a href="${encodedRelativePath}">${f.name}</a>

--- a/src/main/resources/hudson/tasks/test/TestObject/sidepanel.jelly
+++ b/src/main/resources/hudson/tasks/test/TestObject/sidepanel.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
       <j:set var="buildUrl" value="${h.decompose(request)}" />
       <j:set var="baseUrl" value="${request.findAncestor(it).relativePath}"/>
       <st:include it="${it.run}" page="tasks.jelly" optional="true"/>
-      <l:task href="${baseUrl}/history" icon="icon-graph icon-md" title="${%History}"/>
+      <l:task href="${baseUrl}/history" icon="symbol-bar-chart-outline plugin-ionicons-api" title="${%History}"/>
       <st:include it="${it.run}" page="actions.jelly" optional="true" />
 
       <t:actions actions="${it.testActions}" />

--- a/src/test/resources/hudson/tasks/test/TrivialTestResult/body.jelly
+++ b/src/test/resources/hudson/tasks/test/TrivialTestResult/body.jelly
@@ -37,27 +37,22 @@ THE SOFTWARE.
       <j:forEach var="f" items="${it.failedTests}" varStatus="i">
         <tr>
           <td class="pane">
-          <j:set var="rawPath" value="${f.getRelativePathFrom(it)}" />
-          <j:set var="encodedRelativePath">
-              ${rawPath.replace('[', '%5B').replace(']', '%5D')}
-          </j:set>
-			<a id="test-${f.fullName}-showlink" href="#"
-				onclick='javascript:showStackTrace("test-${f.fullName}","${encodedRelativePath}/summary")'>&gt;&gt;&gt;</a>
-			<a id="test-${f.fullName}-hidelink" href="#" style="display:none"
-				onclick='javascript:hideStackTrace("test-${f.fullName}")'>&lt;&lt;&lt;</a>
-          	<st:nbsp/>
-            <j:set var="rawPath" value="${f.getRelativePathFrom(it)}" />
-            <j:set var="encodedRelativePath">
-                ${rawPath.replace('[', '%5B').replace(']', '%5D')}
-            </j:set>
+            <j:invokeStatic var="encodedRelativePath" className="hudson.Util" method="encodeEachPathComponent">
+              <j:arg value="${f.getRelativePathFrom(it)}" />
+            </j:invokeStatic>
+            <a id="test-${f.fullName}-showlink" href="#"
+              onclick='javascript:showStackTrace("test-${f.fullName}","${encodedRelativePath}/summary")'>&gt;&gt;&gt;</a>
+            <a id="test-${f.fullName}-hidelink" href="#" style="display:none"
+              onclick='javascript:hideStackTrace("test-${f.fullName}")'>&lt;&lt;&lt;</a>
+            <st:nbsp/>
             <a href="${encodedRelativePath}"><st:out value="${f.fullName}"/></a>
-          	<st:nbsp/>
-	        <j:forEach var="badge" items="${f.testActions}">
-	          <st:include it="${badge}" page="badge.jelly" optional="true"/>
-	        </j:forEach>
-			<div id="test-${f.fullName}" class="hidden" style="display:none">
-			${%Loading...}
-			</div>
+            <st:nbsp/>
+            <j:forEach var="badge" items="${f.testActions}">
+              <st:include it="${badge}" page="badge.jelly" optional="true"/>
+            </j:forEach>
+            <div id="test-${f.fullName}" class="hidden" style="display:none">
+              ${%Loading...}
+            </div>
           </td>
 
           <td class="pane" style="text-align:right;">

--- a/src/test/resources/hudson/tasks/test/TrivialTestResult/body.jelly
+++ b/src/test/resources/hudson/tasks/test/TrivialTestResult/body.jelly
@@ -37,9 +37,14 @@ THE SOFTWARE.
       <j:forEach var="f" items="${it.failedTests}" varStatus="i">
         <tr>
           <td class="pane">
-            <j:invokeStatic var="encodedRelativePath" className="hudson.Util" method="rawEncode">
-              <j:arg value="${f.getRelativePathFrom(it)}" />
-            </j:invokeStatic>
+            <!-- Temporarily replace slashes to prevent rawEncode from encoding them. -->
+            <j:set var="tempPath" value="${f.getRelativePathFrom(it).replace('/', '__SLASH__')}" />
+            <j:set var="rawEncodedPath">
+              <j:invokeStatic className="hudson.Util" method="rawEncode">
+                <j:arg value="${tempPath}" />
+              </j:invokeStatic>
+            </j:set>
+            <j:set var="encodedRelativePath" value="${rawEncodedPath.replace('__SLASH__', '/')}" />
             <a id="test-${f.fullName}-showlink" href="#"
               onclick='javascript:showStackTrace("test-${f.fullName}","${encodedRelativePath}/summary")'>&gt;&gt;&gt;</a>
             <a id="test-${f.fullName}-hidelink" href="#" style="display:none"

--- a/src/test/resources/hudson/tasks/test/TrivialTestResult/body.jelly
+++ b/src/test/resources/hudson/tasks/test/TrivialTestResult/body.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
       <j:forEach var="f" items="${it.failedTests}" varStatus="i">
         <tr>
           <td class="pane">
-            <j:invokeStatic var="encodedRelativePath" className="hudson.Util" method="encodeEachPathComponent">
+            <j:invokeStatic var="encodedRelativePath" className="hudson.Util" method="rawEncode">
               <j:arg value="${f.getRelativePathFrom(it)}" />
             </j:invokeStatic>
             <a id="test-${f.fullName}-showlink" href="#"

--- a/src/test/resources/hudson/tasks/test/TrivialTestResult/body.jelly
+++ b/src/test/resources/hudson/tasks/test/TrivialTestResult/body.jelly
@@ -37,12 +37,20 @@ THE SOFTWARE.
       <j:forEach var="f" items="${it.failedTests}" varStatus="i">
         <tr>
           <td class="pane">
+          <j:set var="rawPath" value="${f.getRelativePathFrom(it)}" />
+          <j:set var="encodedRelativePath">
+              ${rawPath.replace('[', '%5B').replace(']', '%5D')}
+          </j:set>
 			<a id="test-${f.fullName}-showlink" href="#"
-				onclick='javascript:showStackTrace("test-${f.fullName}","${f.getRelativePathFrom(it)}/summary")'>&gt;&gt;&gt;</a>
+				onclick='javascript:showStackTrace("test-${f.fullName}","${encodedRelativePath}/summary")'>&gt;&gt;&gt;</a>
 			<a id="test-${f.fullName}-hidelink" href="#" style="display:none"
 				onclick='javascript:hideStackTrace("test-${f.fullName}")'>&lt;&lt;&lt;</a>
           	<st:nbsp/>
-            <a href="${f.getRelativePathFrom(it)}"><st:out value="${f.fullName}"/></a>
+            <j:set var="rawPath" value="${f.getRelativePathFrom(it)}" />
+            <j:set var="encodedRelativePath">
+                ${rawPath.replace('[', '%5B').replace(']', '%5D')}
+            </j:set>
+            <a href="${encodedRelativePath}"><st:out value="${f.fullName}"/></a>
           	<st:nbsp/>
 	        <j:forEach var="badge" items="${f.testActions}">
 	          <st:include it="${badge}" page="badge.jelly" optional="true"/>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done through Jenkins: [https://ci.jenkins.io/job/Plugins/job/junit-plugin/job/PR-664/](https://ci.jenkins.io/job/Plugins/job/junit-plugin/job/PR-664/)

After the fix implemented in [PR #661](https://github.com/jenkinsci/junit-plugin/pull/661), the "All Failed Tests" sections continued to fail due to the lack of percent-encoding for square brackets specifically.

This PR addresses and resolves the issue.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
