### PR TITLE
Group failed tests by package name in the test results page

### DIFF
--- a/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/src/main/java/hudson/tasks/junit/TestResult.java
@@ -66,8 +66,9 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.export.Exported;
+import java.util.LinkedHashMap;
 
-/**
+/*
  * Root of all the test results for one build.
  *
  * @author Kohsuke Kawaguchi
@@ -1252,4 +1253,37 @@ public final class TestResult extends MetaTabulatedResult {
     public PrismConfiguration getPrismConfiguration() {
         return PrismConfiguration.getInstance();
     }
+
+
+    /**
+     * Gets failed tests grouped by package name.
+     * Returns a map where key is package name and value is list of failed tests in that package.
+     *
+     * @return Map of package name to list of CaseResult
+     */
+
+    public Map<String, List<CaseResult>> getFailedTestsByPackage() {
+        List<CaseResult> failed = getFailedTests();
+        Map<String, List<CaseResult>> grouped = new TreeMap<>();
+
+        for (CaseResult test : failed) {
+            String packageName = test.getPackageName();
+            grouped.computeIfAbsent(packageName, k -> new ArrayList<>()).add(test);
+        }
+
+        // Sort tests within each package by className then testName
+        for (List<CaseResult> tests : grouped.values()) {
+            tests.sort((a, b) -> {
+                int classCompare = a.getClassName().compareTo(b.getClassName());
+                if (classCompare != 0) {
+                    return classCompare;
+                }
+                return a.getName().compareTo(b.getName());
+            });
+        }
+
+        return grouped;
+    }
+
+
 }

--- a/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
+++ b/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson/test" xmlns:f="/lib/form">
   <j:if test="${it.failCount!=0}">
     <f:section title="${%All Failed Tests}">
-      <t:table items="${it.failedTests}" id="failedtestresult" />
+      <t:table-grouped items="${it.failedTestsByPackage}" id="failedtestresult" />
     </f:section>
   </j:if>
 

