### PR TITLE
Revert "Do not call `contributeTestData` with `WorkflowRun` lock held"

### DIFF
--- a/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
+++ b/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
@@ -291,15 +291,6 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
                             task.isKeepTestNames())
                     .summarizeResult(testResults, build, pipelineTestDetails, workspace, launcher, listener, storage);
         }
-        var data = new ArrayList<TestResultAction.Data>();
-        if (task.getTestDataPublishers() != null) {
-            for (var tdp : task.getTestDataPublishers()) {
-                var d = tdp.contributeTestData(build, workspace, launcher, listener, result);
-                if (d != null) {
-                    data.add(d);
-                }
-            }
-        }
 
         synchronized (build) {
             // TODO can the build argument be omitted now, or is it used prior to the call to addAction?
@@ -329,7 +320,14 @@ public class JUnitResultArchiver extends Recorder implements SimpleBuildStep, JU
                 }
             }
 
-            data.forEach(action::addData);
+            if (task.getTestDataPublishers() != null) {
+                for (TestDataPublisher tdp : task.getTestDataPublishers()) {
+                    TestResultAction.Data d = tdp.contributeTestData(build, workspace, launcher, listener, result);
+                    if (d != null) {
+                        action.addData(d);
+                    }
+                }
+            }
 
             if (appending) {
                 build.save();


### PR DESCRIPTION
Fixes #739. Reverts jenkinsci/junit-plugin#738.

Not exactly clear on what is going wrong but I think https://github.com/jenkinsci/junit-plugin/blob/71188fea0df5061d9d64a75d154469f6f59206ef/src/main/java/hudson/tasks/junit/TestResultAction.java#L125 is getting called too late.