### PR TITLE
Prevent stdio trimming from creating invalid unicode data

### DIFF
--- a/src/test/java/hudson/tasks/junit/CaseResultTest.java
+++ b/src/test/java/hudson/tasks/junit/CaseResultTest.java
@@ -442,6 +442,23 @@ class CaseResultTest {
         assertEquals(0, cr.getProperties().size());
     }
 
+    /**
+     * Test truncation works along unicode codepoint boundaries.
+     */
+    @Test
+    void testCleanupTruncated() throws Exception {
+        // empty
+        assertEquals("", CaseResult.cleanupTruncated("").toString());
+        // ordinary
+        assertEquals("abc", CaseResult.cleanupTruncated("abc").toString());
+        // starts with a trail surrogate.
+        assertEquals("abc", CaseResult.cleanupTruncated("\uDC00abc").toString());
+        // ends with a lead surrogate.
+        assertEquals("abc", CaseResult.cleanupTruncated("abc\uD800").toString());
+        // starts with trail surrogate and ends with lead surrogate
+        assertEquals("abc", CaseResult.cleanupTruncated("\uDC00abc\uD800").toString());
+    }
+
     private String composeXPath(String[] fields) {
         StringBuilder tmp = new StringBuilder(100);
         for (String f : fields) {


### PR DESCRIPTION
`CaseResult.possiblyTrimStdio()` creates substrings according to UTF-16 (java `char`) boundaries. When stdio contains Unicode supplementary characters, this method can create unpaired surrogates by splitting a single unicode character "in half". Such strings can't be converted to UTF-8 and cause build failures:

```
FATAL: Failed to save the JUnit test result
java.io.IOException: java.lang.RuntimeException: Failed to serialize hudson.tasks.junit.TestResult#suites for class hudson.tasks.junit.TestResult
Caused by: java.lang.RuntimeException: Failed to serialize hudson.tasks.junit.TestResult#suites for class hudson.tasks.junit.TestResult
Caused by: java.lang.RuntimeException: Failed to serialize hudson.tasks.junit.SuiteResult#stderr for class hudson.tasks.junit.SuiteResult
Caused by: [com.thoughtworks.xstream.io](http://com.thoughtworks.xstream.io/).StreamException: Invalid character 0xd83a in XML stream
```

Fix trimming to remove unpaired trailing (low) surrogates at the beginning of truncated strings and unpaired leading (high) surrogates at the end of truncated strings.

We're hitting this bug over at Apache Jenkins every once in a while: in the Lucene project our tests exercise a lot of Unicode functionality due to the nature of the software.