--- a/src/main/resources/lib/hudson/test/table-grouped.jelly
+++ b/src/main/resources/lib/hudson/test/table-grouped.jelly
@@ -1,0 +1,137 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson/test">
+    <st:documentation>
+        <st:attribute name="items">
+            Map of package names to lists of tests to display.
+        </st:attribute>
+        <st:attribute name="baseUrl" use="optional">
+            Optional base URL for the table.
+        </st:attribute>
+        <st:attribute name="relativeParent" use="optional">
+            Optional relative parent for the row's ID and URL.
+        </st:attribute>
+        <st:attribute name="id" use="optional">
+            Optional ID for the table.
+        </st:attribute>
+    </st:documentation>
+
+    <st:once>
+        <link rel="stylesheet" href="${resURL}/plugin/junit/styles.css" defer="true" />
+        <st:adjunct includes="lib.hudson.test.js.failureSummary" />
+        <style>
+            .package-group-header {
+            background-color: var(--background);
+            font-weight: 500;
+            font-family: var(--font-family-mono);
+            padding: 12px 16px;
+            border-top: 2px solid var(--line-green);
+            border-bottom: 1px solid var(--medium-grey);
+            }
+            .package-group-header .package-icon {
+            margin-right: 8px;
+            opacity: 0.7;
+            }
+            .package-test-row td:first-child {
+            padding-left: 48px;
+            }
+        </style>
+    </st:once>
+
+    <table class="jenkins-table" id="${attrs.id}">
+        <thead>
+            <tr>
+                <th>${%Name}</th>
+                <th style="width: 4em" class="jenkins-mobile-hide">${%Age}</th>
+                <th style="width: 4em" class="jenkins-mobile-hide">${%Duration}</th>
+                <j:forEach var="tableheader" items="${it.testActions}">
+                    <st:include it="${tableheader}" page="casetableheader.jelly" optional="true" />
+                </j:forEach>
+                <th class="jenkins-mobile-hide" />
+            </tr>
+        </thead>
+        <tbody>
+            <j:forEach var="packageEntry" items="${attrs.items.entrySet()}" varStatus="pkgStatus">
+                <!-- Package Header Row -->
+                <tr class="package-group-header">
+                    <td colspan="10">
+                        <span class="package-icon">📦</span>
+                        <st:out value="${packageEntry.key}" />
+                        <span class="jenkins-!-text-color-secondary jenkins-!-margin-left-2">
+                            (${packageEntry.value.size()} ${packageEntry.value.size() == 1 ? 'test' : 'tests'})
+                        </span>
+                    </td>
+                </tr>
+
+                <!-- Test Rows for this Package -->
+                <j:forEach var="f" items="${packageEntry.value}" varStatus="i">
+                    <tr class="package-test-row" data-type="test-row" data="${f.className}.${f.name}">
+                        <td>
+                            <j:set var="url" value="${attrs.baseUrl}${f.getRelativePathFrom(attrs.relativeParent ?: it)}" />
+                            <j:set var="id" value="${h.htmlAttributeEscape(url)}" />
+
+                            <j:choose>
+                                <j:when test="${f.status == 'SKIPPED'}">
+                                    <div class="jp-table-row">
+                                        <l:icon src="symbol-status-skipped plugin-junit" />
+
+                                        <span style="font-family: var(--font-family-mono)">
+                                            <st:out value="${f.simpleName}" />
+                                        </span>
+
+                                        <span class="jenkins-!-text-color-secondary">.</span>
+
+                                        <st:out value="${f.name}" />
+
+                                        <t:condition-tag test="${f}" clazz="jenkins-!-margin-left-2 jenkins-mobile-hide" />
+                                    </div>
+                                </j:when>
+                                <j:otherwise>
+                                    <a id="test-${id}-showlink" class="jp-table-row" href="${url}">
+                                        <l:icon src="${f.status == 'PASSED' ? 'symbol-status-blue' : 'symbol-status-red'}" />
+
+                                        <span style="font-family: var(--font-family-mono)">
+                                            <st:out value="${f.simpleName}" />
+                                        </span>
+
+                                        <span class="jenkins-!-text-color-secondary">.</span>
+
+                                        <st:out value="${f.name}" />
+
+                                        <t:condition-tag test="${f}" clazz="jenkins-!-margin-left-2 jenkins-mobile-hide" />
+
+                                        <l:icon src="symbol-chevron-forward-outline plugin-ionicons-api" class="jenkins-!-margin-left-2" />
+                                    </a>
+                                </j:otherwise>
+                            </j:choose>
+
+                            <j:forEach var="badge" items="${f.testActions}">
+                                <st:include it="${badge}" page="badge.jelly" optional="true" />
+                            </j:forEach>
+                        </td>
+                        <td class="jenkins-mobile-hide">
+                            <j:choose>
+                                <j:when test="${f.age == 0 or f.skipped}">0</j:when>
+                                <j:otherwise>
+                                    <a href="${rootURL}/${f.failedSinceRun.url}">${f.age}</a>
+                                </j:otherwise>
+                            </j:choose>
+                        </td>
+                        <td class="no-wrap jenkins-mobile-hide" data="${f.duration}">
+                            ${f.durationString}
+                        </td>
+                        <j:forEach var="tablerow" items="${f.testActions}">
+                            <st:include it="${tablerow}" page="tablerow.jelly" optional="true" />
+                        </j:forEach>
+                        <td class="jenkins-table__cell--tight jenkins-mobile-hide">
+                            <div class="jenkins-table__cell__button-wrapper">
+                                <a href="${url}" class="jenkins-button jenkins-button--tertiary" tooltip="Open in new tab" target="_blank">
+                                    <l:icon src="symbol-external" class="icon-sm" />
+                                </a>
+                            </div>
+                        </td>
+                    </tr>
+                </j:forEach>
+            </j:forEach>
+        </tbody>
+    </table>
+</j:jelly>


### PR DESCRIPTION
## Problem
 According to [ #766](https://github.com/jenkinsci/junit-plugin/issues/766) , the test failure summary page showed all the failed cases in flat list , making it difficult for the developers to find the packages with most test failure, also tests from different packages was mixed together making it difficult to find all the failed test cases of particular package

## Solution
- Package level grouping of the test classes 
- Package are sorted lexicographically
- Package headers shows the package name and test count
- Within each package the test are sorted by the classname, then method name


## Changes

1. **TestResult.java**: Added `getFailedTestsByPackage()` method that sort the packages alphabetically
2.  **table-grouped.jelly**: New UI component that displays grouped test results with the package headers
3. **MetaTabulatedResult/body.jelly**: Modified to use the `table-grouped` component instead of flat `table` component

 


### Testing

Tested with the JUnit test reports containing multiple packages:

- Package headers display correctly with test counts
- Tests are properly grouped under their packages
- Sorting  works correctly

## Screenshots

### Before

<img width="811" height="799" alt="Screenshot 2026-01-03 130631" src="https://github.com/user-attachments/assets/68c587e6-1f78-4506-8903-0ce16c903125" />


### After
<img width="633" height="791" alt="Screenshot 2026-01-03 131715" src="https://github.com/user-attachments/assets/ab7893df-c3e2-4fd5-a1a6-d1a06c2da961" />




### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
