### PR TITLE
Fix #753: Remove bogus Java stacktrace highlighting from non-exception output

### DIFF
--- a/src/main/resources/hudson/tasks/junit/CaseResult/test-output.jelly
+++ b/src/main/resources/hudson/tasks/junit/CaseResult/test-output.jelly
@@ -34,9 +34,8 @@ THE SOFTWARE.
                             <l:icon src="symbol-chevron-forward-outline plugin-ionicons-api" />
                             <l:copyButton text="${value}" iconOnly="true" clazz="jenkins-mobile-hide" />
                         </summary>
-
                         <pre class="jdl-component-code__code">
-                            <code class="language-javastacktrace">
+                            <code class="${codeClass}">
                                 ${value}
                             </code>
                         </pre>
@@ -45,12 +44,27 @@ THE SOFTWARE.
             </j:if>
         </d:tag>
     </d:taglib>
-
-    <local:item id="${id}" name="error" title="${%Error Details}" value="${it.errorDetails}" />
+    <local:item id="${id}" name="error" title="${%Error Details}" value="${it.errorDetails}" codeClass="language-javastacktrace" />
     <j:forEach var="p" items="${it.properties}">
-        <local:item id="${id}" name="${p.key}" title="${p.key}" value="${p.value}" />
+        <local:item id="${id}" name="${p.key}" title="${p.key}" value="${p.value}" codeClass="" />
     </j:forEach>
-    <local:item id="${id}" name="stacktrace" title="${%Stack Trace}" value="${it.errorStackTrace}" />
-    <local:item id="${id}" name="stdout" title="${%Standard Output}" value="${it.stdout}" />
-    <local:item id="${id}" name="stderr" title="${%Standard Error}" value="${it.stderr}" />
+    <local:item id="${id}" name="stacktrace" title="${%Stack Trace}" value="${it.errorStackTrace}" codeClass="language-javastacktrace" />
+
+
+    <j:set var="stdoutClass" value="" />
+    <j:if test="${it.stdout != null}">
+        <j:if test="${it.stdout.contains('Exception') or it.stdout.contains('Error') or it.stdout.contains('at ') and (it.stdout.contains('.java:') or it.stdout.contains('Caused by:'))}">
+            <j:set var="stdoutClass" value="language-javastacktrace" />
+        </j:if>
+    </j:if>
+    <local:item id="${id}" name="stdout" title="${%Standard Output}" value="${it.stdout}" codeClass="${stdoutClass}" />
+
+
+    <j:set var="stderrClass" value="" />
+    <j:if test="${it.stderr != null}">
+        <j:if test="${it.stderr.contains('Exception') or it.stderr.contains('Error') or it.stderr.contains('at ') and (it.stderr.contains('.java:') or it.stderr.contains('Caused by:'))}">
+            <j:set var="stderrClass" value="language-javastacktrace" />
+        </j:if>
+    </j:if>
+    <local:item id="${id}" name="stderr" title="${%Standard Error}" value="${it.stderr}" codeClass="${stderrClass}" />
 </j:jelly>


### PR DESCRIPTION


## Problem
JUnit test output that is not a Java stack trace was getting highlighted as if it were a Java exception. This made normal logs (API responses, timestamps, tokens, plain text) look like stack traces, causing bad UX and confusion.

## Solution
- Only apply `language-javastacktrace` syntax highlighting to **Error Details** and **Stack Trace** fields (which always contain Java exceptions when present)
- Remove automatic highlighting from **Standard Output** and **Standard Error** fields
- Add conditional logic to detect Java exception patterns in stdout/stderr and apply highlighting only when appropriate

## Changes
- Modified the Jelly template to use a `codeClass` parameter
- Error Details and Stack Trace: always highlighted (they only exist when there's a Java exception)
- Standard Output and Standard Error: conditionally highlighted based on content detection

## Testing
Tested with:
1. Test with Java exception → Error Details, Stack Trace, and stdout properly highlighted ✅
2. Test with regular logs → No highlighting on API responses, tokens, timestamps ✅
3. Test with successful output → No highlighting on normal logs ✅

Before

<img width="1439" height="611" alt="Screenshot 2026-01-02 115442" src="https://github.com/user-attachments/assets/6181d062-e8e1-420d-ab2c-3937e28630b1" />


After

<img width="916" height="836" alt="Screenshot 2026-01-03 094342" src="https://github.com/user-attachments/assets/ca0ede95-f41a-425f-bd04-578d023adc22" />



<img width="863" height="508" alt="Screenshot 2026-01-03 094411" src="https://github.com/user-attachments/assets/a52db011-87c7-4c15-9a74-4260235e7b59" />
