### PR TITLE
Optimize the test history some more

### DIFF
--- a/src/main/java/hudson/tasks/junit/History.java
+++ b/src/main/java/hudson/tasks/junit/History.java
@@ -713,6 +713,7 @@ public class History {
 
                             return new HistoryTestResultSummary(
                                     build,
+                                    resultInRun,
                                     resultInRun.getDuration(),
                                     resultInRun.getFailCount(),
                                     resultInRun.getSkipCount(),

--- a/src/main/java/hudson/tasks/junit/HistoryTestResultSummary.java
+++ b/src/main/java/hudson/tasks/junit/HistoryTestResultSummary.java
@@ -12,19 +12,29 @@ public class HistoryTestResultSummary {
     private final int skipCount;
     private final int passCount;
     private final String description;
-
-    public HistoryTestResultSummary(Run<?, ?> run, float duration, int failCount, int skipCount, int passCount) {
-        this(run, duration, failCount, skipCount, passCount, null);
+    private final hudson.tasks.test.TestResult resultInRun;
+    public HistoryTestResultSummary(Run<?, ?> run, hudson.tasks.test.TestResult resultInRun, float duration, int failCount, int skipCount, int passCount) {
+        this(run, resultInRun, duration, failCount, skipCount, passCount, null);
     }
 
     public HistoryTestResultSummary(
-            Run<?, ?> run, float duration, int failCount, int skipCount, int passCount, String description) {
+            Run<?, ?> run, hudson.tasks.test.TestResult resultInRun, float duration, int failCount, int skipCount, int passCount, String description) {
         this.run = run;
         this.duration = duration;
         this.failCount = failCount;
         this.skipCount = skipCount;
         this.passCount = passCount;
         this.description = description;
+        this.resultInRun = resultInRun;
+    }
+    @Deprecated
+    public HistoryTestResultSummary(Run<?, ?> run, float duration, int failCount, int skipCount, int passCount) {
+        this(run, null, duration, failCount, skipCount, passCount, null);
+    }
+    @Deprecated
+    public HistoryTestResultSummary(
+            Run<?, ?> run, float duration, int failCount, int skipCount, int passCount, String description) {
+        this(run, null, duration, failCount, skipCount, passCount, description);
     }
 
     public String getDescription() {
@@ -66,8 +76,13 @@ public class HistoryTestResultSummary {
     public String getFullDisplayName() {
         return run.getFullDisplayName();
     }
-
+    public hudson.tasks.test.TestResult getResultInRun() {
+        return resultInRun;
+    }
     public String getUrl() {
+        if (resultInRun != null) {
+            return resultInRun.getUrl();
+        }
         AbstractTestResultAction<?> action = run.getAction(AbstractTestResultAction.class);
 
         // TODO pass id to end of url

--- a/src/main/java/hudson/tasks/junit/HistoryTestResultSummary.java
+++ b/src/main/java/hudson/tasks/junit/HistoryTestResultSummary.java
@@ -13,12 +13,25 @@ public class HistoryTestResultSummary {
     private final int passCount;
     private final String description;
     private final hudson.tasks.test.TestResult resultInRun;
-    public HistoryTestResultSummary(Run<?, ?> run, hudson.tasks.test.TestResult resultInRun, float duration, int failCount, int skipCount, int passCount) {
+
+    public HistoryTestResultSummary(
+            Run<?, ?> run,
+            hudson.tasks.test.TestResult resultInRun,
+            float duration,
+            int failCount,
+            int skipCount,
+            int passCount) {
         this(run, resultInRun, duration, failCount, skipCount, passCount, null);
     }
 
     public HistoryTestResultSummary(
-            Run<?, ?> run, hudson.tasks.test.TestResult resultInRun, float duration, int failCount, int skipCount, int passCount, String description) {
+            Run<?, ?> run,
+            hudson.tasks.test.TestResult resultInRun,
+            float duration,
+            int failCount,
+            int skipCount,
+            int passCount,
+            String description) {
         this.run = run;
         this.duration = duration;
         this.failCount = failCount;
@@ -27,10 +40,12 @@ public class HistoryTestResultSummary {
         this.description = description;
         this.resultInRun = resultInRun;
     }
+
     @Deprecated
     public HistoryTestResultSummary(Run<?, ?> run, float duration, int failCount, int skipCount, int passCount) {
         this(run, null, duration, failCount, skipCount, passCount, null);
     }
+
     @Deprecated
     public HistoryTestResultSummary(
             Run<?, ?> run, float duration, int failCount, int skipCount, int passCount, String description) {
@@ -76,9 +91,11 @@ public class HistoryTestResultSummary {
     public String getFullDisplayName() {
         return run.getFullDisplayName();
     }
+
     public hudson.tasks.test.TestResult getResultInRun() {
         return resultInRun;
     }
+
     public String getUrl() {
         if (resultInRun != null) {
             return resultInRun.getUrl();

--- a/src/main/java/hudson/tasks/junit/TestResultAction.java
+++ b/src/main/java/hudson/tasks/junit/TestResultAction.java
@@ -263,9 +263,9 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
     static Object syncObj = new Object();
     static volatile long lastCleanupNs = 0;
 
-    static long LARGE_RESULT_CACHE_CLEANUP_INTERVAL_NS =
-            SystemProperties.getLong(TestResultAction.class.getName() + ".LARGE_RESULT_CACHE_CLEANUP_INTERVAL_MS", 30000L)
-                    * 1000000L;
+    static long LARGE_RESULT_CACHE_CLEANUP_INTERVAL_NS = SystemProperties.getLong(
+                    TestResultAction.class.getName() + ".LARGE_RESULT_CACHE_CLEANUP_INTERVAL_MS", 30000L)
+            * 1000000L;
     static int LARGE_RESULT_CACHE_THRESHOLD =
             SystemProperties.getInteger(TestResultAction.class.getName() + ".LARGE_RESULT_CACHE_THRESHOLD", 10000);
     static boolean RESULT_CACHE_ENABLED =

--- a/src/main/java/hudson/tasks/junit/TestResultAction.java
+++ b/src/main/java/hudson/tasks/junit/TestResultAction.java
@@ -261,13 +261,13 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
 
     static ConcurrentHashMap<String, SoftReference<TestResult>> resultCache = new ConcurrentHashMap<>();
     static Object syncObj = new Object();
-    static long lastCleanupNs = 0;
+    static volatile long lastCleanupNs = 0;
 
     static long LARGE_RESULT_CACHE_CLEANUP_INTERVAL_NS =
-            SystemProperties.getLong(TestResultAction.class.getName() + ".LARGE_RESULT_CACHE_CLEANUP_INTERVAL_MS", 500L)
+            SystemProperties.getLong(TestResultAction.class.getName() + ".LARGE_RESULT_CACHE_CLEANUP_INTERVAL_MS", 30000L)
                     * 1000000L;
     static int LARGE_RESULT_CACHE_THRESHOLD =
-            SystemProperties.getInteger(TestResultAction.class.getName() + ".LARGE_RESULT_CACHE_THRESHOLD", 1000);
+            SystemProperties.getInteger(TestResultAction.class.getName() + ".LARGE_RESULT_CACHE_THRESHOLD", 10000);
     static boolean RESULT_CACHE_ENABLED =
             SystemProperties.getBoolean(TestResultAction.class.getName() + ".RESULT_CACHE_ENABLED", true);
 
@@ -301,16 +301,21 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
      */
     private TestResult loadCached() {
         if (resultCache.size() > LARGE_RESULT_CACHE_THRESHOLD) {
-            synchronized (syncObj) {
-                if (resultCache.size() > LARGE_RESULT_CACHE_THRESHOLD
-                        && (System.nanoTime() - lastCleanupNs) > LARGE_RESULT_CACHE_CLEANUP_INTERVAL_NS) {
-                    lastCleanupNs = System.nanoTime();
-                    resultCache.forEach((String k, SoftReference<TestResult> v) -> {
-                        if (v.get() == null) {
-                            resultCache.remove(k);
-                        }
-                    });
+            boolean doCleanup = false;
+            if ((System.nanoTime() - lastCleanupNs) > LARGE_RESULT_CACHE_CLEANUP_INTERVAL_NS) {
+                synchronized (syncObj) {
+                    if ((System.nanoTime() - lastCleanupNs) > LARGE_RESULT_CACHE_CLEANUP_INTERVAL_NS) {
+                        lastCleanupNs = System.nanoTime();
+                        doCleanup = true;
+                    }
                 }
+            }
+            if (doCleanup) {
+                resultCache.forEach((String k, SoftReference<TestResult> v) -> {
+                    if (v.refersTo(null)) {
+                        resultCache.remove(k);
+                    }
+                });
             }
         }
         TestResult r;

--- a/src/main/resources/hudson/tasks/junit/History/index.jelly
+++ b/src/main/resources/hudson/tasks/junit/History/index.jelly
@@ -60,7 +60,6 @@ THE SOFTWARE.
               class="jenkins-!-margin-bottom-2 jenkins-!-margin-top-0"
               style="display: flex; flex-direction: row; justify-content: space-between; align-items: center; height: auto; flex-wrap: wrap;"
       >
-        <!--j:if test="${it.testObject.run.parent.builds.size() > end}"-->
         <j:if test="${buildCount > end}">
           <a href="${app.rootUrl}${it.testObject.url}/history?start=${end+1}&amp;count=${count}&amp;interval=${interval}"
              class="jenkins-!-margin-right-2 jenkins-!-margin-bottom-1 jenkins-!-margin-top-1" style="height: fit-content">${%Older}
@@ -125,7 +124,6 @@ THE SOFTWARE.
 
       <br/>
       <div class="jenkins-!-margin-bottom-2">
-        <!--j:if test="${it.testObject.run.parent.builds.size() > end}"-->
         <j:if test="${buildCount > end}">
           <a href="${app.rootUrl}${it.testObject.url}/history?start=${end+1}&amp;count=${count}&amp;interval=${interval}"
              class="jenkins-!-margin-right-2">
@@ -174,7 +172,6 @@ THE SOFTWARE.
       </table>
 
       <div>
-        <!--j:if test="${it.testObject.run.parent.builds.size() > end}"-->
         <j:if test="${buildCount > end}">
           <a href="${app.rootUrl}${it.testObject.url}/history?start=${end+1}&amp;count=${count}&amp;interval=${interval}"
              class="jenkins-!-margin-right-2">

--- a/src/main/resources/hudson/tasks/junit/History/index.jelly
+++ b/src/main/resources/hudson/tasks/junit/History/index.jelly
@@ -30,6 +30,7 @@ THE SOFTWARE.
 
   <l:run-subpage>
     <j:set var="it" value="${history}" />
+    <j:set var="buildCount" value="${it.testObject.run.parent.buildsAsMap.keySet().size()}"/>
     <j:set var="count" value="${it.asInt(request2.getParameter('count'),100)}"/>
     <j:set var="start" value="${it.asInt(request2.getParameter('start'),0)}"/>
     <j:set var="end" value="${it.asInt(request2.getParameter('end'),start+count-1)}"/>
@@ -59,7 +60,8 @@ THE SOFTWARE.
               class="jenkins-!-margin-bottom-2 jenkins-!-margin-top-0"
               style="display: flex; flex-direction: row; justify-content: space-between; align-items: center; height: auto; flex-wrap: wrap;"
       >
-        <j:if test="${it.testObject.run.parent.builds.size() > end}">
+        <!--j:if test="${it.testObject.run.parent.builds.size() > end}"-->
+        <j:if test="${buildCount > end}">
           <a href="${app.rootUrl}${it.testObject.url}/history?start=${end+1}&amp;count=${count}&amp;interval=${interval}"
              class="jenkins-!-margin-right-2 jenkins-!-margin-bottom-1 jenkins-!-margin-top-1" style="height: fit-content">${%Older}
           </a>
@@ -123,7 +125,8 @@ THE SOFTWARE.
 
       <br/>
       <div class="jenkins-!-margin-bottom-2">
-        <j:if test="${it.testObject.run.parent.builds.size() > end}">
+        <!--j:if test="${it.testObject.run.parent.builds.size() > end}"-->
+        <j:if test="${buildCount > end}">
           <a href="${app.rootUrl}${it.testObject.url}/history?start=${end+1}&amp;count=${count}&amp;interval=${interval}"
              class="jenkins-!-margin-right-2">
             ${%Older}
@@ -171,7 +174,8 @@ THE SOFTWARE.
       </table>
 
       <div>
-        <j:if test="${it.testObject.run.parent.builds.size() > end}">
+        <!--j:if test="${it.testObject.run.parent.builds.size() > end}"-->
+        <j:if test="${buildCount > end}">
           <a href="${app.rootUrl}${it.testObject.url}/history?start=${end+1}&amp;count=${count}&amp;interval=${interval}"
              class="jenkins-!-margin-right-2">
             ${%Older}

--- a/src/main/resources/lib/hudson/test/table.jelly
+++ b/src/main/resources/lib/hudson/test/table.jelly
@@ -67,13 +67,7 @@ THE SOFTWARE.
                             <div class="jp-table-row">
                                 <l:icon src="symbol-status-skipped plugin-junit" />
 
-                                ${f.name}
-
-                                <j:if test="${it.class.simpleName eq 'TestResult'}">
-                                    <span class="jenkins-!-text-color-secondary jenkins-!-margin-left-2" style="font-family: var(--font-family-mono)">
-                                        <st:out value="${f.className}" />
-                                    </span>
-                                </j:if>
+                                ${f.className}.${f.name}
 
                                 <t:condition-tag test="${f}" clazz="jenkins-!-margin-left-2 jenkins-mobile-hide" />
                             </div>
@@ -82,13 +76,7 @@ THE SOFTWARE.
                             <a id="test-${id}-showlink" class="jp-table-row" href="${url}">
                                 <l:icon src="${f.status == 'PASSED' ? 'symbol-status-blue' : 'symbol-status-red'}" />
 
-                                ${f.name}
-
-                                <j:if test="${it.class.simpleName eq 'TestResult'}">
-                                    <span class="jenkins-!-text-color-secondary jenkins-!-margin-left-2" style="font-family: var(--font-family-mono)">
-                                        <st:out value="${f.className}" />
-                                    </span>
-                                </j:if>
+                                ${f.className}.${f.name}
 
                                 <t:condition-tag test="${f}" clazz="jenkins-!-margin-left-2 jenkins-mobile-hide" />
 

--- a/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
+++ b/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
@@ -523,8 +523,8 @@ class TestResultStorageJunitTest {
                                     Job<?, ?> theJob = Jenkins.get().getItemByFullName(getJobName(), Job.class);
                                     if (theJob != null) {
                                         Run<?, ?> run = theJob.getBuildByNumber(buildNumber);
-                                        historyTestResultSummaries.add(
-                                                new HistoryTestResultSummary(run, null, duration, failed, skipped, passed));
+                                        historyTestResultSummaries.add(new HistoryTestResultSummary(
+                                                run, null, duration, failed, skipped, passed));
                                     }
                                 }
                                 return historyTestResultSummaries;

--- a/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
+++ b/src/test/java/io/jenkins/plugins/junit/storage/TestResultStorageJunitTest.java
@@ -521,7 +521,7 @@ class TestResultStorageJunitTest {
                                     if (theJob != null) {
                                         Run<?, ?> run = theJob.getBuildByNumber(buildNumber);
                                         historyTestResultSummaries.add(
-                                                new HistoryTestResultSummary(run, duration, failed, skipped, passed));
+                                                new HistoryTestResultSummary(run, null, duration, failed, skipped, passed));
                                     }
                                 }
                                 return historyTestResultSummaries;


### PR DESCRIPTION
- Reinstate the link to specific test result in the test history table in place of the parent build, makes navigation in the history easier.
- Increase result cache cleanup interval, make cleanup non-blocking and avoid updating timestamp on SoftReference. Should reduce memory pressure, give GC more room to work.
- Avoid touching all the builds when about to show the history page, avoids a potentially catastrophic memory usage spike right after computing the history.
- Always show full test name in the failed tests list, make it possible to distinguish tests when viewing combined results of multiple namespaces.

Improves https://github.com/jenkinsci/junit-plugin/issues/652

### Testing done

- [x] Internal test instance 
- [x] Internal production instance - memory pressure seems significantly less from tests on my side.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
