### PR TITLE
Fix expand single failure

### DIFF
--- a/src/main/resources/lib/hudson/test/js/failureSummary.js
+++ b/src/main/resources/lib/hudson/test/js/failureSummary.js
@@ -43,7 +43,9 @@ function handleShowHideClick(event) {
     const id = link.id.replace(/-showlink$/, '').replace(/-hidelink$/, '');
 
     if (link.id.endsWith('-showlink')) {
-        showFailureSummary(id, document.URL + id.replace(PREFIX, '') + "summary");
+        // Remove any queries from URL
+        const baseUrl = document.URL.split('?')[0];
+        showFailureSummary(id, baseUrl + id.replace(PREFIX, '') + "summary");
     } else {
         hideFailureSummary(id);
     }

--- a/src/main/resources/lib/hudson/test/js/failureSummary.js
+++ b/src/main/resources/lib/hudson/test/js/failureSummary.js
@@ -43,9 +43,10 @@ function handleShowHideClick(event) {
     const id = link.id.replace(/-showlink$/, '').replace(/-hidelink$/, '');
 
     if (link.id.endsWith('-showlink')) {
-        // Remove any queries from URL
-        const baseUrl = document.URL.split('?')[0];
-        showFailureSummary(id, baseUrl + id.replace(PREFIX, '') + "summary");
+        // clear the query parameters
+        const cleanUrl = new URL(document.URL);
+        cleanUrl.search = "";
+        showFailureSummary(id, cleanUrl + id.replace(PREFIX, '') + "summary");
     } else {
         hideFailureSummary(id);
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Addresses https://github.com/jenkinsci/junit-plugin/issues/704
Removes any search parameter from the URL when showing test failures

### Testing done
Manual testing. Created job with failure report. Visited the test results page with a search query and then clicked on the failures.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
