### PR TITLE
Add duration to TestResultSummary

### DIFF
--- a/src/main/java/hudson/tasks/junit/TestResultSummary.java
+++ b/src/main/java/hudson/tasks/junit/TestResultSummary.java
@@ -13,16 +13,22 @@ public class TestResultSummary implements Serializable {
     private int skipCount;
     private int passCount;
     private int totalCount;
+    private float duration;
 
     @Deprecated
     @Restricted(DoNotUse.class)
     public TestResultSummary() {}
 
     public TestResultSummary(int failCount, int skipCount, int passCount, int totalCount) {
+        this(failCount, skipCount, passCount, totalCount, -1.f);
+    }
+
+    public TestResultSummary(int failCount, int skipCount, int passCount, int totalCount, float duration) {
         this.failCount = failCount;
         this.skipCount = skipCount;
         this.passCount = passCount;
         this.totalCount = totalCount;
+        this.duration = duration;
     }
 
     public TestResultSummary(TestResult result) {
@@ -30,6 +36,7 @@ public class TestResultSummary implements Serializable {
         this.skipCount = result.getSkipCount();
         this.passCount = result.getPassCount();
         this.totalCount = result.getTotalCount();
+        this.duration = result.getDuration();
         if (totalCount == 0) {
             for (SuiteResult suite : result.getSuites()) {
                 if (!suite.getCases().isEmpty()) {
@@ -58,5 +65,10 @@ public class TestResultSummary implements Serializable {
     @Whitelisted
     public int getTotalCount() {
         return totalCount;
+    }
+
+    @Whitelisted
+    public float getDuration() {
+        return duration;
     }
 }

--- a/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
+++ b/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
@@ -232,6 +232,7 @@ class TestResultStorageJunitTest {
             assertThat(testResultSummary.getPassCount(), equalTo(1));
             assertThat(testResultSummary.getSkipCount(), equalTo(1));
             assertThat(testResultSummary.getTotalCount(), equalTo(4));
+            assertThat(testResultSummary.getDuration(), equalTo(200.0f));
 
             int countOfBuildsWithTestResults = pluggableStorage.getCountOfBuildsWithTestResults();
             assertThat(countOfBuildsWithTestResults, is(1));
@@ -452,7 +453,7 @@ class TestResultStorageJunitTest {
                 public List<TrendTestResultSummary> getTrendTestResultSummary() {
                     return query(connection -> {
                         try (PreparedStatement statement = connection.prepareStatement(
-                                "SELECT build, sum(case when errorDetails is not null then 1 else 0 end) as failCount, sum(case when skipped is not null then 1 else 0 end) as skipCount, sum(case when errorDetails is null and skipped is null then 1 else 0 end) as passCount FROM "
+                                "SELECT build, sum(case when errorDetails is not null then 1 else 0 end) as failCount, sum(case when skipped is not null then 1 else 0 end) as skipCount, sum(case when errorDetails is null and skipped is null then 1 else 0 end) as passCount, sum(duration) as duration FROM "
                                         + Impl.CASE_RESULTS_TABLE + " WHERE job = ? group by build order by build;")) {
                             statement.setString(1, job);
                             try (ResultSet result = statement.executeQuery()) {
@@ -464,9 +465,11 @@ class TestResultStorageJunitTest {
                                     int failed = result.getInt("failCount");
                                     int skipped = result.getInt("skipCount");
                                     int total = passed + failed + skipped;
+                                    float duration = result.getFloat("duration");
 
                                     trendTestResultSummaries.add(new TrendTestResultSummary(
-                                            buildNumber, new TestResultSummary(failed, skipped, passed, total)));
+                                            buildNumber,
+                                            new TestResultSummary(failed, skipped, passed, total, duration)));
                                 }
                                 return trendTestResultSummaries;
                             }


### PR DESCRIPTION
If one wants a summary of the recorded test results, including the tests **duration**, currently one has to query the Jenkins API via the CLI using for example
```
curl ${BUILD_URL}/testReport/api/json?tree=failCount,passCount,skipCount,duration
```
This adds that `duration` to the `TestResultSummary` object returned by the `junit` step to make it more convenient to get it.

Fixes https://github.com/jenkinsci/junit-plugin/issues/1235

### Testing done

~~Not yet, but I can extend the tests if necessary.~~
The existing test cases are extended to also cover the new `duration` field.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

