### PR TITLE
Handle missing parent action while test data publishers are running

### DIFF
--- a/src/main/java/hudson/tasks/test/TestResult.java
+++ b/src/main/java/hudson/tasks/test/TestResult.java
@@ -142,6 +142,16 @@ public abstract class TestResult extends TestObject {
         if (b == null) {
             return null;
         }
+        // getParentAction() returns null when no AbstractTestResultAction is attached
+        // to this run yet — notably while JUnitResultArchiver.parseAndSummarize is
+        // invoking TestDataPublishers (the action is constructed but only added to
+        // the build *after* the publisher loop). Without a known action class we
+        // can't find a corresponding result on a previous build, so just stop here
+        // instead of NPEing on .getClass() inside the loop below.
+        AbstractTestResultAction<?> parentAction = getParentAction();
+        if (parentAction == null) {
+            return null;
+        }
         Job<?, ?> job = b.getParent();
         while (true) {
             b = b.getPreviousBuild();
@@ -149,7 +159,7 @@ public abstract class TestResult extends TestObject {
                 return null;
             }
             try {
-                AbstractTestResultAction r = b.getAction(getParentAction().getClass());
+                AbstractTestResultAction r = b.getAction(parentAction.getClass());
                 if (r != null) {
                     TestResult result = r.findCorrespondingResult(this.getId());
                     if (result != null) {
@@ -174,7 +184,11 @@ public abstract class TestResult extends TestObject {
      */
     @Override
     public TestResult getResultInRun(Run<?, ?> build) {
-        AbstractTestResultAction tra = build.getAction(getParentAction().getClass());
+        AbstractTestResultAction<?> parentAction = getParentAction();
+        if (parentAction == null) {
+            return null;
+        }
+        AbstractTestResultAction tra = build.getAction(parentAction.getClass());
         if (tra == null) {
             tra = build.getAction(AbstractTestResultAction.class);
         }

--- a/src/main/java/hudson/tasks/test/TestResult.java
+++ b/src/main/java/hudson/tasks/test/TestResult.java
@@ -148,7 +148,7 @@ public abstract class TestResult extends TestObject {
         // the build *after* the publisher loop). Without a known action class we
         // can't find a corresponding result on a previous build, so just stop here
         // instead of NPEing on .getClass() inside the loop below.
-        AbstractTestResultAction<?> parentAction = getParentAction();
+        AbstractTestResultAction parentAction = getParentAction();
         if (parentAction == null) {
             return null;
         }
@@ -184,7 +184,7 @@ public abstract class TestResult extends TestObject {
      */
     @Override
     public TestResult getResultInRun(Run<?, ?> build) {
-        AbstractTestResultAction<?> parentAction = getParentAction();
+        AbstractTestResultAction parentAction = getParentAction();
         if (parentAction == null) {
             return null;
         }

--- a/src/test/java/hudson/tasks/test/TestResultParentActionTest.java
+++ b/src/test/java/hudson/tasks/test/TestResultParentActionTest.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.tasks.test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import hudson.model.Run;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for the case where {@link TestResult#getParentAction()} returns
+ * {@code null} because no {@link AbstractTestResultAction} is attached to the run yet.
+ * This happens in particular when a {@link hudson.tasks.junit.TestDataPublisher} walks
+ * history during {@link hudson.tasks.junit.JUnitResultArchiver}'s
+ * {@code parseAndSummarize}: the action is constructed but only added to the build
+ * <em>after</em> the publisher loop. Without a guard, {@code getParentAction().getClass()}
+ * NPEs inside {@link TestResult#getPreviousResult} and
+ * {@link TestResult#getResultInRun}.
+ */
+class TestResultParentActionTest {
+
+    @Test
+    void getPreviousResultShortCircuitsWhenParentActionNull() {
+        TestResult testResult = spy(new SimpleCaseResult());
+        Run currentRun = mock(Run.class);
+        doReturn(currentRun).when(testResult).getRun();
+        doReturn(null).when(testResult).getParentAction();
+
+        assertNull(testResult.getPreviousResult());
+        // The fix bails before entering the history-walking loop; without it, the
+        // loop iterates getPreviousBuild() repeatedly and NPEs once per previous build.
+        verify(currentRun, never()).getPreviousBuild();
+    }
+
+    @Test
+    void getResultInRunReturnsNullWhenParentActionNull() {
+        TestResult testResult = spy(new SimpleCaseResult());
+        Run targetRun = mock(Run.class);
+        doReturn(null).when(testResult).getParentAction();
+
+        // Without the fix this NPEs on getParentAction().getClass().
+        assertNull(testResult.getResultInRun(targetRun));
+    }
+}


### PR DESCRIPTION
`getParentAction()` is implemented as `getRun().getAction(AbstractTestResultAction.class)` and returns null when no `AbstractTestResultAction` is yet attached to the run - notably while `JUnitResultArchiver.parseAndSummarize` is invoking `TestDataPublishers` (the action is constructed but only added to the build *after* the publisher loop). Without a guard, `getParentAction().getClass()` NPEs.

Hoist `getParentAction()` once in `getPreviousResult` and short-circuit when it's null. Restores the pre-#651 effective behavior (return null fast) without going through exception flow and exception logging. Apply the same null guard at the top of `getResultInRun`, which has the identical `getParentAction().getClass()` pattern and the same latent NPE; its existing `if (tra == null)` fallback handles a different scenario and doesn't help here.

Fixes #1233.

### Testing done

Two new unit tests added in `TestResultParentActionTest`, exercising the null-parent-action path in both `getPreviousResult` and `getResultInRun`:

- `getPreviousResultShortCircuitsWhenParentActionNull` — asserts the method returns null AND, via Mockito, that `getPreviousBuild()` is never called (i.e., the early-return short-circuits before the history-walking loop). Without the fix this fails because the loop still iterates.
- `getResultInRunReturnsNullWhenParentActionNull` — asserts the method returns null. Without the fix it errors with `NullPointerException` on `getParentAction().getClass()` at line 177.

Verified both tests fail on `master` and pass on this branch (stash/pop dance). Full `mvn verify` passes locally: 498/498 tests, 0 failures, 0 errors.

End-to-end Docker reproduction also validated: a Jenkins LTS container with `junit:1403.vd9d1413fd205` + `test-stability:2.4` + a single all-passing pipeline emits 6 `Failed to load (corrupt?)` warnings across 4 builds; swapping in the patched `.hpi` from this branch produces 0 warnings across the next 4 builds (same job, same workload).


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

