### PR TITLE
Reuse title information as summary

### DIFF
--- a/src/main/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisher.java
@@ -44,9 +44,10 @@ public class JUnitChecksPublisher {
     @VisibleForTesting
     ChecksDetails extractChecksDetails() {
         String testsURL = DisplayURLProvider.get().getTestsURL(run);
+        String resultDetails = extractChecksTitle()
         ChecksOutput output = new ChecksOutput.ChecksOutputBuilder()
-                .withTitle(extractChecksTitle())
-                .withSummary(extractChecksTitle())
+                .withTitle(resultDetails)
+                .withSummary(resultDetails)
                 .withText(extractChecksText(testsURL))
                 .build();
 

--- a/src/main/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisher.java
@@ -44,7 +44,7 @@ public class JUnitChecksPublisher {
     @VisibleForTesting
     ChecksDetails extractChecksDetails() {
         String testsURL = DisplayURLProvider.get().getTestsURL(run);
-        String resultDetails = extractChecksTitle()
+        String resultDetails = extractChecksTitle();
         ChecksOutput output = new ChecksOutput.ChecksOutputBuilder()
                 .withTitle(resultDetails)
                 .withSummary(resultDetails)

--- a/src/main/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisher.java
@@ -46,7 +46,7 @@ public class JUnitChecksPublisher {
         String testsURL = DisplayURLProvider.get().getTestsURL(run);
         ChecksOutput output = new ChecksOutput.ChecksOutputBuilder()
                 .withTitle(extractChecksTitle())
-                .withSummary("<sub>Send us [feedback](https://github.com/jenkinsci/junit-plugin/issues)")
+                .withSummary(extractChecksTitle())
                 .withText(extractChecksText(testsURL))
                 .build();
 

--- a/src/test/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisherTest.java
+++ b/src/test/java/io/jenkins/plugins/junit/checks/JUnitChecksPublisherTest.java
@@ -70,6 +70,7 @@ public class JUnitChecksPublisherTest {
         ChecksOutput output = checksDetails.getOutput().get();
 
         assertThat(output.getTitle().get(), is("passed: 6"));
+        assertThat(output.getSummary().get(), is("passed: 6"));
         assertThat(output.getText().get(), is(""));
     }
 
@@ -98,6 +99,7 @@ public class JUnitChecksPublisherTest {
         ChecksOutput output = checksDetails.getOutput().get();
 
         assertThat(output.getTitle().get(), is("some.package.somewhere.WhooHoo.testHudsonReporting failed"));
+        assertThat(output.getSummary().get(), is("some.package.somewhere.WhooHoo.testHudsonReporting failed"));
     }
 
     @Test
@@ -125,6 +127,7 @@ public class JUnitChecksPublisherTest {
         ChecksOutput output = checksDetails.getOutput().get();
 
         assertThat(output.getTitle().get(), is("failed: 3, passed: 5"));
+        assertThat(output.getSummary().get(), is("failed: 3, passed: 5"));
     }
 
     @Test


### PR DESCRIPTION
These changes remove the hard-coded summary that links to the repository issue page.
I had a peak on how the `xunit` plugin provides such [status check details](https://github.com/jenkinsci/xunit-plugin/blob/4bf589c23c09a1988cf3e641e48d3251563814ac/src/main/java/org/jenkinsci/plugins/xunit/XUnitChecksPublisher.java#L85-L86).
They split test result details from overall summary.

Unfortunately, `github-checks-plugin` and `gitea-checks-plugin` seem to use different parts of the provided status check information. That's why every test report on any Jenkins plugin already has the `passed: xyz` as status check details.
Gitea seems to receive the static repo issue "fallback" instead.
So, splitting the currently provided information like `xunit` does it would probably be a somewhat breaking change.
That's why I simply reused the text provided as "Title".

Resolves https://github.com/jenkinsci/junit-plugin/issues/674

### Testing done

- Unit test execution via `mvn clean verify`
- Plugin usage in Jenkins, screenshots below for different behaviors

Single failing test:
![image](https://github.com/user-attachments/assets/822cf06f-33f3-472e-b1ea-effdf0269988)

Multiple failing tests:
![image](https://github.com/user-attachments/assets/747ac651-7441-4068-8168-ec4044dc207f)

All passing tests:
![image](https://github.com/user-attachments/assets/22af1fe5-72e0-4eb1-a7bc-3f21b618eb45)

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
