### PR TITLE
Use different icons for errors and failures

### DIFF
--- a/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -78,6 +78,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
     private String testName;
 
     private transient String safeName;
+    private boolean isProperFailure;
     private boolean skipped;
     private boolean keepTestNames;
     private String skippedMessage;
@@ -138,6 +139,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         this.stderr = null;
         this.duration = 0.0f;
         this.startTime = -1;
+        this.isProperFailure = false;
         this.skipped = false;
         this.skippedMessage = null;
         this.properties = Collections.emptyMap();
@@ -165,6 +167,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         this.duration = duration;
         this.startTime = -1;
 
+        this.isProperFailure = false;
         this.skipped = skippedMessage != null;
         this.skippedMessage = skippedMessage;
         this.properties = Collections.emptyMap();
@@ -220,6 +223,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         testName = nameAttr;
         errorStackTrace = getError(testCase);
         errorDetails = getErrorMessage(testCase);
+        isProperFailure = isMarkedAsProperFailure(testCase);
         this.parent = parent;
         duration = clampDuration(parseTime(testCase));
         this.startTime = -1;
@@ -259,6 +263,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         this.testName = src.testName;
         this.skippedMessage = src.skippedMessage;
         this.skipped = src.skipped;
+        this.isProperFailure = src.isProperFailure;
         this.keepTestNames = src.keepTestNames;
         this.errorStackTrace = src.errorStackTrace;
         this.errorDetails = src.errorDetails;
@@ -335,6 +340,9 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
                         break;
                     case "skipped":
                         r.skipped = Boolean.parseBoolean(reader.getElementText());
+                        break;
+                    case "isProperFailure":
+                        r.isProperFailure = Boolean.parseBoolean(reader.getElementText());
                         break;
                     case "keepTestNames":
                         r.keepTestNames = Boolean.parseBoolean(reader.getElementText());
@@ -597,6 +605,13 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
      */
     private static boolean isMarkedAsSkipped(Element testCase) {
         return testCase.element("skipped") != null;
+    }
+
+    /**
+     * If the testCase element includes a failure element rather than an error element.
+     */
+    private static boolean isMarkedAsProperFailure(Element testCase) {
+        return testCase.element("failure") != null;
     }
 
     private static String getSkippedMessage(Element testCase) {
@@ -1214,7 +1229,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         return switch (getStatus()) {
             case PASSED -> "symbol-status-blue";
             case SKIPPED -> "symbol-status-skipped plugin-junit";
-            default -> "symbol-status-red";
+            default -> this.isProperFailure ? "symbol-status-failure plugin-junit" : "symbol-status-red";
         };
     }
 }

--- a/src/main/resources/images/symbols/status-failure.svg
+++ b/src/main/resources/images/symbols/status-failure.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <ellipse cx="256" cy="256" rx="210" ry="210" fill="none" stroke="var(--orange)" stroke-linecap="round" stroke-miterlimit="10" stroke-width="36" />
+    <path fill="none" stroke="var(--orange)" stroke-linecap="round" stroke-linejoin="round" stroke-width="36" d="M320 320L192 192M192 320l128-128"/>
+</svg>

--- a/src/main/resources/lib/hudson/test/table.jelly
+++ b/src/main/resources/lib/hudson/test/table.jelly
@@ -65,7 +65,7 @@ THE SOFTWARE.
                     <j:choose>
                         <j:when test="${f.status == 'SKIPPED'}">
                             <div class="jp-table-row">
-                                <l:icon src="symbol-status-skipped plugin-junit" />
+                                <l:icon src="${f.iconFileName}" />
 
                                 ${f.name}
 
@@ -80,7 +80,7 @@ THE SOFTWARE.
                         </j:when>
                         <j:otherwise>
                             <a id="test-${id}-showlink" class="jp-table-row" href="${url}">
-                                <l:icon src="${f.status == 'PASSED' ? 'symbol-status-blue' : 'symbol-status-red'}" />
+                                <l:icon src="${f.iconFileName}" />
 
                                 ${f.name}
 


### PR DESCRIPTION
Fixes #744 

Introduce different icons to distinguish "failed" failures from "error" failures. This is a meaningful distinction within jUnit. Jenkins traditionally merges these results into one single failed category. This PR keeps the merging itself, but helps users to distinguish "failed" results from "error" results by displaying a slightly changed icon. The icon difference is only in color, so that the merging of the results still makes sense.

- Add the `isProperFailure` attribute to `CaseResult`, storing if the jUnit result included a "failure" element, which indicates a "failure" failure rather than an "error" failure.

- Add the `isProperFailure` attribute to junit-plugin's internal storage handling.

- Add status-failure.svg, which is copied from status-red.svg, but uses `stroke="var(--orange)"` instead.

- Switch to the new icon in the `getIconFileName()` method.

### Usage

- In order for the new coloring to take effect, new test results need to be generated. That is because junit-plugin's internal storage of the jUnit results need to be updated with the new isProperFailure information.

### Testing done

Front-end change only. Visuals tested locally.

Using this jUnit XML file for reference, the PR changes the icon of "failed" failures to orange like this:

<img width="303" height="558" alt="grafik" src="https://github.com/user-attachments/assets/0af9e297-54ce-434a-9785-6a66b764b291" />

<img width="294" height="555" alt="grafik" src="https://github.com/user-attachments/assets/b8d9f462-0dde-455a-bf0e-452d758f7c77" />



### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
