### PR TITLE
Remove 'pane-header' class usage

### DIFF
--- a/src/main/resources/hudson/tasks/junit/CaseResult/list.jelly
+++ b/src/main/resources/hudson/tasks/junit/CaseResult/list.jelly
@@ -30,10 +30,10 @@ THE SOFTWARE.
   <table class="jenkins-table sortable" id="testresult">
     <thead>
       <tr>
-        <th class="pane-header" style="width:10em">${%Build}</th>
-        <th class="pane-header" style="width:10em">${%Test Description}</th>
-        <th class="pane-header" style="width:5em">${%Test Duration}</th>
-        <th class="pane-header" style="width:5em">${%Test Result}</th>
+        <th style="width:10em">${%Build}</th>
+        <th style="width:10em">${%Test Description}</th>
+        <th style="width:5em">${%Test Duration}</th>
+        <th style="width:5em">${%Test Result}</th>
       </tr>
     </thead>
     <tbody>

--- a/src/main/resources/hudson/tasks/junit/ClassResult/body.jelly
+++ b/src/main/resources/hudson/tasks/junit/ClassResult/body.jelly
@@ -29,9 +29,9 @@ THE SOFTWARE.
     <table class="jenkins-table sortable" id="testresult">
       <thead>
         <tr>
-          <th class="pane-header">${%Test name}</th>
-          <th class="pane-header" style="width:6em">${%Duration}</th>
-          <th class="pane-header" style="width:6em">${%Status}</th>
+          <th>${%Test name}</th>
+          <th style="width:6em">${%Duration}</th>
+          <th style="width:6em">${%Status}</th>
           <j:forEach var="tableheader" items="${it.testActions}">
             <st:include it="${tableheader}" page="${it.childType}tableheader.jelly" optional="true"/>
           </j:forEach>

--- a/src/main/resources/hudson/tasks/junit/ClassResult/list.jelly
+++ b/src/main/resources/hudson/tasks/junit/ClassResult/list.jelly
@@ -27,12 +27,12 @@ THE SOFTWARE.
     <table class="jenkins-table sortable" id="testresult">
       <thead>
         <tr>
-          <th class="pane-header">${%Build}</th>
-          <th class="pane-header">${%Description}</th>
-          <th class="pane-header" style="width:5em; text-align:right;">${%Duration}</th>
-          <th class="pane-header" style="width:5em; text-align:right;">${%Fail}</th>
-          <th class="pane-header" style="width:5em; text-align:right;">${%Skip}</th>
-          <th class="pane-header" style="width:5em; text-align:right;">${%Total}</th>
+          <th>${%Build}</th>
+          <th>${%Description}</th>
+          <th style="width:5em; text-align:right;">${%Duration}</th>
+          <th style="width:5em; text-align:right;">${%Fail}</th>
+          <th style="width:5em; text-align:right;">${%Skip}</th>
+          <th style="width:5em; text-align:right;">${%Total}</th>
         </tr>
       </thead>
       <tbody>

--- a/src/main/resources/hudson/tasks/junit/History/index.jelly
+++ b/src/main/resources/hudson/tasks/junit/History/index.jelly
@@ -135,14 +135,14 @@ THE SOFTWARE.
       <table class="jenkins-table sortable" style="--table-padding: 5px;" id="testresult">
         <thead>
           <tr>
-            <th class="pane-header" style="text-align:center">${%Build}</th>
+            <th class="" style="text-align:center">${%Build}</th>
             <j:if test="${historySummary.descriptionAvailable}">
-              <th class="pane-header" style="text-align:center">${%Description}</th>
+              <th class="" style="text-align:center">${%Description}</th>
             </j:if>
-            <th class="pane-header" style="text-align:center">${%Duration}</th>
-            <th class="pane-header" style="text-align:center">${%Fail}</th>
-            <th class="pane-header" style="text-align:center">${%Skip}</th>
-            <th class="pane-header" style="text-align:center">${%Total}</th>
+            <th class="" style="text-align:center">${%Duration}</th>
+            <th class="" style="text-align:center">${%Fail}</th>
+            <th class="" style="text-align:center">${%Skip}</th>
+            <th class="" style="text-align:center">${%Total}</th>
           </tr>
         </thead>
         <tbody>

--- a/src/main/resources/hudson/tasks/junit/History/index.jelly
+++ b/src/main/resources/hudson/tasks/junit/History/index.jelly
@@ -135,14 +135,14 @@ THE SOFTWARE.
       <table class="jenkins-table sortable" style="--table-padding: 5px;" id="testresult">
         <thead>
           <tr>
-            <th class="" style="text-align:center">${%Build}</th>
+            <th style="text-align:center">${%Build}</th>
             <j:if test="${historySummary.descriptionAvailable}">
-              <th class="" style="text-align:center">${%Description}</th>
+              <th style="text-align:center">${%Description}</th>
             </j:if>
-            <th class="" style="text-align:center">${%Duration}</th>
-            <th class="" style="text-align:center">${%Fail}</th>
-            <th class="" style="text-align:center">${%Skip}</th>
-            <th class="" style="text-align:center">${%Total}</th>
+            <th style="text-align:center">${%Duration}</th>
+            <th style="text-align:center">${%Fail}</th>
+            <th style="text-align:center">${%Skip}</th>
+            <th style="text-align:center">${%Total}</th>
           </tr>
         </thead>
         <tbody>

--- a/src/main/resources/hudson/tasks/test/AggregatedTestResultPublisher/TestResultAction/index.jelly
+++ b/src/main/resources/hudson/tasks/test/AggregatedTestResultPublisher/TestResultAction/index.jelly
@@ -38,9 +38,9 @@ THE SOFTWARE.
           <table class="jenkins-table sortable">
             <thead>
               <tr>
