### PR TITLE
Do not call `contributeTestData` with `WorkflowRun` lock held

### DIFF
--- a/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
+++ b/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
@@ -291,6 +291,15 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
                             task.isKeepTestNames())
                     .summarizeResult(testResults, build, pipelineTestDetails, workspace, launcher, listener, storage);
         }
+        var data = new ArrayList<TestResultAction.Data>();
+        if (task.getTestDataPublishers() != null) {
+            for (var tdp : task.getTestDataPublishers()) {
+                var d = tdp.contributeTestData(build, workspace, launcher, listener, result);
+                if (d != null) {
+                    data.add(d);
+                }
+            }
+        }
 
         synchronized (build) {
             // TODO can the build argument be omitted now, or is it used prior to the call to addAction?
@@ -320,14 +329,7 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
                 }
             }
 
-            if (task.getTestDataPublishers() != null) {
-                for (TestDataPublisher tdp : task.getTestDataPublishers()) {
-                    TestResultAction.Data d = tdp.contributeTestData(build, workspace, launcher, listener, result);
-                    if (d != null) {
-                        action.addData(d);
-                    }
-                }
-            }
+            data.forEach(action::addData);
 
             if (appending) {
                 build.save();


### PR DESCRIPTION
Observed in a CloudBees CI controller:

```
"org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution [#…] / waiting for JNLP4-connect connection from … id=…" Id=… Group=main TIMED_WAITING on hudson.remoting.UserRequest@…
	at java.base@21.0.8/java.lang.Object.wait0(Native Method)
	-  waiting on hudson.remoting.UserRequest@…
	at java.base@21.0.8/java.lang.Object.wait(Object.java:366)
	at hudson.remoting.Request.call(Request.java:179)
	at hudson.remoting.Channel.call(Channel.java:1107)
	at hudson.FilePath.act(FilePath.java:1204)
	at hudson.FilePath.act(FilePath.java:1193)
	at hudson.FilePath.copyTo(FilePath.java:2673)
	at hudson.FilePath.copyTo(FilePath.java:2626)
	at PluginClassLoader for junit-attachments//hudson.plugins.junitattachments.GetTestDataMethodObject.captureAttachment(GetTestDataMethodObject.java:249)
	at PluginClassLoader for junit-attachments//hudson.plugins.junitattachments.GetTestDataMethodObject.captureAttachment(GetTestDataMethodObject.java:228)
	at PluginClassLoader for junit-attachments//hudson.plugins.junitattachments.GetTestDataMethodObject.attachStdInAndOut(GetTestDataMethodObject.java:217)
	at PluginClassLoader for junit-attachments//hudson.plugins.junitattachments.GetTestDataMethodObject.getAttachments(GetTestDataMethodObject.java:112)
	at PluginClassLoader for junit-attachments//hudson.plugins.junitattachments.AttachmentPublisher.contributeTestData(AttachmentPublisher.java:79)
	at PluginClassLoader for junit-attachments//hudson.plugins.junitattachments.AttachmentPublisher.contributeTestData(AttachmentPublisher.java:30)
	at PluginClassLoader for junit//hudson.tasks.junit.JUnitResultArchiver.parseAndSummarize(JUnitResultArchiver.java:325)
	-  locked org.jenkinsci.plugins.workflow.job.WorkflowRun@…
	at PluginClassLoader for junit//hudson.tasks.junit.pipeline.JUnitResultsStepExecution.run(JUnitResultsStepExecution.java:62)
	at PluginClassLoader for junit//hudson.tasks.junit.pipeline.JUnitResultsStepExecution.run(JUnitResultsStepExecution.java:27)
	at PluginClassLoader for workflow-step-api//org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:49)
	at PluginClassLoader for workflow-step-api//org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$$Lambda/0x00007fb3bdcf1400.run(Unknown Source)
	at java.base@21.0.8/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
```

This in turn was blocking other threads from making progress:

```
"Running CpsFlowExecution[…]" Id=… Group=main BLOCKED on org.jenkinsci.plugins.workflow.job.WorkflowRun@… owned by "org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution [#…] / waiting for …" Id=…
	at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.save(WorkflowRun.java:1278)
	-  blocked on org.jenkinsci.plugins.workflow.job.WorkflowRun@…
	at hudson.BulkChange.commit(BulkChange.java:98)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1576)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$3.run(CpsThreadGroup.java:536)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService.lambda$wrap$2(CpsVmExecutorService.java:85)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$$Lambda/0x00007fb3bdcb0680.run(Unknown Source)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:139)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
	at jenkins.util.ErrorLoggingExecutorService.lambda$wrap$0(ErrorLoggingExecutorService.java:51)
	at jenkins.util.ErrorLoggingExecutorService$$Lambda/0x00007fb3bd5ceb28.run(Unknown Source)
	at java.base@21.0.8/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base@21.0.8/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base@21.0.8/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base@21.0.8/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$1.call(CpsVmExecutorService.java:53)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$1.call(CpsVmExecutorService.java:50)
	at org.codehaus.groovy.runtime.GroovyCategorySupport$ThreadCategoryInfo.use(GroovyCategorySupport.java:136)
	at org.codehaus.groovy.runtime.GroovyCategorySupport.use(GroovyCategorySupport.java:275)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService.lambda$categoryThreadFactory$0(CpsVmExecutorService.java:50)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$$Lambda/0x00007fb3bdcb08a8.run(Unknown Source)
```

and even preventing the controller from shutting down cleanly (though https://github.com/jenkinsci/workflow-cps-plugin/pull/1088 may also help):

```
"Thread-…" Id=… Group=main TIMED_WAITING on java.util.concurrent.CompletableFuture$Signaller@…
	at java.base@21.0.8/jdk.internal.misc.Unsafe.park(Native Method)
	-  waiting on java.util.concurrent.CompletableFuture$Signaller@…
	at java.base@21.0.8/java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:269)
	at java.base@21.0.8/java.util.concurrent.CompletableFuture$Signaller.block(CompletableFuture.java:1866)
	at java.base@21.0.8/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3780)
	at java.base@21.0.8/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3725)
	at java.base@21.0.8/java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1939)
	at java.base@21.0.8/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2095)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.suspendAll(CpsFlowExecution.java:1689)
	at java.base@21.0.8/java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(DirectMethodHandle$Holder)
	at java.base@21.0.8/java.lang.invoke.LambdaForm$MH/0x00007fb3beaff400.invoke(LambdaForm$MH)
	at java.base@21.0.8/java.lang.invoke.Invokers$Holder.invokeExact_MT(Invokers$Holder)
	at java.base@21.0.8/jdk.internal.reflect.DirectMethodHandleAccessor.invokeImpl(DirectMethodHandleAccessor.java:153)
	at java.base@21.0.8/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base@21.0.8/java.lang.reflect.Method.invoke(Method.java:580)
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:109)
	at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:185)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:304)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:221)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:120)
	at jenkins.model.Jenkins$$Lambda/0x00007fb3bea9bdb8.execute(Unknown Source)
	at org.jvnet.hudson.reactor.Reactor$Node.runIfPossible(Reactor.java:142)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:131)
	-  locked org.jvnet.hudson.reactor.Reactor@…
	at jenkins.model.Jenkins$$Lambda/0x00007fb3bea9bdb8.execute(Unknown Source)
	at org.jvnet.hudson.reactor.Reactor$Node.runIfPossible(Reactor.java:142)
	at org.jvnet.hudson.reactor.Reactor.execute(Reactor.java:284)
	-  locked org.jvnet.hudson.reactor.Reactor@…
	at jenkins.model.Jenkins._cleanUpRunTerminators(Jenkins.java:3726)
	at jenkins.model.Jenkins.cleanUp(Jenkins.java:3649)
	at hudson.WebAppMain._contextDestroyed(WebAppMain.java:430)
	at hudson.WebAppMain.contextDestroyed(WebAppMain.java:422)
```

So far as I can tell, this problem was introduced in #141, though I cannot tell what was calling `contributeTestData` before that.

At any rate, doing the heavy work on the agent before acquiring the lock, along with the regular test XML parsing, ought to solve this, though it sounds tricky to test that. (Create a synthetic `TestDataPublisher` that blocks forever, and assert that `junit` inside `timeout` exits cleanly?)
