### PR TITLE
Migrate from EE 8 to EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.7</version>
     <relativePath />
   </parent>
 
@@ -32,8 +32,8 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.baseline>2.414</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>2982.vdce2153031a_0</version>
+        <version>3850.vb_c5319efa_e29</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -682,7 +682,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     public Run<?, ?> getFailedSinceRun() {
         JunitTestResultStorage storage = JunitTestResultStorage.find();
         if (!(storage instanceof FileJunitTestResultStorage)) {
-            Run<?, ?> run = Stapler.getCurrentRequest().findAncestorObject(Run.class);
+            Run<?, ?> run = Stapler.getCurrentRequest2().findAncestorObject(Run.class);
             TestResultImpl pluggableStorage = storage.load(run.getParent().getFullName(), run.getNumber());
             return pluggableStorage.getFailedSinceRun(this);
         }

--- a/src/main/java/hudson/tasks/junit/ClassResult.java
+++ b/src/main/java/hudson/tasks/junit/ClassResult.java
@@ -30,8 +30,8 @@ import hudson.tasks.test.TestResult;
 import java.util.Collection;
 import java.util.Set;
 import java.util.TreeSet;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.export.Exported;
 
 /**
@@ -141,7 +141,7 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
     }
 
     @Override
-    public Object getDynamic(String name, StaplerRequest req, StaplerResponse rsp) {
+    public Object getDynamic(String name, StaplerRequest2 req, StaplerResponse2 rsp) {
         CaseResult c = getCaseResult(name);
         if (c != null) {
             return c;

--- a/src/main/java/hudson/tasks/junit/PackageResult.java
+++ b/src/main/java/hudson/tasks/junit/PackageResult.java
@@ -33,8 +33,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.export.Exported;
 
 /**
@@ -162,7 +162,7 @@ public final class PackageResult extends MetaTabulatedResult implements Comparab
     }
 
     @Override
-    public Object getDynamic(String name, StaplerRequest req, StaplerResponse rsp) {
+    public Object getDynamic(String name, StaplerRequest2 req, StaplerResponse2 rsp) {
         ClassResult result = getClassResult(name);
         if (result != null) {
             return result;

--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -60,8 +60,8 @@ import javax.xml.stream.XMLStreamReader;
 import jenkins.util.SystemProperties;
 import org.apache.tools.ant.DirectoryScanner;
 import org.dom4j.DocumentException;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.export.Exported;
 
 /**
@@ -951,7 +951,7 @@ public final class TestResult extends MetaTabulatedResult {
     }
 
     @Override
-    public Object getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
+    public Object getDynamic(String token, StaplerRequest2 req, StaplerResponse2 rsp) {
         if (token.equals(getId())) {
             return this;
         }

--- a/src/main/java/hudson/tasks/test/AggregatedTestResultPublisher.java
+++ b/src/main/java/hudson/tasks/test/AggregatedTestResultPublisher.java
@@ -59,7 +59,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * Aggregates downstream test reports into a single consolidated report,
@@ -389,9 +389,10 @@ public class AggregatedTestResultPublisher extends Recorder {
         }
 
         @Override
-        public AggregatedTestResultPublisher newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public AggregatedTestResultPublisher newInstance(StaplerRequest2 req, JSONObject formData)
+                throws FormException {
             // Starting in 1.640, Descriptor#newInstance is
-            // newInstance(@CheckForNull StaplerRequest req, @NonNull JSONObject formData)
+            // newInstance(@CheckForNull StaplerRequest2 req, @NonNull JSONObject formData)
             if (formData == null) {
                 // Should not happen. See above
                 throw new AssertionError("Null parameters to Descriptor#newInstance");

--- a/src/main/java/hudson/tasks/test/TestObject.java
+++ b/src/main/java/hudson/tasks/test/TestObject.java
@@ -51,8 +51,8 @@ import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -188,7 +188,7 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
             buf.insert(0, myBuild.getUrl());
 
             // If we're inside a stapler request, just delegate to Hudson.Functions to get the relative path!
-            StaplerRequest req = Stapler.getCurrentRequest();
+            StaplerRequest2 req = Stapler.getCurrentRequest2();
             if (req != null && myBuild instanceof Item) {
                 buf.insert(0, '/');
                 // Ugly but I don't see how else to convince the compiler that myBuild is an Item
@@ -227,7 +227,7 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
         if (owner != null) {
             return owner.getAction(AbstractTestResultAction.class);
         } else {
-            Run<?, ?> run = Stapler.getCurrentRequest().findAncestorObject(Run.class);
+            Run<?, ?> run = Stapler.getCurrentRequest2().findAncestorObject(Run.class);
             if (run != null) {
                 return run.getAction(AbstractTestResultAction.class);
             }
@@ -462,7 +462,7 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
         return new History(this);
     }
 
-    public Object getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
+    public Object getDynamic(String token, StaplerRequest2 req, StaplerResponse2 rsp) {
         for (Action a : getTestActions()) {
             if (a == null) {
                 continue; // be defensive

--- a/src/main/java/hudson/tasks/test/TestResultProjectAction.java
+++ b/src/main/java/hudson/tasks/test/TestResultProjectAction.java
@@ -38,13 +38,15 @@ import io.jenkins.plugins.echarts.AsyncTrendChart;
 import io.jenkins.plugins.junit.storage.FileJunitTestResultStorage;
 import io.jenkins.plugins.junit.storage.JunitTestResultStorage;
 import io.jenkins.plugins.junit.storage.TestResultImpl;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
 
 /**
@@ -198,7 +200,7 @@ public class TestResultProjectAction implements Action, AsyncTrendChart, AsyncCo
     /**
      * Changes the test result report display mode.
      */
-    public void doFlipTrend(final StaplerRequest req, final StaplerResponse rsp) throws IOException {
+    public void doFlipTrend(final StaplerRequest2 req, final StaplerResponse2 rsp) throws IOException {
         boolean failureOnly = false;
 
         // check the current preference value

--- a/src/main/java/io/jenkins/plugins/junit/storage/JunitTestResultStorageConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/junit/storage/JunitTestResultStorageConfiguration.java
@@ -10,7 +10,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 @Extension
 @Restricted(Beta.class)
@@ -34,7 +34,7 @@ public class JunitTestResultStorageConfiguration extends GlobalConfiguration {
     }
 
     @Override
-    public boolean configure(StaplerRequest req, JSONObject json) {
+    public boolean configure(StaplerRequest2 req, JSONObject json) {
         req.bindJSON(this, json);
         save();
         return true;

--- a/src/main/resources/hudson/tasks/junit/History/index.jelly
+++ b/src/main/resources/hudson/tasks/junit/History/index.jelly
@@ -26,10 +26,10 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:bs="/bootstrap5" xmlns:c="/charts" xmlns:f="/lib/form">
   <bs:layout title="${%title(it.testObject.displayName)}">
-    <j:set var="count" value="${it.asInt(request.getParameter('count'),100)}"/>
-    <j:set var="start" value="${it.asInt(request.getParameter('start'),0)}"/>
-    <j:set var="end" value="${it.asInt(request.getParameter('end'),start+count-1)}"/>
-    <j:set var="interval" value="${it.asInt(request.getParameter('interval'),1)}"/>
+    <j:set var="count" value="${it.asInt(request2.getParameter('count'),100)}"/>
+    <j:set var="start" value="${it.asInt(request2.getParameter('start'),0)}"/>
+    <j:set var="end" value="${it.asInt(request2.getParameter('end'),start+count-1)}"/>
+    <j:set var="interval" value="${it.asInt(request2.getParameter('interval'),1)}"/>
     <j:set var="historySummary" value="${it.retrieveHistorySummary(start, end, interval)}"/>
     <st:adjunct includes="io.jenkins.plugins.echarts"/>
     <st:adjunct includes="io.jenkins.plugins.bootstrap5"/>

--- a/src/main/resources/hudson/tasks/test/TestObject/sidepanel.jelly
+++ b/src/main/resources/hudson/tasks/test/TestObject/sidepanel.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
   <l:side-panel>
     <l:tasks>
       <j:set var="buildUrl" value="${h.decompose(request)}" />
-      <j:set var="baseUrl" value="${request.findAncestor(it).relativePath}"/>
+      <j:set var="baseUrl" value="${request2.findAncestor(it).relativePath}"/>
       <st:include it="${it.run}" page="tasks.jelly" optional="true"/>
       <l:task href="${baseUrl}/history" icon="symbol-bar-chart-outline plugin-ionicons-api" title="${%History}"/>
       <st:include it="${it.run}" page="actions.jelly" optional="true" />

--- a/src/main/resources/hudson/tasks/test/TestResultProjectAction/index.jelly
+++ b/src/main/resources/hudson/tasks/test/TestResultProjectAction/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" it="${it.job}" />
     <l:main-panel>
       <div>
-        <img src="trend?${request.queryString}" lazymap="trendMap?rel=../&amp;${request.queryString}" alt="[Test result trend chart]"/>
+        <img src="trend?${request2.queryString}" lazymap="trendMap?rel=../&amp;${request2.queryString}" alt="[Test result trend chart]"/>
       </div>
     </l:main-panel>
   </l:layout>

--- a/src/test/java/io/jenkins/plugins/junit/storage/benchmarks/TrendGraphBenchmark.java
+++ b/src/test/java/io/jenkins/plugins/junit/storage/benchmarks/TrendGraphBenchmark.java
@@ -49,8 +49,7 @@ public class TrendGraphBenchmark {
             System.out.println("Next build number: " + lastJob.getNextBuildNumber());
         }
 
-        private void createLotsOfRuns(String jobName, int runCount)
-                throws java.io.IOException, InterruptedException, ExecutionException {
+        private void createLotsOfRuns(String jobName, int runCount) throws Exception {
             Jenkins jenkins = Jenkins.get();
             lastJob = jenkins.createProject(WorkflowJob.class, jobName);
             lastJob.setDefinition(new CpsFlowDefinition(SIMPLE_TEST_RESULT, true));


### PR DESCRIPTION
Migrate from EE 8 to EE 9, at least in non-deprecated methods. This was tested with BOM/PCT.