### PR TITLE
Prevent internal server error when loading tests backed by pluggable storage

### DIFF
--- a/src/main/java/hudson/tasks/junit/TestResultAction.java
+++ b/src/main/java/hudson/tasks/junit/TestResultAction.java
@@ -159,7 +159,9 @@ public class TestResultAction extends AbstractTestResultAction<TestResultAction>
         long started = System.nanoTime();
         JunitTestResultStorage storage = JunitTestResultStorage.find();
         if (!(storage instanceof FileJunitTestResultStorage)) {
-            return new TestResult(storage.load(run.getParent().getFullName(), run.getNumber()));
+            TestResult result = new TestResult(storage.load(run.getParent().getFullName(), run.getNumber()));
+            result.setParentAction(this);
+            return result;
         }
         TestResult r;
         if (result == null) {


### PR DESCRIPTION
Makes sure that `TestResults` that aren't file-backed have a parent action set. 

Should fix an issue where accessing test result pages in Jenkins returns a 500 Internal Server error because `it.parent` is `null` in the Jelly file (`TestResult/index.jelly`).

### Testing done

1. Ran `mvn test` locally. All tests passed apart from `io.jenkins.plugins.junit.storage.TestResultStorageJunitTest.smokes`, which also failed in the same way on the main branch (which seems to be related to some network configuration on my machine).
2. Built a `.hpi` file and installed it on my controller. With this version my Tests page displays correctly.

I haven't worked on any Jenkins plugins before, so please let me know if there's anything additional I can do here.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
