### PR TITLE
Disable automatic test file validation

### DIFF
--- a/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
+++ b/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
@@ -35,7 +35,6 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
-import hudson.model.Item;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.Saveable;
@@ -59,7 +58,6 @@ import java.util.logging.Logger;
 import jenkins.tasks.SimpleBuildStep;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.types.FileSet;
-import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -544,22 +542,6 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
         @Override
         public String getDisplayName() {
             return Messages.JUnitResultArchiver_DisplayName();
-        }
-
-        /**
-         * Performs on-the-fly validation on the file mask wildcard.
-         * @param project Project.
-         * @param value File mask to validate.
-         *
-         * @return the validation result.
-         * @throws IOException if an error occurs.
-         */
-        public FormValidation doCheckTestResults(@AncestorInPath AbstractProject project, @QueryParameter String value)
-                throws IOException {
-            if (project == null || !project.hasPermission(Item.WORKSPACE)) {
-                return FormValidation.ok();
-            }
-            return FilePath.validateFileMask(project.getSomeWorkspace(), value);
         }
 
         @Override


### PR DESCRIPTION
Automatic test file validation causes issues when workspaces have large O(millions) amount of files. In those cases, if the particular test file doesn't exist at the time the user looks at the configuration page, the Agent will start crawling the whole workspace looking for other subdirectories where that file might be.

By doing so, it's tracking all the files it's seen which eventually leads to filling up the heap and crashing.

This disables the automatic file validation.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
