### PR TITLE
Replace every URL-illegal character in TestObject.safe

### DIFF
--- a/src/main/java/hudson/tasks/test/TestObject.java
+++ b/src/main/java/hudson/tasks/test/TestObject.java
@@ -405,6 +405,16 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
     private static final Map<String, Map<TestObject, Void>> UNIQUIFIED_NAMES = new HashMap<>();
 
     /**
+     * Characters that {@link #safe(String)} replaces, in addition to the space, the control
+     * characters and {@code DEL}.
+     *
+     * <p>These are the printable ASCII characters that RFC 3986 does not permit to appear
+     * literally in a URL path segment, plus {@code /} (the separator {@link #getId()} builds
+     * paths with) and {@code :} (replaced ever since this method was introduced).
+     */
+    private static final String UNSAFE_CHARS = "\"#%/:<>?[\\]^`{|}";
+
+    /**
      * Replaces URL-unsafe characters.
      * If s is an empty string, returns "(empty)" otherwise the generated URL would contain
      * two slashes one after the other and getDynamic() would fail.
@@ -415,20 +425,32 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
     public static String safe(String s) {
         if (s == null || s.isEmpty()) {
             return "(empty)";
-        } else {
-            // this still seems to be a bit faster than a single replace with regexp
-            return s.replace('/', '_')
-                    .replace('\\', '_')
-                    .replace(':', '_')
-                    .replace('?', '_')
-                    .replace('#', '_')
-                    .replace('%', '_')
-                    .replace('<', '_')
-                    .replace('>', '_');
-            // Note: we probably should some helpers like Commons URIEscapeUtils here to escape all invalid URL chars,
-            // but then we
-            // still would have to escape /, ? and so on
         }
+        // A single pass over the characters is faster than either a regexp or a chain of
+        // String#replace calls, and allocates nothing when there is nothing to replace.
+        StringBuilder buf = null;
+        for (int i = 0; i < s.length(); i++) {
+            if (isUnsafe(s.charAt(i))) {
+                if (buf == null) {
+                    buf = new StringBuilder(s);
+                }
+                buf.setCharAt(i, '_');
+            }
+        }
+        return buf == null ? s : buf.toString();
+    }
+
+    /**
+     * Whether the given character has to be replaced by {@link #safe(String)} for the result to be
+     * usable as a URL path segment.
+     *
+     * <p>Non-ASCII characters are left alone: they are percent-encoded as UTF-8 by the browser and
+     * survive the round trip, so replacing them would needlessly mangle test names that are not
+     * written in English.
+     */
+    private static boolean isUnsafe(char c) {
+        // c <= ' ' covers the C0 control characters as well as the space
+        return c <= ' ' || c == 0x7F || UNSAFE_CHARS.indexOf(c) >= 0;
     }
 
     /**

--- a/src/test/java/hudson/tasks/junit/TestResultTest.java
+++ b/src/test/java/hudson/tasks/junit/TestResultTest.java
@@ -376,17 +376,17 @@ public class TestResultTest {
         PackageResult pkg = testResult.byPackage("(root)");
         assertEquals(1704281235000L, pkg.getStartTime());
 
-        ClassResult class1 = pkg.getClassResult("contents adjust properly when resizing test");
+        ClassResult class1 = pkg.getClassResult("contents_adjust_properly_when_resizing_test");
         CaseResult case1 = class1.getCaseResult("testResize");
         assertEquals(1704288431210L, class1.getStartTime());
         assertEquals(1704288431210L, case1.getStartTime());
 
-        ClassResult class2 = pkg.getClassResult("date reflects offset test");
+        ClassResult class2 = pkg.getClassResult("date_reflects_offset_test");
         CaseResult case2 = class2.getCaseResult("testDate");
         assertEquals(-1, class2.getStartTime());
         assertEquals(-1, case2.getStartTime());
 
-        ClassResult class3 = pkg.getClassResult("get test");
+        ClassResult class3 = pkg.getClassResult("get_test");
         CaseResult case3 = class3.getCaseResult("testGet");
         assertEquals(-1, class3.getStartTime());
         assertEquals(-1, case3.getStartTime());
@@ -407,22 +407,22 @@ public class TestResultTest {
         assertEquals(1704284831000L, case7.getStartTime());
         assertEquals(1704284838000L, case8.getStartTime());
 
-        ClassResult class6 = pkg.getClassResult("pages load in under ten seconds under ideal conditions test");
+        ClassResult class6 = pkg.getClassResult("pages_load_in_under_ten_seconds_under_ideal_conditions_test");
         CaseResult case9 = class6.getCaseResult("testExperience");
         assertEquals(1704284864000L, class6.getStartTime());
         assertEquals(1704284864000L, case9.getStartTime());
 
-        ClassResult class7 = pkg.getClassResult("popups triggered when hovering test");
+        ClassResult class7 = pkg.getClassResult("popups_triggered_when_hovering_test");
         CaseResult case10 = class7.getCaseResult("testPopup");
         assertEquals(-1, class7.getStartTime());
         assertEquals(-1, case10.getStartTime());
 
-        ClassResult class8 = pkg.getClassResult("proper images displayed when items added");
+        ClassResult class8 = pkg.getClassResult("proper_images_displayed_when_items_added");
         CaseResult case11 = class8.getCaseResult("testShop");
         assertEquals(1704281235000L, class8.getStartTime());
         assertEquals(1704281235000L, case11.getStartTime());
 
-        ClassResult class9 = pkg.getClassResult("time offset is correct test");
+        ClassResult class9 = pkg.getClassResult("time_offset_is_correct_test");
         CaseResult case12 = class9.getCaseResult("testOffset");
         assertEquals(-1, class9.getStartTime());
         assertEquals(-1, case12.getStartTime());

--- a/src/test/java/hudson/tasks/test/TestObjectTest.java
+++ b/src/test/java/hudson/tasks/test/TestObjectTest.java
@@ -118,4 +118,45 @@ class TestObjectTest {
         doReturn(run).when(testObject).getRun();
         assertEquals("job/abc/123/testReport/dummy", testObject.getUrl());
     }
+
+    @Test
+    void safeReplacesEveryCharacterIllegalInAPathSegment() {
+        // RFC 3986 does not allow any of these to appear literally in a URL path segment
+        for (char c : " \"#%/:<>?[\\]^`{|}".toCharArray()) {
+            assertEquals("a_b", TestObject.safe("a" + c + "b"), "should have replaced '" + c + "'");
+        }
+    }
+
+    @Test
+    void safeReplacesControlCharacters() {
+        assertEquals("a_b", TestObject.safe("a\u0000b"));
+        assertEquals("a_b", TestObject.safe("a\tb"));
+        assertEquals("a_b", TestObject.safe("a\nb"));
+        assertEquals("a_b", TestObject.safe("a\u007Fb"));
+    }
+
+    @Test
+    void safeKeepsCharactersLegalInAPathSegment() {
+        String legal = "azAZ09-._~!$&'()*+,;=@";
+        assertEquals(legal, TestObject.safe(legal));
+    }
+
+    @Test
+    void safeKeepsNonAsciiCharacters() {
+        // percent-encoded as UTF-8 by the browser, so they survive the round trip
+        String name = "Gr\u00fc\u00dfe\u30c6\u30b9\u30c8";
+        assertEquals(name, TestObject.safe(name));
+    }
+
+    @Test
+    void safeReturnsPlaceholderForNullOrEmptyName() {
+        assertEquals("(empty)", TestObject.safe(null));
+        assertEquals("(empty)", TestObject.safe(""));
+    }
+
+    @Test
+    void safeReplacesEveryOccurrenceOfAnUnsafeCharacter() {
+        assertEquals("a_b_c", TestObject.safe("a|b|c"));
+        assertEquals("___", TestObject.safe("|||"));
+    }
 }


### PR DESCRIPTION
Fixes #1211

### Problem

`TestObject.safe()` replaced eight characters (`/ \ : ? # % < >`), but RFC 3986 forbids several more from appearing literally in a URL path segment. Everything else — `|`, a space, `[`, `]`, `{`, `}`, `^`, a backtick, `"`, control characters — was carried through verbatim into `getId()`, which `getUrl()` concatenates into the URL without encoding it:

```java
public String getUrl() {
    return getRun().getUrl() + getTestResultAction().getUrlName() + "/" + getId();
}
```

The reporter hit this with `|` in a name. The same method is used by jenkinsci/junit-attachments-plugin#201 to build a path.

### Change

`safe()` now replaces every ASCII character that RFC 3986 does not permit literally in a path segment, plus the C0 controls and DEL.

Non-ASCII characters are deliberately left alone: the browser percent-encodes them as UTF-8 so they survive the round trip, and replacing them would mangle test names that are not written in English for no benefit.

The replacement runs in a single pass and allocates nothing when the name is already safe, which also retires the chain of eight `String#replace` calls and the TODO comment that asked for exactly this.

### Compatibility

This changes the URL of any package/class/suite whose name contains one of the newly replaced characters. Those URLs were already invalid, but they are user-visible, so it is worth calling out — in particular the **space**, which is the widest-reaching one:

- `CaseResult.getSafeName()` already replaces spaces (it keeps only `Character.isJavaIdentifierPart`), so this has always been the behaviour at the case level. This change makes the package/class/suite levels agree with it.
- `TestResultTest.testStartTimes` shows the existing asymmetry: it already looks up cases as `home_button_redirects_to_home_test` while the XML says `home button redirects to home test`, but looks up classes with the spaces intact. I updated the class-level lookups in that test to match.

Happy to drop the space from the set if you would rather leave those URLs untouched.

### Testing done

- Six new unit tests in `TestObjectTest` covering every illegal character, control characters, the characters that must be preserved, non-ASCII names, null/empty, and repeated occurrences.
- `mvn test` on the full suite: 506 tests, 0 failures, 0 errors, 3 skipped.