-                <th class="pane-header">${%Test}</th>
-                <th class="pane-header" style="text-align:right">${%Fail}</th>
-                <th class="pane-header" style="text-align:right">${%Total}</th>
+                <th>${%Test}</th>
+                <th style="text-align:right">${%Fail}</th>
+                <th style="text-align:right">${%Total}</th>
               </tr>
             </thead>
             <j:forEach var="i" items="${it.individuals}">

--- a/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
+++ b/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
@@ -30,9 +30,9 @@ THE SOFTWARE.
     <table class="jenkins-table sortable" id="failedtestresult">
       <thead>
         <tr>
-          <th class="pane-header">${%Test Name}</th>
-          <th class="pane-header" style="width:4em">${%Duration}</th>
-          <th class="pane-header" style="width:3em">${%Age}</th>
+          <th>${%Test Name}</th>
+          <th style="width:4em">${%Duration}</th>
+          <th style="width:3em">${%Age}</th>
           <j:forEach var="tableheader" items="${it.testActions}">
             <st:include it="${tableheader}" page="casetableheader.jelly" optional="true"/>
           </j:forEach>
@@ -60,16 +60,16 @@ THE SOFTWARE.
     <table class="jenkins-table sortable" id="testresult">
       <thead>
         <tr>
-          <th class="pane-header">${it.childTitle}</th>
-          <th class="pane-header" style="width:5em; text-align:right">${%Duration}</th>
-          <th class="pane-header" style="width:5em; text-align:right">${%Fail}</th>
-          <th class="pane-header" style="width:3em; text-align:right; white-space:nowrap;">(${%diff})</th>
-          <th class="pane-header" style="width:5em; text-align:right">${%Skip}</th>
-          <th class="pane-header" style="width:3em; text-align:right; white-space:nowrap;">(${%diff})</th>
-          <th class="pane-header" style="width:5em; text-align:right">${%Pass}</th>
-          <th class="pane-header" style="width:3em; text-align:right; white-space:nowrap;">(${%diff})</th>
-          <th class="pane-header" style="width:5em; text-align:right">${%Total}</th>
-          <th class="pane-header" style="width:3em; text-align:right; white-space:nowrap;">(${%diff})</th>
+          <th>${it.childTitle}</th>
+          <th style="width:5em; text-align:right">${%Duration}</th>
+          <th style="width:5em; text-align:right">${%Fail}</th>
+          <th style="width:3em; text-align:right; white-space:nowrap;">(${%diff})</th>
+          <th style="width:5em; text-align:right">${%Skip}</th>
+          <th style="width:3em; text-align:right; white-space:nowrap;">(${%diff})</th>
+          <th style="width:5em; text-align:right">${%Pass}</th>
+          <th style="width:3em; text-align:right; white-space:nowrap;">(${%diff})</th>
+          <th style="width:5em; text-align:right">${%Total}</th>
+          <th style="width:3em; text-align:right; white-space:nowrap;">(${%diff})</th>
           <j:forEach var="tableheader" items="${it.testActions}">
             <st:include it="${tableheader}" page="${it.childType}tableheader.jelly" optional="true"/>
           </j:forEach>

--- a/src/main/resources/hudson/tasks/test/MetaTabulatedResult/list.jelly
+++ b/src/main/resources/hudson/tasks/test/MetaTabulatedResult/list.jelly
@@ -27,12 +27,12 @@ THE SOFTWARE.
     <table class="jenkins-table sortable" id="testresult">
       <thead>
           <tr>
-            <th class="pane-header">${%Build}</th>
-            <th class="pane-header">${%Description}</th>
-            <th class="pane-header" style="width:5em; text-align:right">${%Duration}</th>
-            <th class="pane-header" style="width:5em; text-align:right">${%Fail}</th>
-            <th class="pane-header" style="width:5em; text-align:right">${%Skip}</th>
-            <th class="pane-header" style="width:5em; text-align:right">${%Total}</th>
+            <th>${%Build}</th>
+            <th>${%Description}</th>
+            <th style="width:5em; text-align:right">${%Duration}</th>
+            <th style="width:5em; text-align:right">${%Fail}</th>
+            <th style="width:5em; text-align:right">${%Skip}</th>
+            <th style="width:5em; text-align:right">${%Total}</th>
           </tr>
       </thead>
       <tbody>

--- a/src/main/resources/lib/hudson/test/aggregated-failed-tests.jelly
+++ b/src/main/resources/lib/hudson/test/aggregated-failed-tests.jelly
@@ -47,9 +47,9 @@ THE SOFTWARE.
         <table class="jenkins-table sortable">
           <thead>
             <tr>
-              <th class="pane-header">Test Name</th>
-              <th class="pane-header" style="width:4em; text-align:right;">Duration</th>
-              <th class="pane-header" style="width:4em; text-align:right;">Age</th>
+              <th>Test Name</th>
+              <th style="width:4em; text-align:right;">Duration</th>
+              <th style="width:4em; text-align:right;">Age</th>
             </tr>
           </thead>
           <j:forEach var="f" items="${report.result.failedTests}" varStatus="i">


### PR DESCRIPTION
This PR removes the usage of the 'pane-header' class. The class isn't needed, and it currently causes weird visuals in different themes:

<img width="860" alt="image" src="https://github.com/user-attachments/assets/b5b3287a-ecea-47ab-82e1-06894dc2d9d6" />

### Testing done

* Tables look as expected

<img width="645" alt="image" src="https://github.com/user-attachments/assets/243d2c43-541f-405a-8e6c-dd304fbc1d38" />

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
