### PR TITLE
Use core status icons for test results

### DIFF
--- a/src/main/java/hudson/tasks/junit/Widget.java
+++ b/src/main/java/hudson/tasks/junit/Widget.java
@@ -6,7 +6,6 @@ import java.util.List;
 public class Widget {
 
     private final String symbol;
-    private final String symbolClass;
     private final List<String> lines = new ArrayList<>();
 
     public Widget(TestResult result) {
@@ -14,10 +13,7 @@ public class Widget {
         boolean isFailed = failCount > 0;
         int totalCount = result.getTotalCount();
 
-        this.symbol = isFailed
-                ? "symbol-close-circle-outline plugin-ionicons-api"
-                : "symbol-checkmark-done-outline plugin-ionicons-api";
-        this.symbolClass = isFailed ? "jenkins-!-error-color" : "jenkins-!-success-color";
+        this.symbol = isFailed ? "symbol-status-red" : "symbol-status-blue";
 
         List<String> counts = new ArrayList<>();
 
@@ -57,10 +53,6 @@ public class Widget {
 
     public String getSymbol() {
         return symbol;
-    }
-
-    public String getSymbolClass() {
-        return symbolClass;
     }
 
     public List<String> getLines() {

--- a/src/main/resources/hudson/tasks/test/AbstractTestResultAction/widget.jelly
+++ b/src/main/resources/hudson/tasks/test/AbstractTestResultAction/widget.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
         <j:set var="widget" value="${it.widget}" />
 
         <a class="jenkins-card__teaser" href="${it.urlName}" tabindex="-1">
-            <l:icon src="${widget.symbol}" class="${widget.symbolClass}" />
+            <l:icon src="${widget.symbol}" />
             <j:forEach var="line" items="${widget.lines}">
                 <div>${line}</div>
             </j:forEach>


### PR DESCRIPTION
Had a bit of a brain fart when writing this code originally - rather than just use core's status icons I instead used Ionicons, which required an additional `class` property to be applied. This PR simplifies that and just uses the colourful icons already available in core.

### Testing done

* Icons look the same as they did before, just with less code

<img width="425" height="370" alt="Screenshot 2026-01-26 at 15 04 13" src="https://github.com/user-attachments/assets/9763d110-9b9e-4312-8956-3bce6c019cb7" />

<img width="423" height="371" alt="Screenshot 2026-01-26 at 15 03 56" src="https://github.com/user-attachments/assets/99e8b4bd-f709-428f-a017-69abdeeace3a" />

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
