### PR TITLE
Added support for the skipMarkingStageUnstable config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,18 @@ The JUnit publisher is configured at the job level by adding a Publish JUnit tes
   results to corresponding SCM hosting platforms. If not, a default of "Test" will be used.
 * **Skip marking build unstable:**  If this option is unchecked, then the plugin will mark the build as unstable when it finds at least 1 test failure.
     If this option is checked, then the build will still be successful even if there are test failures reported.
-    In any case, the corresponding pipeline node (and stage) will be marked as unstable in case of test failure.
+    The corresponding pipeline node (and stage) will still be marked as unstable in case of test failure, unless `skipMarkingStageUnstable` is also set.
     In order to enable this, set the property: 
     `skipMarkingBuildUnstable` to `true`:
     
       junit skipMarkingBuildUnstable: true, testResults: 'test-results.xml'
+* **Skip marking stage unstable:** If this option is unchecked, then the plugin will mark the pipeline node (and stage) as unstable when it finds at least 1 test failure.
+    If this option is checked, then the test failures will still be reported, but no warning is attached to the pipeline node. Neither the stage nor the build will be marked as unstable.
+    Checking this option effectively implies `skipMarkingBuildUnstable: true`.
+    In order to enable this, set the property:
+    `skipMarkingStageUnstable` to `true`:
+
+      junit skipMarkingStageUnstable: true, testResults: 'test-results.xml'
       
 ### Test result checks (for GitHub projects)
 

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStep.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStep.java
@@ -70,6 +70,11 @@ public class JUnitResultsStep extends Step implements JUnitTask {
      */
     private boolean skipMarkingBuildUnstable;
 
+    /**
+     * If true, the stage (pipeline node) won't be marked as unstable if there are failing tests.
+     */
+    private boolean skipMarkingStageUnstable;
+
     private boolean skipOldReports;
 
     @DataBoundConstructor
@@ -225,6 +230,15 @@ public class JUnitResultsStep extends Step implements JUnitTask {
     @DataBoundSetter
     public void setSkipMarkingBuildUnstable(boolean skipMarkingBuildUnstable) {
         this.skipMarkingBuildUnstable = skipMarkingBuildUnstable;
+    }
+
+    public boolean isSkipMarkingStageUnstable() {
+        return skipMarkingStageUnstable;
+    }
+
+    @DataBoundSetter
+    public void setSkipMarkingStageUnstable(boolean skipMarkingStageUnstable) {
+        this.skipMarkingStageUnstable = skipMarkingStageUnstable;
     }
 
     @Override

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStep.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStep.java
@@ -71,9 +71,8 @@ public class JUnitResultsStep extends Step implements JUnitTask {
     private boolean skipMarkingBuildUnstable;
 
     /**
-     * If true, the stage (pipeline node) won't be marked as unstable if there are failing tests.
+     * If true, failing tests will not mark the stage (pipeline node) or the overall build as unstable.
      */
-    private boolean skipMarkingStageUnstable;
 
     private boolean skipOldReports;
 

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStep.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStep.java
@@ -73,6 +73,7 @@ public class JUnitResultsStep extends Step implements JUnitTask {
     /**
      * If true, failing tests will not mark the stage (pipeline node) or the overall build as unstable.
      */
+    private boolean skipMarkingStageUnstable;
 
     private boolean skipOldReports;
 

--- a/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
+++ b/src/main/java/hudson/tasks/junit/pipeline/JUnitResultsStepExecution.java
@@ -65,10 +65,12 @@ public class JUnitResultsStepExecution extends SynchronousNonBlockingStepExecuti
             if (summary.getFailCount() > 0) {
                 int testFailures = summary.getFailCount();
                 if (testFailures > 0) {
-                    node.addOrReplaceAction(
-                            new WarningAction(Result.UNSTABLE).withMessage(testFailures + " tests failed"));
-                    if (!step.isSkipMarkingBuildUnstable()) {
-                        run.setResult(Result.UNSTABLE);
+                    if (!step.isSkipMarkingStageUnstable()) {
+                        node.addOrReplaceAction(
+                                new WarningAction(Result.UNSTABLE).withMessage(testFailures + " tests failed"));
+                        if (!step.isSkipMarkingBuildUnstable()) {
+                            run.setResult(Result.UNSTABLE);
+                        }
                     }
                 }
             }

--- a/src/main/resources/hudson/tasks/junit/pipeline/JUnitResultsStep/config.jelly
+++ b/src/main/resources/hudson/tasks/junit/pipeline/JUnitResultsStep/config.jelly
@@ -27,4 +27,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
     xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <st:include page="config.jelly" class="hudson.tasks.junit.JUnitResultArchiver" />
+    <f:entry title="${%Skip marking stage as unstable on test failure}" field="skipMarkingStageUnstable">
+            <f:checkbox default="false" title="${%If checked, the test failures will still be reported but won't mark the stage (nor the build) as unstable}"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/tasks/junit/pipeline/JUnitResultsStep/config.jelly
+++ b/src/main/resources/hudson/tasks/junit/pipeline/JUnitResultsStep/config.jelly
@@ -28,6 +28,6 @@ THE SOFTWARE.
     xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <st:include page="config.jelly" class="hudson.tasks.junit.JUnitResultArchiver" />
     <f:entry title="${%Skip marking stage as unstable on test failure}" field="skipMarkingStageUnstable">
-            <f:checkbox default="false" title="${%If checked, the test failures will still be reported but won't mark the stage (nor the build) as unstable}"/>
+            <f:checkbox default="false" title="${%If checked, the test failures will still be reported but won't mark the stage nor the build as unstable}"/>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/tasks/junit/pipeline/JUnitResultsStep/help-skipMarkingBuildUnstable.html
+++ b/src/main/resources/hudson/tasks/junit/pipeline/JUnitResultsStep/help-skipMarkingBuildUnstable.html
@@ -1,5 +1,6 @@
 <div>
     If this option is unchecked, then the plugin will mark the build as unstable when it finds at least 1 test failure.
     If this option is checked, then the build will still be successful even if there are test failures reported.
-    In any case, the corresponding pipeline node (and stage) will be marked as unstable in case of test failure.
+    The corresponding pipeline node (and stage) will still be marked as unstable in case of test failure, unless
+    <code>skipMarkingStageUnstable</code> is also set.
 </div>

--- a/src/main/resources/hudson/tasks/junit/pipeline/JUnitResultsStep/help-skipMarkingStageUnstable.html
+++ b/src/main/resources/hudson/tasks/junit/pipeline/JUnitResultsStep/help-skipMarkingStageUnstable.html
@@ -1,0 +1,7 @@
+<div>
+    If this option is unchecked, then the plugin will mark the pipeline node (and stage) as unstable when it finds at
+    least 1 test failure.
+    If this option is checked, then the test failures will still be reported, but no warning is attached to the
+    pipeline node, so neither the stage nor the build will be marked as unstable. This effectively implies
+    <code>skipMarkingBuildUnstable</code> as well.
+</div>

--- a/src/test/java/hudson/tasks/junit/pipeline/JUnitResultsStepTest.java
+++ b/src/test/java/hudson/tasks/junit/pipeline/JUnitResultsStepTest.java
@@ -83,6 +83,10 @@ class JUnitResultsStepTest {
         st.assertRoundTrip(
                 step,
                 "junit allowEmptyResults: true, healthScaleFactor: 2.0, skipMarkingBuildUnstable: true, testDataPublishers: [[$class: 'MockTestDataPublisher', name: 'testing']], testResults: '**/target/surefire-reports/TEST-*.xml'");
+        step.setSkipMarkingStageUnstable(true);
+        st.assertRoundTrip(
+                step,
+                "junit allowEmptyResults: true, healthScaleFactor: 2.0, skipMarkingBuildUnstable: true, skipMarkingStageUnstable: true, testDataPublishers: [[$class: 'MockTestDataPublisher', name: 'testing']], testResults: '**/target/surefire-reports/TEST-*.xml'");
     }
 
     @Issue("JENKINS-48250")
@@ -460,6 +464,31 @@ class JUnitResultsStepTest {
         WorkflowRun r = rule.waitForCompletion(j.scheduleBuild2(0).waitForStart());
         rule.assertBuildStatus(Result.SUCCESS, r);
         assertStageResults(r, 1, 8, 3, "first");
+    }
+
+    @Test
+    void skipStageUnstable() throws Exception {
+        WorkflowJob j = rule.jenkins.createProject(WorkflowJob.class, "skipStageUnstable");
+        j.setDefinition(new CpsFlowDefinition(
+                "stage('first') {\n" + "  node {\n"
+                        + "    touch 'test-result.xml'\n"
+                        + "    def results = junit(skipMarkingStageUnstable: true, testResults: '*.xml')\n"
+                        + "    assert results.totalCount == 8\n"
+                        + "    assert currentBuild.result == null\n"
+                        + "  }\n"
+                        + "}\n",
+                true));
+        copyToWorkspace(
+                j, JUnitResultsStepTest.class.getResource("junit-report-testTrends-first-2.xml"), "test-result.xml");
+        WorkflowRun r = rule.waitForCompletion(j.scheduleBuild2(0).waitForStart());
+        rule.assertBuildStatus(Result.SUCCESS, r);
+
+        // Neither the build nor the stage should be marked unstable: the junit step attaches no WarningAction.
+        FlowExecution execution = r.getExecution();
+        BlockStartNode stage =
+                (BlockStartNode) new DepthFirstScanner().findFirstMatch(execution, stageForName("first"));
+        assertNotNull(stage);
+        assertThat(findJUnitSteps(stage), CoreMatchers.not(CoreMatchers.hasItem(hasWarningAction())));
     }
 
     @Test


### PR DESCRIPTION
This PR adds the skipMarkingStageUnstable configuration option. If checked, a failed test will not mark the the node, stage or build as unstable.

Closes https://github.com/jenkinsci/junit-plugin/issues/1238

### Testing done

The test suite was extended with automated tests.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed