### PR TITLE
Switch to standard automerge semantics

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,6 @@
     "github>jenkinsci/renovate-config",
     "schedule:earlyMondays"
   ],
-  "automerge": true,
   "packageRules": [
     {
       "matchPackageNames": [

--- a/.github/workflows/auto-merge-safe-deps.yml
+++ b/.github/workflows/auto-merge-safe-deps.yml
@@ -1,0 +1,9 @@
+name: Automatically approve and merge safe dependency updates
+on:
+- pull_request_target
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  auto-merge-safe-deps:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/auto-merge-safe-deps.yml@v1

--- a/.github/workflows/close-bom-if-passing.yml
+++ b/.github/workflows/close-bom-if-passing.yml
@@ -1,0 +1,11 @@
+name: Close BOM update PR if passing
+on:
+  check_run:
+    types:
+    - completed
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  close-bom-if-passing:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/close-bom-if-passing.yml@v1


### PR DESCRIPTION
https://github.com/jenkinsci/junit-plugin/pull/1191#discussion_r2766044889 so as to avoid constantly bumping the `bom-*` dep, which can cause problems for downstream plugins.